### PR TITLE
GitHub Release Upload for OS X and Linux (Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
 - make
 - grep '^Schism Tracker' <(./schismtracker --version)
 after_success:
-- tar -cvzf "schismtracker-$TRAVIS_TAG.tar.gz" ./schismtracker ../README.md ../COPYING ../docs/configuration.md
+- tar -cvzf "schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz" ./schismtracker ../README.md ../COPYING ../docs/configuration.md
 notifications:
   email:
     on_success: change
@@ -50,7 +50,7 @@ deploy:
   provider: releases
   api_key:
     secure: cUAYZylRFR658zj3l5bgRptyca3wD/92byCKkFFwnuDjFHUcXX+B3qur5muzC/kx0MUO1T/3rPqtrfcDMiGshOXtJbGN+b0FjlBDr3QGpS57yb3ULzzESZmxWA4EFjrJjvw8L0nleUveAYXx7DvGQXHO6yVZ57q+A2DemfU8KtUrTWrX5Pjn9xYYhd4OBBiJ+HxLaaQLAIggAAA2k2Lt3Ah3bBkGVX2rM+YbqJ4ylbYaltW1S6GCAWDKpsR6dL6ddt1UAu+sahm2pFhWHupW/Kt8J4YNr6nS1Z7YydmPB8Cp7IJVpXK+XEtaLVEV5N/ggEIdJytfLz38dotkJ0XYjqPE8s4MSpvBzFCAHhAitH5sOXP78SzeCJHjlUN918BXhD/hYDfv1gnGRCj4WZuYxaxTPmSbemprpSLXiO31mrjBHDbqD4xylfnRaCFY6DV1afe2Zvz70/4dkoqVYZN18pWDnkF0ekQWaBTBB1xhJ744R0/7k5E5FYFF++xX5hmUtu+tawhXZoTY1LWqAwiF1UvFz+ROqJQqJtkKJzTF+L42ceBzYL5SVlIf/mJm5qV+HvcxYIj/d20qMmwReZLUe6Wir3wHxugIP6eCS2pRvnVAtzTVBuFNB7hi6r8/jtITmKJWPjXTWcuc/xhbTXoAZumKnNfTvfdeVbFRMqYRQjQ=
-  file: "./build/schismtracker-$TRAVIS_TAG.tar.gz"
+  file: "./build/schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz"
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,56 @@
 language: c
 os:
-  - linux
-  - osx
+- linux
+- osx
 matrix:
   include:
-    - os: linux
-    - os: linux
-      dist: trusty
-    - os: osx
-      osx_image: beta-xcode6.1
-    - os: osx
-      osx_image: beta-xcode6.2
-    - os: osx
-      osx_image: beta-xcode6.3
-    - os: osx
-      osx_image: xcode6.4
-    - os: osx
-      osx_image: xcode7
-    - os: osx
-      osx_image: xcode7.1
-    - os: osx
-      osx_image: xcode7.2
-    - os: osx
-      osx_image: xcode7.3
-    - os: osx
-      osx_image: xcode8
+  - os: linux
+  - os: linux
+    dist: trusty
+  - os: osx
+    osx_image: beta-xcode6.1
+  - os: osx
+    osx_image: beta-xcode6.2
+  - os: osx
+    osx_image: beta-xcode6.3
+  - os: osx
+    osx_image: xcode6.4
+  - os: osx
+    osx_image: xcode7
+  - os: osx
+    osx_image: xcode7.1
+  - os: osx
+    osx_image: xcode7.2
+  - os: osx
+    osx_image: xcode7.3
+  - os: osx
+    osx_image: xcode8
 addons:
   apt:
     packages:
-      - libsdl1.2-dev
+    - libsdl1.2-dev
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
 script:
-  - autoreconf -i
-  - mkdir -p build
-  - cd build
-  - sh ../configure
-  - make
-  - grep '^Schism Tracker' <(./schismtracker --version)
+- autoreconf -i
+- mkdir -p build
+- cd build
+- sh ../configure
+- make
+- grep '^Schism Tracker' <(./schismtracker --version)
+after_success:
+- tar -cvzf "schismtracker-$TRAVIS_TAG.tar.gz" ./schismtracker ../README.md ../COPYING ../docs/configuration.md
 notifications:
   email:
     on_success: change
     on_failure: change
+deploy:
+  provider: releases
+  api_key:
+    secure: cUAYZylRFR658zj3l5bgRptyca3wD/92byCKkFFwnuDjFHUcXX+B3qur5muzC/kx0MUO1T/3rPqtrfcDMiGshOXtJbGN+b0FjlBDr3QGpS57yb3ULzzESZmxWA4EFjrJjvw8L0nleUveAYXx7DvGQXHO6yVZ57q+A2DemfU8KtUrTWrX5Pjn9xYYhd4OBBiJ+HxLaaQLAIggAAA2k2Lt3Ah3bBkGVX2rM+YbqJ4ylbYaltW1S6GCAWDKpsR6dL6ddt1UAu+sahm2pFhWHupW/Kt8J4YNr6nS1Z7YydmPB8Cp7IJVpXK+XEtaLVEV5N/ggEIdJytfLz38dotkJ0XYjqPE8s4MSpvBzFCAHhAitH5sOXP78SzeCJHjlUN918BXhD/hYDfv1gnGRCj4WZuYxaxTPmSbemprpSLXiO31mrjBHDbqD4xylfnRaCFY6DV1afe2Zvz70/4dkoqVYZN18pWDnkF0ekQWaBTBB1xhJ744R0/7k5E5FYFF++xX5hmUtu+tawhXZoTY1LWqAwiF1UvFz+ROqJQqJtkKJzTF+L42ceBzYL5SVlIf/mJm5qV+HvcxYIj/d20qMmwReZLUe6Wir3wHxugIP6eCS2pRvnVAtzTVBuFNB7hi6r8/jtITmKJWPjXTWcuc/xhbTXoAZumKnNfTvfdeVbFRMqYRQjQ=
+  file: "./build/schismtracker-$TRAVIS_TAG.tar.gz"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
 - make
 - grep '^Schism Tracker' <(./schismtracker --version)
 after_success:
-- tar -cvzf "$ARTIFACT_FILE" "$TRAVIS_BUILD_DIR/build/schismtracker" "$TRAVIS_BUILD_DIR/README.md" "$TRAVIS_BUILD_DIR/COPYING" "$TRAVIS_BUILD_DIR/docs/configuration.md"
+- tar -cvzf "$ARTIFACT_FILE" ./schismtracker ../README.md ../COPYING ../docs/configuration.md
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
 - make
 - grep '^Schism Tracker' <(./schismtracker --version)
 after_success:
-- tar -cvzf "$ARTIFACT_FILE" ./schismtracker ../README.md ../COPYING ../docs/configuration.md
+- tar -cvzf "$ARTIFACT_FILE" ./schismtracker -C ../ README.md COPYING -C docs configuration.md
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: c
 os:
 - linux
 - osx
+env:
+- ARTIFACT_FILE="$TRAVIS_BUILD_DIR/build/schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz"
 matrix:
   include:
   - os: linux
@@ -41,7 +43,7 @@ script:
 - make
 - grep '^Schism Tracker' <(./schismtracker --version)
 after_success:
-- tar -cvzf "schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz" ./schismtracker ../README.md ../COPYING ../docs/configuration.md
+- tar -cvzf "$ARTIFACT_FILE" "$TRAVIS_BUILD_DIR/build/schismtracker" "$TRAVIS_BUILD_DIR/README.md" "$TRAVIS_BUILD_DIR/COPYING" "$TRAVIS_BUILD_DIR/docs/configuration.md"
 notifications:
   email:
     on_success: change
@@ -50,7 +52,7 @@ deploy:
   provider: releases
   api_key:
     secure: cUAYZylRFR658zj3l5bgRptyca3wD/92byCKkFFwnuDjFHUcXX+B3qur5muzC/kx0MUO1T/3rPqtrfcDMiGshOXtJbGN+b0FjlBDr3QGpS57yb3ULzzESZmxWA4EFjrJjvw8L0nleUveAYXx7DvGQXHO6yVZ57q+A2DemfU8KtUrTWrX5Pjn9xYYhd4OBBiJ+HxLaaQLAIggAAA2k2Lt3Ah3bBkGVX2rM+YbqJ4ylbYaltW1S6GCAWDKpsR6dL6ddt1UAu+sahm2pFhWHupW/Kt8J4YNr6nS1Z7YydmPB8Cp7IJVpXK+XEtaLVEV5N/ggEIdJytfLz38dotkJ0XYjqPE8s4MSpvBzFCAHhAitH5sOXP78SzeCJHjlUN918BXhD/hYDfv1gnGRCj4WZuYxaxTPmSbemprpSLXiO31mrjBHDbqD4xylfnRaCFY6DV1afe2Zvz70/4dkoqVYZN18pWDnkF0ekQWaBTBB1xhJ744R0/7k5E5FYFF++xX5hmUtu+tawhXZoTY1LWqAwiF1UvFz+ROqJQqJtkKJzTF+L42ceBzYL5SVlIf/mJm5qV+HvcxYIj/d20qMmwReZLUe6Wir3wHxugIP6eCS2pRvnVAtzTVBuFNB7hi6r8/jtITmKJWPjXTWcuc/xhbTXoAZumKnNfTvfdeVbFRMqYRQjQ=
-  file: "./build/schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz"
+  file: "$ARTIFACT_FILE"
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
This PR modifies `.travis.yml` to upload a `.tar.gz` file for Linux and OS X for every tag on GitHub. You can see an example of how this looks like [here](https://github.com/asbjornu/schismtracker/releases/tag/20170628).

What needs to be done before this PR starts working is replacing this gibberish:

```yaml
deploy:
  api_key:
    secure: cUAYZylRFR658zj3l5bgRptyca3wD/92byCKkFFwnuDjFHUcXX+B3qur5muzC/kx0MUO1T/3rPqtrfcDMiGshOXtJbGN+b0FjlBDr3QGpS57yb3ULzzESZmxWA4EFjrJjvw8L0nleUveAYXx7DvGQXHO6yVZ57q+A2DemfU8KtUrTWrX5Pjn9xYYhd4OBBiJ+HxLaaQLAIggAAA2k2Lt3Ah3bBkGVX2rM+YbqJ4ylbYaltW1S6GCAWDKpsR6dL6ddt1UAu+sahm2pFhWHupW/Kt8J4YNr6nS1Z7YydmPB8Cp7IJVpXK+XEtaLVEV5N/ggEIdJytfLz38dotkJ0XYjqPE8s4MSpvBzFCAHhAitH5sOXP78SzeCJHjlUN918BXhD/hYDfv1gnGRCj4WZuYxaxTPmSbemprpSLXiO31mrjBHDbqD4xylfnRaCFY6DV1afe2Zvz70/4dkoqVYZN18pWDnkF0ekQWaBTBB1xhJ744R0/7k5E5FYFF++xX5hmUtu+tawhXZoTY1LWqAwiF1UvFz+ROqJQqJtkKJzTF+L42ceBzYL5SVlIf/mJm5qV+HvcxYIj/d20qMmwReZLUe6Wir3wHxugIP6eCS2pRvnVAtzTVBuFNB7hi6r8/jtITmKJWPjXTWcuc/xhbTXoAZumKnNfTvfdeVbFRMqYRQjQ=
```
 
…with an encrypted Access Token created by someone who has ownership of the Schism Tracker repository. To create a new Access Token:

1. Go [here](https://github.com/settings/tokens).
2. Click "Generate new token".
3. Enter a description such as "automatic releases for schismtracker/schismtracker".
4. Check the `public_repo` ("Access public repositories") claim.
5. Click "Generate token".
6. Copy the generated token to an editor or some other useful place.

Now the token needs to be encrypted before it can be used in the `.travis.yml` file. To do that, the [Travis Ruby Gem](https://rubygems.org/gems/travis/versions/1.8.8) needs to be installed. Then type:

```bash
travis encrypt <token>
```

…will output the encrypted token you can use in the `.travis.yml` file.

**NB: Keep the unencrypted token, since it might provide useful for the AppVeyor version of this PR.**

This fixes the Travis part of #40 and partially fixes #76. To fully fix #76, we need to complete #42 as well.