### PR TITLE
Add AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,9 @@
 environment:
     matrix:
-    - platform: x86
-      arch: i686
-      mingw: mingw32
-      msys: msys32
-    - platform: x64
-      arch: x86_64
-      mingw: mingw64
-      msys: msys64
+    - arch: i686
+      bits: 32
+    - arch: x86_64
+      bits: 64
 
 cache:
   - 'C:\msys32'
@@ -15,22 +11,21 @@ cache:
 install:
   - ps: |
       [Environment]::SetEnvironmentVariable("MSYS2_PATH_TYPE", "inherit", "Machine")
-      $platform = $env:Platform
       $arch = $env:Arch
-      $msys = $env:Msys
-      $mingw = $env:Mingw
+      $bits = $env:Bits
+      $msys = "msys$bits"
+      $mingw = "mingw$bits"
+      $mingwUpper = $mingw.ToUpper()
       $folder = $env:APPVEYOR_BUILD_FOLDER
 
       $env:PATH="C:\$msys\$mingw\bin;C:\$msys\usr\bin;$env:PATH"
 
       function bash($command, $dieOnError = $true) {
         ""
-
         Write-Host $command
 
         $folder = $folder -Replace '\\', '/'
 
-        $mingwUpper = $mingw.ToUpper()
         & "C:\$msys\usr\bin\sh.exe" --login -c "MSYSTEM=$mingwUpper . /etc/profile && cd $folder && $command"
 
         if ($LASTEXITCODE -eq 0) {
@@ -48,7 +43,7 @@ install:
       }
 
       # 32-bit MSYS2 is not offered on AppVeyor yet, so we need to install it.
-      if ($platform -eq "x86") {
+      if ($arch -eq "i686") {
         Write-Host "Installing 32-bit MSYS2..." -ForegroundColor Cyan
 
         # download installer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,11 +75,11 @@ build_script:
       bash "autoreconf --install --include=/$mingw/share/aclocal/"
       bash "./configure"
       bash "make"
-      Copy-Item C:\$msys\$mingw\bin\SDL.dll .\
+      xcopy C:\$msys\$mingw\bin\SDL.dll .\
 
       if ($arch -eq "i686") {
-        Copy-Item C:\$msys\$mingw\bin\libgcc_s_dw2-1.dll .\
-        Copy-Item C:\$msys\$mingw\bin\libwinpthread-1.dll .\
+        xcopy C:\$msys\$mingw\bin\libgcc_s_dw2-1.dll .\
+        xcopy C:\$msys\$mingw\bin\libwinpthread-1.dll .\
       }
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+environment:
+    matrix:
+    - platform: x86
+      arch: i686
+      mingw: mingw32
+      msys: msys32
+    - platform: x64
+      arch: x86_64
+      mingw: mingw64
+      msys: msys64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,20 +102,20 @@ test_script:
 
 on_failure:
   - dir /s /b > dir.txt
-  - if exist "dir.txt" 7z a schismtracker_debug_logs.7z "dir.txt" > nul
-  - if exist "config.log" 7z a schismtracker_debug_logs.7z "config.log" > nul
-  - if exist "configure.ac" 7z a schismtracker_debug_logs.7z "configure.ac" > nul
-  - if exist "configure" 7z a schismtracker_debug_logs.7z "configure" > nul
-  - if exist "C:\msys%bits%\mingw%bits%\bin\sdl-config" 7z a schismtracker_debug_logs.7z "C:\msys%bits%\mingw%bits%\bin\sdl-config" > nul
+  - if exist "dir.txt" 7z a -tzip schismtracker_debug_logs.zip "dir.txt" > nul
+  - if exist "config.log" 7z a -tzip schismtracker_debug_logs.zip "config.log" > nul
+  - if exist "configure.ac" 7z a -tzip schismtracker_debug_logs.zip "configure.ac" > nul
+  - if exist "configure" 7z a -tzip schismtracker_debug_logs.zip "configure" > nul
+  - if exist "C:\msys%bits%\mingw%bits%\bin\sdl-config" 7z a -tzip schismtracker_debug_logs.zip "C:\msys%bits%\mingw%bits%\bin\sdl-config" > nul
 
 on_finish:
-  - if exist "schismtracker_debug_logs.7z" appveyor PushArtifact "schismtracker_debug_logs.7z"
-  - if exist "schismtracker.exe" 7z a schismtracker.7z "schismtracker.exe" > nul
-  - if exist "SDL.dll" 7z a schismtracker.7z "SDL.dll" > nul
-  - if exist "schismtracker.7z" appveyor PushArtifact "schismtracker.7z"
+  - if exist "schismtracker_debug_logs.zip" appveyor PushArtifact "schismtracker_debug_logs.zip"
+  - if exist "schismtracker.exe" 7z a -tzip schismtracker.zip "schismtracker.exe" > nul
+  - if exist "SDL.dll" 7z a -tzip schismtracker.zip "SDL.dll" > nul
+  - if exist "schismtracker.zip" appveyor PushArtifact "schismtracker.zip"
 
 artifacts:
-  - path: '*.7z'
+  - path: '*.zip'
 
 notifications:
   on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,6 +86,7 @@ on_failure:
 
 on_finish:
   - if exist schismtracker_debug_logs.7z appveyor PushArtifact schismtracker_debug_logs.7z
+  - if exist schismtracker.exe appveyor PushArtifact schismtracker.exe
 
 artifacts:
   - path: '*.7z'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,6 +75,7 @@ build_script:
       bash "autoreconf --install --include=/$mingw/share/aclocal/"
       bash "./configure"
       bash "make"
+      Copy-Item C:\$msys\$mingw\bin\SDL.dll .\
 
 test_script:
   - ps: |
@@ -108,8 +109,10 @@ on_failure:
   - if exist "C:\msys%bits%\mingw%bits%\bin\sdl-config" 7z a schismtracker_debug_logs.7z "C:\msys%bits%\mingw%bits%\bin\sdl-config" > nul
 
 on_finish:
-  - if exist schismtracker_debug_logs.7z appveyor PushArtifact schismtracker_debug_logs.7z
-  - if exist schismtracker.exe appveyor PushArtifact schismtracker.exe
+  - if exist "schismtracker_debug_logs.7z" appveyor PushArtifact "schismtracker_debug_logs.7z"
+  - if exist "schismtracker.exe" 7z a schismtracker.7z "schismtracker.exe" > nul
+  - if exist "SDL.dll" 7z a schismtracker.7z "SDL.dll" > nul
+  - if exist "schismtracker.7z" appveyor PushArtifact "schismtracker.7z"
 
 artifacts:
   - path: '*.7z'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -93,17 +93,19 @@ test_script:
         exit 1
       }
 
-      $result = Invoke-Expression "& '$exe' /version"
-      if ($result -Match 'Schism Tracker') {
-        Write-Host "'$exe /version' output 'Schism Tracker'. Success!" -ForegroundColor Green
-      } elseif ([string]::IsNullOrWhiteSpace($result)) {
-        Write-Host "'$exe /version' did not output anything. It might be damaged." -ForegroundColor Red
-        exit 1
-      } else {
-        Write-Host "'$exe /version' did not output 'Schism Tracker' as expected. The result was:" -ForegroundColor Red
-        Write-Host $result -ForegroundColor Red
-        exit 1
-      }
+      Invoke-Expression "& '$exe' /version"
+
+#      $result = Invoke-Expression "& '$exe' /version"
+#      if ($result -Match 'Schism Tracker') {
+#        Write-Host "'$exe /version' output 'Schism Tracker'. Success!" -ForegroundColor Green
+#      } elseif ([string]::IsNullOrWhiteSpace($result)) {
+#        Write-Host "'$exe /version' did not output anything. It might be damaged." -ForegroundColor Red
+#        exit 1
+#      } else {
+#        Write-Host "'$exe /version' did not output 'Schism Tracker' as expected. The result was:" -ForegroundColor Red
+#        Write-Host $result -ForegroundColor Red
+#        exit 1
+#      }
 
 on_failure:
   - dir /s /b > dir.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,89 @@ environment:
       mingw: mingw64
       msys: msys64
 
+cache:
+  - 'C:\msys32'
+
+install:
+  - ps: |
+      [Environment]::SetEnvironmentVariable("MSYS2_PATH_TYPE", "inherit", "Machine")
+      $platform = $env:Platform
+      $arch = $env:Arch
+      $msys = $env:Msys
+      $mingw = $env:Mingw
+      $folder = $env:APPVEYOR_BUILD_FOLDER
+
+      $env:PATH="C:\$msys\$mingw\bin;C:\$msys\usr\bin;$env:PATH"
+
+      function bash($command, $dieOnError = $true) {
+        ""
+
+        Write-Host $command
+
+        $folder = $folder -Replace '\\', '/'
+
+        $mingwUpper = $mingw.ToUpper()
+        & "C:\$msys\usr\bin\sh.exe" --login -c "MSYSTEM=$mingwUpper . /etc/profile && cd $folder && $command"
+
+        if ($LASTEXITCODE -eq 0) {
+          Write-Host "'$command' succeeded. While its output might be red, it exited with '0'." -ForegroundColor Green
+        } else {
+          Write-Host "'$command' failed with exit code $LASTEXITCODE! " -ForegroundColor Red -NoNewline
+
+          if ($dieOnError) {
+            Write-Host "Exiting." -ForegroundColor Red
+            exit $LASTEXITCODE
+          } else {
+            "Continuing."
+          }
+        }
+      }
+
+      # 32-bit MSYS2 is not offered on AppVeyor yet, so we need to install it.
+      if ($platform -eq "x86") {
+        Write-Host "Installing 32-bit MSYS2..." -ForegroundColor Cyan
+
+        # download installer
+        $zipPath = "$($env:USERPROFILE)\msys2-i686-latest.tar.xz"
+        $tarPath = "$($env:USERPROFILE)\msys2-i686-latest.tar"
+
+        "Downloading MSYS2 installation package..."
+        (New-Object Net.WebClient).DownloadFile('http://repo.msys2.org/distrib/msys2-i686-latest.tar.xz', $zipPath)
+
+        Write-Host "Unzipping $zipPath..."
+        7z x $zipPath -y -o"$env:USERPROFILE" | Out-Null
+
+        Write-Host "Untaring $tarPath to C:\msys32\..."
+        7z x $tarPath -y -oC:\ | Out-Null
+        del $zipPath
+        del $tarPath
+
+        Write-Host "32-bit MSYS2 installed" -ForegroundColor Green
+
+        bash "pacman --sync --noconfirm --needed pacman pacman-mirrors"
+        bash "pacman --sync --noconfirm --needed VCS"
+        bash "pacman --sync --noconfirm --needed base-devel"
+        bash "pacman --sync --noconfirm --needed msys2-devel"
+        bash "pacman --sync --noconfirm --needed mingw-w64-$arch-toolchain"
+      }
+
+      bash "pacman --sync --noconfirm --needed mingw-w64-$arch-SDL"
+
+build_script:
+  - ps: |
+      bash "autoreconf --install --include=/$mingw/share/aclocal/"
+      bash "./configure"
+      bash "make"
+
+on_failure:
+  - ps: |
+      bash "ls -la"
+      bash "if [ -e config.log ]; then echo ''; echo 'Contents of config.log:'; cat config.log; else echo '`"config.log`" not found.'; fi;"
+      bash "if [ -e configure.ac ]; then echo ''; echo 'Contents of configure.ac:'; cat configure.ac; else echo '`"configure.ac`" not found.'; fi;"
+      bash "if [ -e configure ]; then echo ''; echo 'Contents of configure:'; cat configure; else echo '`"configure`" not found.'; fi;"
+      bash "if [ -e /$mingw/bin/sdl-config ]; then echo ''; echo 'Contents of $/mingw/bin/sdl-config:'; cat /$mingw/bin/sdl-config; else echo '`"/$mingw/bin/sdl-config`" not found.'; fi;"
+
 notifications:
-  - provider: Email
-    on_build_success: false
-    on_build_failure: false
-    on_build_status_changed: true
+  on_build_success: false
+  on_build_failure: false
+  on_build_status_changed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,12 +79,16 @@ build_script:
       bash "make"
 
 on_failure:
-  - ps: |
-      bash "ls -la"
-      bash "if [ -e config.log ]; then echo ''; echo 'Contents of config.log:'; cat config.log; else echo '`"config.log`" not found.'; fi;"
-      bash "if [ -e configure.ac ]; then echo ''; echo 'Contents of configure.ac:'; cat configure.ac; else echo '`"configure.ac`" not found.'; fi;"
-      bash "if [ -e configure ]; then echo ''; echo 'Contents of configure:'; cat configure; else echo '`"configure`" not found.'; fi;"
-      bash "if [ -e /$mingw/bin/sdl-config ]; then echo ''; echo 'Contents of $/mingw/bin/sdl-config:'; cat /$mingw/bin/sdl-config; else echo '`"/$mingw/bin/sdl-config`" not found.'; fi;"
+  - if exist "config.log" 7z a schismtracker_debug_logs.7z "config.log" > nul
+  - if exist "configure.ac" 7z a schismtracker_debug_logs.7z "configure.ac" > nul
+  - if exist "configure" 7z a schismtracker_debug_logs.7z "configure" > nul
+  - if exist "C:\msys%bits%\mingw%bits%\bin\sdl-config" 7z a schismtracker_debug_logs.7z "C:\msys%bits%\mingw%bits%\bin\sdl-config" > nul
+
+on_finish:
+  - if exist schismtracker_debug_logs.7z appveyor PushArtifact schismtracker_debug_logs.7z
+
+artifacts:
+  - path: '*.7z'
 
 notifications:
   on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,17 +16,15 @@ install:
       $msys = "msys$bits"
       $mingw = "mingw$bits"
       $mingwUpper = $mingw.ToUpper()
-      $folder = $env:APPVEYOR_BUILD_FOLDER
-
+      $buildFolder = $env:APPVEYOR_BUILD_FOLDER
+      $posixBuildFolder = $buildFolder -Replace '\\', '/'
       $env:PATH="C:\$msys\$mingw\bin;C:\$msys\usr\bin;$env:PATH"
 
       function bash($command, $dieOnError = $true) {
         ""
         Write-Host $command
 
-        $folder = $folder -Replace '\\', '/'
-
-        & "C:\$msys\usr\bin\sh.exe" --login -c "MSYSTEM=$mingwUpper . /etc/profile && cd $folder && $command"
+        & "C:\$msys\usr\bin\sh.exe" --login -c "MSYSTEM=$mingwUpper . /etc/profile && cd $posixBuildFolder && $command"
 
         if ($LASTEXITCODE -eq 0) {
           Write-Host "'$command' succeeded. While its output might be red, it exited with '0'." -ForegroundColor Green
@@ -78,7 +76,32 @@ build_script:
       bash "./configure"
       bash "make"
 
+test_script:
+  - ps: |
+      $exe = "$buildFolder\schismtracker.exe"
+
+      if (Test-Path $exe) {
+        Write-Host "'$exe' exists. Continuing." -ForegroundColor Green
+      } else {
+        Write-Host "'$exe' does not exist. Exiting." -ForegroundColor Red
+        exit 1
+      }
+
+      $result = Invoke-Expression "& '$exe' /version"
+      if ($result -Match 'Schism Tracker') {
+        Write-Host "'$exe /version' output 'Schism Tracker'. Success!" -ForegroundColor Green
+      } elseif ([string]::IsNullOrWhiteSpace($result)) {
+        Write-Host "'$exe /version' did not output anything. It might be damaged." -ForegroundColor Red
+        exit 1
+      } else {
+        Write-Host "'$exe /version' did not output 'Schism Tracker' as expected. The result was:" -ForegroundColor Red
+        Write-Host $result -ForegroundColor Red
+        exit 1
+      }
+
 on_failure:
+  - dir /s /b > dir.txt
+  - if exist "dir.txt" 7z a schismtracker_debug_logs.7z "dir.txt" > nul
   - if exist "config.log" 7z a schismtracker_debug_logs.7z "config.log" > nul
   - if exist "configure.ac" 7z a schismtracker_debug_logs.7z "configure.ac" > nul
   - if exist "configure" 7z a schismtracker_debug_logs.7z "configure" > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,3 +8,9 @@ environment:
       arch: x86_64
       mingw: mingw64
       msys: msys64
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,6 +77,11 @@ build_script:
       bash "make"
       Copy-Item C:\$msys\$mingw\bin\SDL.dll .\
 
+      if ($arch -eq "i686") {
+        Copy-Item C:\$msys\$mingw\bin\libgcc_s_dw2-1.dll .\
+        Copy-Item C:\$msys\$mingw\bin\libwinpthread-1.dll .\
+      }
+
 test_script:
   - ps: |
       $exe = "$buildFolder\schismtracker.exe"
@@ -112,6 +117,8 @@ on_finish:
   - if exist "schismtracker_debug_logs.zip" appveyor PushArtifact "schismtracker_debug_logs.zip"
   - if exist "schismtracker.exe" 7z a -tzip schismtracker.zip "schismtracker.exe" > nul
   - if exist "SDL.dll" 7z a -tzip schismtracker.zip "SDL.dll" > nul
+  - if exist "libgcc_s_dw2-1.dll" 7z a -tzip schismtracker.zip "libgcc_s_dw2-1.dll" > nul
+  - if exist "libwinpthread-1.dll" 7z a -tzip schismtracker.zip "libwinpthread-1.dll" > nul
   - if exist "schismtracker.zip" appveyor PushArtifact "schismtracker.zip"
 
 artifacts:


### PR DESCRIPTION
Thanks to the invaluable help from @JosepMaJAZ in #36, this PR adds a 95% completed AppVeyor build. What's missing is figuring out why the compiled `schismtracker.exe` complains about missing `SDL.dll`; I assumed that would be bundled with the `exe` file? This is the error message I get if I try to open the resulting `schismtracker.exe` in Windows:

![Missing SDL.dll](https://cloud.githubusercontent.com/assets/12283/17974158/3cbd488a-6ae5-11e6-8404-fdb6a90f1219.png)

This needs to be tackled before the PR is merged. Also, one of the @schismtracker devs need to [create an AppVeyor account](https://www.appveyor.com/docs/team-setup/#setting-up-appveyor-account-for-github-organization) (preferably called `schismtracker`) which the official build can be run from.

A successful build will expose `schismtracker.exe` for both 32 and 64 bits CPU architectures as a build artifact in AppVeyor. I will try to do the same in Travis so we get precompiled binaries for Linux and OS X as well.

Lastly, it would be nice if more tests than asserting the existence of `Schism Tracker` in `schismtracker --version` were performed, but that doesn't **need** to be tackled before merging this.
