### PR TITLE
drop .PE/.PS macros, add protracker reference

### DIFF
--- a/sys/posix/schismtracker.1
+++ b/sys/posix/schismtracker.1
@@ -104,7 +104,6 @@ The four sub-columns of each channel are the note, sample number, volume, and
 effect. A list of effects is available in the pattern editor help, but you can
 safely ignore that column for now. Assuming a US keymap, notes are entered
 with the keyboard as follows:
-.PS
     (Note)        C# D#    F# G# A#    C# D#    F# G# A#    C# D#
                | | || | | | || || | | | || | | | || || | | | || | |
                | | || | | | || || | | | || | | | || || | | | || | |
@@ -114,7 +113,6 @@ with the keyboard as follows:
                '--'--'--'--'--'--'--'--'--'--'--'--'--'--'--'--'--'
     (Note)       C  D  E  F  G  A  B  C  D  E  F  G  A  B  C  D  E
                 (Octave 0)           (Octave 1)           (Octave 2)
-.PE
 .\" this .P is for elvis, which gets very confused by the preceding diagram
 .P
 The "/" and "*" keys on the numeric keypad change octaves, and the current
@@ -290,6 +288,7 @@ kingdom.
 .\" No favoritism: this list is alphabetical, trackers then players
 .BR chibitracker (1),
 .BR milkytracker (1),
+.BR protracker (1),
 .BR renoise (1),
 .BR ocp (1),
 .BR xmp (1)


### PR DESCRIPTION
see https://sources.debian.net/patches/schism/2:20160521-1/