### PR TITLE
fmt: always include log.h when used

### DIFF
--- a/fmt/iti.c
+++ b/fmt/iti.c
@@ -27,6 +27,7 @@
 
 #include "it.h"
 #include "song.h"
+#include "log.h"
 
 #ifndef WIN32
 #endif

--- a/fmt/ult.c
+++ b/fmt/ult.c
@@ -26,6 +26,7 @@
 #include "slurp.h"
 #include "fmt.h"
 #include "it.h" /* for get_effect_char */
+#include "log.h"
 
 #include "sndfile.h"
 

--- a/fmt/wav.c
+++ b/fmt/wav.c
@@ -27,6 +27,7 @@
 #include "it.h"
 #include "disko.h"
 #include "sndfile.h"
+#include "log.h"
 #include <stdint.h>
 
 #define WAVE_FORMAT_PCM             0x0001


### PR DESCRIPTION
In experimenting with building the player portion as an embeddable
standalone library (e.g. for demo use) this oversight became apparent.