### PR TITLE
Don't cache the MSYS32 folder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,6 @@ environment:
     - arch: i686
       bits: 32
 
-cache:
-  - 'C:\msys32'
-
 install:
   - ps: |
       [Environment]::SetEnvironmentVariable("MSYS2_PATH_TYPE", "inherit", "Machine")


### PR DESCRIPTION
Seems like caching the MSYS32 folder causes old packages to break `pacman` in some way, so even though this might increase the build time, I think it's better to have green builds. Fixes #58.