### PR TITLE
schism/slurp: propagate peeked count in slurp_read

### DIFF
--- a/schism/slurp.c
+++ b/schism/slurp.c
@@ -302,7 +302,7 @@ long slurp_tell(slurp_t *t)
 
 size_t slurp_read(slurp_t *t, void *ptr, size_t count)
 {
-	slurp_peek(t, ptr, count);
+	count = slurp_peek(t, ptr, count);
 	t->pos += count;
 	return count;
 }


### PR DESCRIPTION
The addition of slurp_peek() lost the short-read clipping of
count done by slurp_read() by ignoring the slurp_peek() return value.