### PR TITLE
Allow failures on Trusty Tahr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode8
+  allow_failures:
+    - dist: trusty
 addons:
   apt:
     packages:


### PR DESCRIPTION
Due to [Ubuntu 14.04 Trusty Tahr on Travis now being container based (and in beta)](https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/), it seems like a good idea to allow that particular build configuration to fail without failing the whole build.

I expect the Trusty Tahr container to eventually have all the required dependencies, but until it does, I think SchismTracker should have a green build badge in its readme. Currently it doesn't:

[![Build Status](https://travis-ci.org/schismtracker/schismtracker.svg?branch=master)](https://travis-ci.org/schismtracker/schismtracker)