### PR TITLE
Test the schismtracker executable on Linux and OS X (Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,20 @@ addons:
       - libsdl1.2-dev
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
+  - wget https://raw.github.com/lehmannro/assert.sh/v1.1/assert.sh
+  - wget https://raw.githubusercontent.com/dansoton/assert.sh/assert-extras/assert-extras.sh
+  - source assert.sh
+  - source assert-extras.sh
 script:
   - autoreconf -i
   - mkdir -p build
   - cd build
   - sh ../configure
   - make
+  - assert_startswith "./schismtracker --version" "Schism Tracker"
+  - assert_end tests
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
   - wget https://raw.github.com/lehmannro/assert.sh/v1.1/assert.sh
-  - wget https://raw.githubusercontent.com/dansoton/assert.sh/assert-extras/assert-extras.sh
+  - wget https://raw.github.com/dansoton/assert.sh/assert-extras/assert-extras.sh
   - source assert.sh
   - source assert-extras.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ script:
   - sh ../configure
   - make
   - grep '^Schism Tracker' <(./schismtracker --version)
-  - grep '^Schism Tracker' <(grep --version)
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
   - sh ../configure
   - make
   - grep '^Schism Tracker' <(./schismtracker --version)
+  - grep '^Schism Tracker' <(grep --version)
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,13 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
-  - wget https://raw.github.com/lehmannro/assert.sh/v1.1/assert.sh
-  - wget https://raw.github.com/dansoton/assert.sh/assert-extras/assert-extras.sh
-  - source assert.sh
-  - source assert-extras.sh
 script:
   - autoreconf -i
   - mkdir -p build
   - cd build
   - sh ../configure
   - make
-  - assert_startswith "./schismtracker --version" "Schism Tracker"
-  - assert_end tests
+  - grep '^Schism Tracker' <(./schismtracker --version)
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
This PR adds a test for the `schismtracker` executable that asserts its output begins with "Schism Tracker", just so we know the binary is working.
