### PR TITLE
player: add csf_adjust_sample_loop() bounds check

### DIFF
--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -1116,7 +1116,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, const void *file
 
 void csf_adjust_sample_loop(song_sample_t *sample)
 {
-	if (!sample->data) return;
+	if (!sample->data || sample->length < 1) return;
 	if (sample->loop_end > sample->length) sample->loop_end = sample->length;
 	if (sample->loop_start+2 >= sample->loop_end) {
 		sample->loop_start = sample->loop_end = 0;


### PR DESCRIPTION
This function accesses data[len-1] so when len is 0 it goes out-of-bounds.

Simply add a len < 1 qualifier to the already present !data short-circuit.

Fixes https://github.com/schismtracker/schismtracker/issues/90