### PR TITLE
schism/page_loadinst: stop swallowing KEY_PRESS

### DIFF
--- a/schism/page_loadinst.c
+++ b/schism/page_loadinst.c
@@ -477,9 +477,6 @@ static int file_list_handle_key(struct key_event * k)
 	} else if (k->mouse == MOUSE_DBLCLICK) {
 		handle_enter_key();
 		return 1;
-	} else {
-		if (k->state == KEY_PRESS)
-			return 0;
 	}
 
 	new_file = CLAMP(new_file, 0, flist.num_files - 1);


### PR DESCRIPTION
For some reason the code was short-circuiting on k->state == KEY_PRESS
in a k->mouse state default/fall-through case.  This prevented regular
key press/repeat handling from functioning on the loadinst page.

Fixes https://github.com/schismtracker/schismtracker/issues/86