### PR TITLE
Quit schismtracker without asking if shift+crlt+q is pressed

### DIFF
--- a/helptext/global-keys
+++ b/helptext/global-keys
@@ -42,6 +42,7 @@
 :   Ctrl-P            Calculate approximate song length
 !   Ctrl-Q            Quit to DOS
 :   Ctrl-Q            Quit Schism Tracker
+:   Ctrl-Shift-Q      Quit without asking
 |   Ctrl-S            Save current song
 |
 |   Ctrl-Alt-Enter    Toggle Fullscreen

--- a/schism/page.c
+++ b/schism/page.c
@@ -542,8 +542,11 @@ static int handle_key_global(struct key_event * k)
 			return 0;
 		if (k->mod & KMOD_CTRL) {
 			_mp_finish(NULL);
-			if (k->state == KEY_PRESS)
+			if (k->state == KEY_PRESS) {
+				if (k->mod & KMOD_SHIFT)
+					exit(0);
 				show_exit_prompt();
+			}
 			return 1;
 		}
 		break;


### PR DESCRIPTION
l hope l didn't overlook sth.
