### PR TITLE
Introduce strn_dup() helper and use where applicable

### DIFF
--- a/fmt/669.c
+++ b/fmt/669.c
@@ -67,10 +67,7 @@ int fmt_669_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 		if (header->breaks[i] > 0x3f)
 			return 0;
 
-	file->title = (char *) mem_calloc(37, sizeof(char));
-	memcpy(file->title, header->songmessage, 36);
-	file->title[36] = 0;
-
+	file->title = strn_dup(header->songmessage, 36);
 	file->description = desc;
 	/*file->extension = str_dup("669");*/
 	file->type = TYPE_MODULE_S3M;

--- a/fmt/aiff.c
+++ b/fmt/aiff.c
@@ -174,11 +174,7 @@ static int _read_iff(dmoz_file_t *file, song_sample_t *smp, const uint8_t *data,
 		if (!name.id) name = auth;
 		if (!name.id) name = anno;
 		if (name.id) {
-			if (file) {
-				file->title = mem_calloc(1, name.size + 1);
-				memcpy(file->title, name.data->bytes, name.size);
-				file->title[name.size] = '\0';
-			}
+			if (file) file->title = strn_dup((const char *)name.data->bytes, name.size);
 			if (smp) {
 				int len = MIN(25, name.size);
 				memcpy(smp->name, name.data->bytes, len);
@@ -237,11 +233,7 @@ static int _read_iff(dmoz_file_t *file, song_sample_t *smp, const uint8_t *data,
 		if (!name.id) name = auth;
 		if (!name.id) name = anno;
 		if (name.id) {
-			if (file) {
-				file->title = mem_calloc(1, name.size + 1);
-				memcpy(file->title, name.data->bytes, name.size);
-				file->title[name.size] = '\0';
-			}
+			if (file) file->title = strn_dup((const char *)name.data->bytes, name.size);
 			if (smp) {
 				int len = MIN(25, name.size);
 				memcpy(smp->name, name.data->bytes, len);

--- a/fmt/ams.c
+++ b/fmt/ams.c
@@ -44,9 +44,7 @@ int fmt_ams_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 		n = 30;
 	file->description = "Velvet Studio";
 	/*file->extension = str_dup("ams");*/
-	file->title = mem_calloc(n + 1, sizeof(char));
-	memcpy(file->title, data + 8, n);
-	file->title[n] = 0;
+	file->title = strn_dup((const char *)data + 8, n);
 	file->type = TYPE_MODULE_XM;
 	return 1;
 }

--- a/fmt/au.c
+++ b/fmt/au.c
@@ -81,9 +81,7 @@ int fmt_au_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 	if (au.data_offset > 24) {
 		int extlen = au.data_offset - 24;
 
-		file->title = mem_calloc(extlen + 1, sizeof(char));
-		memcpy(file->title, data + 24, extlen);
-		file->title[extlen] = 0;
+		file->title = strn_dup((const char *)data + 24, extlen);
 	}
 	file->smp_filename = file->title;
 	file->type = TYPE_SAMPLE_PLAIN;

--- a/fmt/f2r.c
+++ b/fmt/f2r.c
@@ -35,9 +35,7 @@ int fmt_f2r_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 	file->description = "Farandole 2 (linear)";
 	/*file->extension = str_dup("f2r");*/
-	file->title = mem_calloc(41, sizeof(char));
-	memcpy(file->title, data + 6, 40);
-	file->title[40] = 0;
+	file->title = strn_dup((const char *)data + 6, 40);
 	file->type = TYPE_MODULE_S3M;
 	return 1;
 }

--- a/fmt/far.c
+++ b/fmt/far.c
@@ -39,9 +39,7 @@ int fmt_far_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 	file->description = "Farandole Module";
 	/*file->extension = str_dup("far");*/
-	file->title = mem_calloc(41, sizeof(char));
-	memcpy(file->title, data + 4, 40);
-	file->title[40] = 0;
+	file->title = strn_dup((const char *)data + 4, 40);
 	file->type = TYPE_MODULE_S3M;
 	return 1;
 }

--- a/fmt/imf.c
+++ b/fmt/imf.c
@@ -38,9 +38,7 @@ int fmt_imf_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 	file->description = "Imago Orpheus";
 	/*file->extension = str_dup("imf");*/
-	file->title = mem_calloc(33, sizeof(char));
-	memcpy(file->title, data, 32);
-	file->title[32] = 0;
+	file->title = strn_dup((const char *)data, 32);
 	file->type = TYPE_MODULE_IT;
 	return 1;
 }

--- a/fmt/iti.c
+++ b/fmt/iti.c
@@ -40,9 +40,7 @@ int fmt_iti_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 {
 	if (!(length > 554 && memcmp(data, "IMPI",4) == 0)) return 0;
 	file->description = "Impulse Tracker Instrument";
-	file->title = (char *)mem_calloc(26,sizeof(char *));
-	memcpy(file->title, data+32, 25);
-	file->title[25] = 0;
+	file->title = strn_dup((const char *)data + 32, 25);
 	file->type = TYPE_INST_ITI;
 
 	return 1;

--- a/fmt/its.c
+++ b/fmt/its.c
@@ -70,14 +70,9 @@ int fmt_its_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 	file->smp_sustain_start = bswapLE32(its->susloopbegin);
 	file->smp_sustain_end = bswapLE32(its->susloopend);
 
-	file->smp_filename = mem_alloc(13);
-	memcpy(file->smp_filename, its->filename, 12);
-	file->smp_filename[12] = 0;
-
+	file->smp_filename = strn_dup((const char *)its->filename, 12);
 	file->description = "Impulse Tracker Sample";
-	file->title = mem_alloc(26);
-	memcpy(file->title, data + 20, 25);
-	file->title[25] = 0;
+	file->title = strn_dup((const char *)data + 20, 25);
 	file->type = TYPE_SAMPLE_EXTD;
 
 	return 1;

--- a/fmt/liq.c
+++ b/fmt/liq.c
@@ -28,19 +28,13 @@
 
 int fmt_liq_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 {
-	char buf[32];
-
 	if (!(length > 64 && data[64] == 0x1a && memcmp(data, "Liquid Module:", 14) == 0))
 		return 0;
 
 	file->description = "Liquid Tracker";
 	/*file->extension = str_dup("liq");*/
-	memcpy(buf, data + 44, 20);
-	buf[20] = 0;
-	file->artist = str_dup(buf);
-	memcpy(buf, data + 14, 30);
-	buf[30] = 0;
-	file->title = str_dup(buf);
+	file->artist = strn_dup((const char *)data + 44, 20);
+	file->title = strn_dup((const char *)data + 14, 30);
 	file->type = TYPE_MODULE_S3M;
 
 	return 1;

--- a/fmt/mdl.c
+++ b/fmt/mdl.c
@@ -36,7 +36,6 @@
 int fmt_mdl_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 {
 	uint32_t position, block_length;
-	char buf[33];
 
 	/* data[4] = major version number (accept 0 or 1) */
 	if (!(length > 5 && ((data[4] & 0xf0) >> 4) <= 1 && memcmp(data, "DMDL", 4) == 0))
@@ -50,13 +49,8 @@ int fmt_mdl_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 			return 0;
 		if (memcmp(data + position, "IN", 2) == 0) {
 			/* hey! we have a winner */
-			memcpy(buf, data + position + 6, 32);
-			buf[32] = 0;
-			file->title = str_dup(buf);
-			memcpy(buf, data + position + 38, 20);
-			buf[20] = 0;
-			file->artist = str_dup(buf);
-
+			file->title = strn_dup((const char *)data + position + 6, 32);
+			file->artist = strn_dup((const char *)data + position + 38, 20);
 			file->description = "Digitrakker";
 			/*file->extension = str_dup("mdl");*/
 			file->type = TYPE_MODULE_XM;

--- a/fmt/mf.c
+++ b/fmt/mf.c
@@ -28,16 +28,12 @@
 
 int fmt_mf_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 {
-	uint8_t titlelen;
 	if (!(length > 290 && memcmp(data, "MOONFISH", 8) == 0))
 		return 0;
 
 	file->description = "MoonFish";
 	/*file->extension = str_dup("mf");*/
-	titlelen = MIN(32, data[32]);
-	file->title = mem_calloc(titlelen + 1, sizeof(char));
-	memcpy(file->title, data + 33, titlelen);
-	file->title[titlelen] = 0;
+	file->title = strn_dup((const char *)data + 33, MIN(32, data[32]));
 	file->type = TYPE_MODULE_MOD;    /* ??? */
 	return 1;
 }

--- a/fmt/mod.c
+++ b/fmt/mod.c
@@ -93,9 +93,7 @@ int fmt_mod_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 			file->description = valid_tags[i][1];
 			/*file->extension = str_dup("mod");*/
-			file->title = mem_calloc(21, sizeof(char));
-			memcpy(file->title, data, 20);
-			file->title[20] = 0;
+			file->title = strn_dup((const char *)data, 20);
 			file->type = TYPE_MODULE_MOD;
 			return 1;
 		}

--- a/fmt/mt2.c
+++ b/fmt/mt2.c
@@ -37,9 +37,7 @@ int fmt_mt2_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 	file->description = "MadTracker 2 Module";
 	/*file->extension = str_dup("mt2");*/
-	file->title = mem_calloc(65, sizeof(char));
-	memcpy(file->title, data + 42, 64);
-	file->title[64] = 0;
+	file->title = strn_dup((const char *)data + 42, 64);
 	file->type = TYPE_MODULE_XM;
 	return 1;
 }

--- a/fmt/mtm.c
+++ b/fmt/mtm.c
@@ -63,9 +63,7 @@ int fmt_mtm_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 	file->description = "MultiTracker Module";
 	/*file->extension = str_dup("mtm");*/
-	file->title = mem_calloc(21, sizeof(char));
-	memcpy(file->title, data + 4, 20);
-	file->title[20] = 0;
+	file->title = strn_dup((const char *)data + 4, 20);
 	file->type = TYPE_MODULE_MOD;
 	return 1;
 }

--- a/fmt/ntk.c
+++ b/fmt/ntk.c
@@ -33,9 +33,7 @@ int fmt_ntk_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 	file->description = "NoiseTrekker";
 	/*file->extension = str_dup("ntk");*/
-	file->title = mem_calloc(16, sizeof(char));
-	memcpy(file->title, data + 9, 15);
-	file->title[15] = 0;
+	file->title = strn_dup((const char *)data + 9, 15);
 	file->type = TYPE_MODULE_MOD;    /* ??? */
 	return 1;
 }

--- a/fmt/pat.c
+++ b/fmt/pat.c
@@ -131,9 +131,7 @@ int fmt_pat_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 		return 0;
 	}
 	file->description = "Gravis Patch File";
-	file->title = mem_alloc(17);
-	memcpy(file->title, header->insname, 16);
-	file->title[16] = '\0';
+	file->title = strn_dup(header->insname, 16);
 	file->type = TYPE_INST_OTHER;
 	return 1;
 }

--- a/fmt/s3i.c
+++ b/fmt/s3i.c
@@ -142,14 +142,10 @@ int fmt_s3i_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 	file->smp_loop_start = smp->loop_start;
 	file->smp_loop_end = smp->loop_end;
 	file->smp_speed = smp->c5speed;
-	file->smp_filename = (char*) mem_alloc(13);
-	memcpy(file->smp_filename, smp->filename, 12);
-	file->smp_filename[12] = 0;
+	file->smp_filename = strn_dup(smp->filename, 12);
 
 	file->description = "Scream Tracker Sample";
-	file->title = mem_alloc(26);
-	memcpy(file->title, smp->name, 25);
-	file->title[25] = 0;
+	file->title = strn_dup(smp->name, 25);
 	file->type = TYPE_SAMPLE_EXTD | TYPE_INST_OTHER;
 	return 1;
 }

--- a/fmt/s3m.c
+++ b/fmt/s3m.c
@@ -41,9 +41,7 @@ int fmt_s3m_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 	file->description = "Scream Tracker 3";
 	/*file->extension = str_dup("s3m");*/
-	file->title = mem_calloc(28, sizeof(char));
-	memcpy(file->title, data, 27);
-	file->title[27] = 0;
+	file->title = strn_dup((const char *)data, 27);
 	file->type = TYPE_MODULE_S3M;
 	return 1;
 }

--- a/fmt/stm.c
+++ b/fmt/stm.c
@@ -44,9 +44,7 @@ int fmt_stm_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 	file->description = "Scream Tracker 2";
 	/*file->extension = str_dup("stm");*/
 	file->type = TYPE_MODULE_MOD;
-	file->title = mem_calloc(21, sizeof(char));
-	memcpy(file->title, data, 20);
-	file->title[20] = 0;
+	file->title = strn_dup((const char *)data, 20);
 	return 1;
 }
 

--- a/fmt/ult.c
+++ b/fmt/ult.c
@@ -42,9 +42,7 @@ int fmt_ult_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 	file->description = "UltraTracker Module";
 	file->type = TYPE_MODULE_S3M;
 	/*file->extension = str_dup("ult");*/
-	file->title = mem_calloc(33, sizeof(char));
-	memcpy(file->title, data + 15, 32);
-	file->title[32] = 0;
+	file->title = strn_dup((const char *)data + 15, 32);
 	return 1;
 }
 

--- a/fmt/xi.c
+++ b/fmt/xi.c
@@ -107,9 +107,7 @@ int fmt_xi_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 		return 0;
 
 	file->description = "FastTracker Instrument";
-	file->title = mem_alloc(24);
-	memcpy(file->title, xi->name, 22);
-	file->title[22]='\0';
+	file->title = strn_dup((const char *)xi->name, 22);
 	file->type = TYPE_INST_XI;
 	return 1;
 }

--- a/fmt/xm.c
+++ b/fmt/xm.c
@@ -41,9 +41,7 @@ int fmt_xm_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 	file->description = "Fast Tracker 2 Module";
 	file->type = TYPE_MODULE_XM;
 	/*file->extension = str_dup("xm");*/
-	file->title = mem_calloc(21, sizeof(char));
-	memcpy(file->title, data + 17, 20);
-	file->title[20] = 0;
+	file->title = strn_dup((const char *)data + 17, 20);
 	return 1;
 }
 

--- a/include/util.h
+++ b/include/util.h
@@ -103,6 +103,7 @@ passed to them in the 'buf' parameter. */
 extern MALLOC void *mem_alloc(size_t);
 extern MALLOC void *mem_calloc(size_t, size_t);
 extern MALLOC char *str_dup(const char *);
+extern MALLOC char *strn_dup(const char *, size_t);
 extern void *mem_realloc(void *,size_t);
 extern void mem_free(void *);
 

--- a/schism/clippy.c
+++ b/schism/clippy.c
@@ -209,9 +209,7 @@ static int _x11_clip_filter(const SDL_Event *ev)
 					if (_current_selection != _current_clipboard) {
 						free(_current_clipboard);
 					}
-					_current_clipboard = mem_alloc(nbytes+1);
-					memcpy(_current_clipboard, (char*)src, nbytes);
-					_current_clipboard[nbytes] = 0;
+					_current_clipboard = strn_dup((const char *)src, nbytes);
 					_string_paste(CLIPPY_BUFFER, _current_clipboard);
 					_widget_owner[CLIPPY_BUFFER]
 							= _widget_owner[CLIPPY_SELECT];
@@ -363,9 +361,7 @@ static char *_internal_clippy_paste(int cb)
 					if (src) {
 						clen = GlobalSize(_hmem);
 						if (clen > 0) {
-							_current_clipboard = mem_alloc(clen+1);
-							memcpy(_current_clipboard, src, clen);
-							_current_clipboard[clen] = '\0';
+							_current_clipboard = strn_dup(src, clen);
 						}
 						GlobalUnlock(_hmem);
 					}
@@ -388,9 +384,7 @@ static char *_internal_clippy_paste(int cb)
 					if (clheader->length > 4 && *cldata == Ph_CL_TEXT) {
 						src = ((char *)clheader->data)+4;
 						clen = clheader->length - 4;
-						_current_clipboard = mem_alloc(clen+1);
-						memcpy(_current_clipboard, src, clen);
-						_current_clipboard[clen] = '\0';
+						_current_clipboard = strn_dup(src, clen);
 
 					}
 					PhClipboardPasteFinish(clhandle);
@@ -404,9 +398,7 @@ static char *_internal_clippy_paste(int cb)
 				if (clheader->length > 4 && *cldata == Ph_CL_TEXT) {
 					src = ((char *)clheader->data)+4;
 					clen = clheader->length - 4;
-					_current_clipboard = mem_alloc(clen+1);
-					memcpy(_current_clipboard, src, clen);
-					_current_clipboard[clen] = '\0';
+					_current_clipboard = strn_dup(src, clen);
 				}
 			}
 #endif /* NTO version selector */
@@ -456,9 +448,7 @@ void clippy_select(struct widget *w, char *addr, int len)
 		for (i = 0; addr[i] && (len < 0 || i < len); i++) {
 			/* nothing */
 		}
-		_current_selection = mem_alloc(i+1);
-		memcpy(_current_selection, addr, i);
-		_current_selection[i] = 0;
+		_current_selection = strn_dup(addr, i);
 		_widget_owner[CLIPPY_SELECT] = w;
 
 		/* update x11 Select (for xterms and stuff) */

--- a/schism/config-parser.c
+++ b/schism/config-parser.c
@@ -110,9 +110,7 @@ static size_t _parse_comments(const char *s, char **comments)
 	len = ptr - s;
 	if (len) {
 		/* save the comments */
-		new_comments = (char *)mem_alloc(len + 1);
-		strncpy(new_comments, s, len);
-		new_comments[len] = 0;
+		new_comments = strn_dup(s, len);
 		if (*comments) {
 			/* already have some comments -- add to them */
 			if (asprintf(&tmp, "%s%s", *comments, new_comments) == -1) {
@@ -285,9 +283,7 @@ int cfg_read(cfg_file_t *cfg)
 		len = strcspn(pos, "#\r\n");
 		if (len) {
 			char *line;
-			line = mem_alloc(len + 1);
-			strncpy(line, pos, len);
-			line[len] = 0;
+			line = strn_dup(pos, len);
 			trim_string(line);
 			if (_parse_section(cfg, line, &cur_section, comments)
 			    || _parse_keyval(cfg, line, cur_section, comments)) {

--- a/schism/util.c
+++ b/schism/util.c
@@ -81,6 +81,20 @@ char *str_dup(const char *s)
 	return q;
 }
 
+char *strn_dup(const char *s, size_t n)
+{
+	char *q;
+	q = malloc(n + 1);
+	if (!q) {
+		/* throw out of memory exception */
+		perror("strndup");
+		exit(255);
+	}
+	memcpy(q, s, n);
+	q[n] = '\0';
+	return q;
+}
+
 void *mem_alloc(size_t amount)
 {
 	void *q;


### PR DESCRIPTION
There are numerous places, particularly in the fmt/* code, where nul-terminated strings are being allocated, copied, and terminated manually.  This is unnecessarily complex, verbose, and error-prone.

Add a helper called strn_dup() which exits on allocation failures like the other MALLOC helpers, and simplify all the obvious instances by using it.

Note rather than simply wrapping strndup() a manual implementation has been retained for portability reasons.