### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
 script:
   - ./scripts/build.sh
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
 script:
-  - ./scripts/build.sh
+  - autoreconf -i
+  - mkdir -p build
+  - cd build
+  - sh ../configure
+  - make
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,29 @@ language: c
 os:
   - linux
   - osx
+matrix:
+  include:
+    - os: linux
+    - os: linux
+      dist: trusty
+    - os: osx
+      osx_image: beta-xcode6.1
+    - os: osx
+      osx_image: beta-xcode6.2
+    - os: osx
+      osx_image: beta-xcode6.3
+    - os: osx
+      osx_image: xcode6.4
+    - os: osx
+      osx_image: xcode7
+    - os: osx
+      osx_image: xcode7.1
+    - os: osx
+      osx_image: xcode7.2
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode8
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+os:
+  - linux
+  - osx
+addons:
+  apt:
+    packages:
+      - libsdl1.2-dev
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
+script:
+  - ./scripts/build.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-autoreconf -i
-mkdir -p build
-cd build
-sh ../configure
-make

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+autoreconf -i
+mkdir -p build
+cd build
+sh ../configure
+make


### PR DESCRIPTION
This PR adds a continuous integration build with [Travis CI](https://travis-ci.org/), so every commit can be verified to be working on both OS X and Linux. It also adds a `build.sh` script so building becomes somewhat easier to newbies like myself.

Before this PR is merged, it would be best if an owner of the schismtracker repository logged in to Travis and created a project (basically flipping a switch for the schismtracker repository) so when this is merged, Travis will build it.

If enabled, all future pull requests will be built by Travis and the build status will be reported back to the pull request as a red cross or green checkbox, with details on what went wrong. This makes it easier to confidentially merge working pull requests and avoid breaking ones until they are fixed.
