### PR TITLE
schism: fix MIDI "all notes off" on stop

### DIFF
--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -567,11 +567,19 @@ void song_stop_unlocked(int quitting)
 			moff[0] = 0xe0 + j;
 			moff[1] = 0;
 			csf_midi_send(current_song, (unsigned char *) moff, 2, 0, 0);
+
+			moff[0] = 0xb0 + j;	/* channel mode message */
+			moff[1] = 0x78;		/* all sound off */
+			moff[2] = 0;
+			csf_midi_send(current_song, (unsigned char *) moff, 3, 0, 0);
+
+			moff[1] = 0x79;		/* reset all controllers */
+			csf_midi_send(current_song, (unsigned char *) moff, 3, 0, 0);
+
+			moff[1] = 0x7b;		/* all notes off */
+			csf_midi_send(current_song, (unsigned char *) moff, 3, 0, 0);
 		}
 
-		// send all notes off
-#define _MIDI_PANIC     "\xb0\x78\0\xb0\x79\0\xb0\x7b\0"
-		csf_midi_send(current_song, (unsigned char *) _MIDI_PANIC, sizeof(_MIDI_PANIC) - 1, 0, 0);
 		csf_process_midi_macro(current_song, 0, current_song->midi_config.stop, 0, 0, 0, 0); // STOP!
 		midi_send_flush(); // NOW!
 


### PR DESCRIPTION
The existing code sent a sequence of:
1. all sound off
2. reset all controllers
3. all notes off

Which are all channel control messsages, and must be sent for every channel.
A channel of 0 was hard-coded for all of these, which prevented F8 from
effectively stopping MIDI notes when any channels other than the first were
in use.

This commit just sends the same sequence, for all the channels.