### PR TITLE
Test the schismtracker executable on Windows (AppVeyor)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -109,6 +109,8 @@ test_script:
 
 on_failure:
   - dir /s /b > dir.txt
+  - if exist "stdout.txt" 7z a -tzip schismtracker_debug_logs.zip "stdout.txt" > nul
+  - if exist "stderr.txt" 7z a -tzip schismtracker_debug_logs.zip "stderr.txt" > nul
   - if exist "dir.txt" 7z a -tzip schismtracker_debug_logs.zip "dir.txt" > nul
   - if exist "config.log" 7z a -tzip schismtracker_debug_logs.zip "config.log" > nul
   - if exist "configure.ac" 7z a -tzip schismtracker_debug_logs.zip "configure.ac" > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -93,19 +93,19 @@ test_script:
         exit 1
       }
 
-      Invoke-Expression "& '$exe' /version"
+      Start-Process -Wait -FilePath $exe -ArgumentList '--version'
+      $result = Get-Content "stdout.txt"
 
-#      $result = Invoke-Expression "& '$exe' /version"
-#      if ($result -Match 'Schism Tracker') {
-#        Write-Host "'$exe /version' output 'Schism Tracker'. Success!" -ForegroundColor Green
-#      } elseif ([string]::IsNullOrWhiteSpace($result)) {
-#        Write-Host "'$exe /version' did not output anything. It might be damaged." -ForegroundColor Red
-#        exit 1
-#      } else {
-#        Write-Host "'$exe /version' did not output 'Schism Tracker' as expected. The result was:" -ForegroundColor Red
-#        Write-Host $result -ForegroundColor Red
-#        exit 1
-#      }
+      if ($result -Match 'Schism Tracker') {
+        Write-Host "'$exe --version' output 'Schism Tracker'. Success!" -ForegroundColor Green
+      } elseif ([string]::IsNullOrWhiteSpace($result)) {
+        Write-Host "'$exe --version' did not output anything. It might be damaged." -ForegroundColor Red
+        exit 1
+      } else {
+        Write-Host "'$exe --version' did not output 'Schism Tracker' as expected. The result was:" -ForegroundColor Red
+        Write-Host $result -ForegroundColor Red
+        exit 1
+      }
 
 on_failure:
   - dir /s /b > dir.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
     matrix:
-    - arch: i686
-      bits: 32
     - arch: x86_64
       bits: 64
+    - arch: i686
+      bits: 32
 
 cache:
   - 'C:\msys32'


### PR DESCRIPTION
As @mb14 mentions in https://github.com/schismtracker/schismtracker/issues/39#issuecomment-244782966, `schismtracker.exe` outputs a `stdout.txt` file that we can check instead of getting stdout to work in any meaningful way in Windows. This PR adds a test to AppVeyor for just that, similar to #41.
