### PR TITLE
We no longer have to allow build failures on Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode8
-  allow_failures:
-    - dist: trusty
 addons:
   apt:
     packages:


### PR DESCRIPTION
As `libsdl1.2` is now included in Ubuntu Trusty Tahr as per travis-ci/apt-package-whitelist#3931, we no longer have to allow build failures on that distro.