### PR TITLE
GitHub Release Upload for Windows (AppVeyor)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -119,10 +119,10 @@ on_finish:
   - ps: |
       Write-Host "$artifact"
       if (Test-Path "schismtracker_debug_logs.zip") { appveyor PushArtifact "schismtracker_debug_logs.zip" }
-      if (Test-Path "schismtracker.exe") { 7z a -tzip "$artifact" "schismtracker.exe" > nul }
-      if (Test-Path "SDL.dll") { 7z a -tzip "$artifact" "SDL.dll" > nul }
-      if (Test-Path "libgcc_s_dw2-1.dll") { 7z a -tzip "$artifact" "libgcc_s_dw2-1.dll" > nul }
-      if (Test-Path "libwinpthread-1.dll") { 7z a -tzip "$artifact" "libwinpthread-1.dll" > nul }
+      if (Test-Path "schismtracker.exe") { 7z a -tzip "$artifact" "schismtracker.exe" }
+      if (Test-Path "SDL.dll") { 7z a -tzip "$artifact" "SDL.dll" }
+      if (Test-Path "libgcc_s_dw2-1.dll") { 7z a -tzip "$artifact" "libgcc_s_dw2-1.dll" }
+      if (Test-Path "libwinpthread-1.dll") { 7z a -tzip "$artifact" "libwinpthread-1.dll" }
       if (Test-Path $artifact) { appveyor PushArtifact "$artifact" }
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -134,8 +134,8 @@ notifications:
   on_build_status_changed: true
 
 deploy:
-  release: schismtracker-$(appveyor_build_version)
-  description: $(appveyor_build_version)
+  release: $(APPVEYOR_REPO_TAG_NAME)
+  description: $(APPVEYOR_REPO_COMMIT_MESSAGE)
   provider: GitHub
   auth_token:
     secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,10 @@ install:
       $mingw = "mingw$bits"
       $mingwUpper = $mingw.ToUpper()
       $buildFolder = $env:APPVEYOR_BUILD_FOLDER
+      $tag = $env:APPVEYOR_REPO_TAG_NAME
       $posixBuildFolder = $buildFolder -Replace '\\', '/'
       $env:PATH="C:\$msys\$mingw\bin;C:\$msys\usr\bin;$env:PATH"
-      $artifact = "schismtracker-$appveyor_build_version-win$bits.zip"
+      $artifact = "schismtracker-$tag-win$bits.zip"
 
       function bash($command, $dieOnError = $true) {
         ""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,12 +115,13 @@ on_failure:
   - if exist "C:\msys%bits%\mingw%bits%\bin\sdl-config" 7z a -tzip schismtracker_debug_logs.zip "C:\msys%bits%\mingw%bits%\bin\sdl-config" > nul
 
 on_finish:
-  - if exist "schismtracker_debug_logs.zip" appveyor PushArtifact "schismtracker_debug_logs.zip"
-  - if exist "schismtracker.exe" 7z a -tzip schismtracker.zip "schismtracker.exe" > nul
-  - if exist "SDL.dll" 7z a -tzip schismtracker.zip "SDL.dll" > nul
-  - if exist "libgcc_s_dw2-1.dll" 7z a -tzip schismtracker.zip "libgcc_s_dw2-1.dll" > nul
-  - if exist "libwinpthread-1.dll" 7z a -tzip schismtracker.zip "libwinpthread-1.dll" > nul
-  - if exist "schismtracker.zip" appveyor PushArtifact "schismtracker.zip"
+  - ps: |
+      if (Test-Path "schismtracker_debug_logs.zip") { appveyor PushArtifact "schismtracker_debug_logs.zip" }
+      if (Test-Path "schismtracker.exe") { 7z a -tzip "schismtracker-$(appveyor_build_version).zip" "schismtracker.exe" > nul }
+      if (Test-Path "SDL.dll") { 7z a -tzip "schismtracker-$(appveyor_build_version).zip" "SDL.dll" > nul }
+      if (Test-Path "libgcc_s_dw2-1.dll") { 7z a -tzip "schismtracker-$(appveyor_build_version).zip" "libgcc_s_dw2-1.dll" > nul }
+      if (Test-Path "libwinpthread-1.dll") { 7z a -tzip "schismtracker-$(appveyor_build_version).zip" "libwinpthread-1.dll" > nul }
+      if (Test-Path "schismtracker.zip") { appveyor PushArtifact "schismtracker-$(appveyor_build_version).zip" }
 
 artifacts:
   - path: '*.zip'
@@ -129,3 +130,16 @@ notifications:
   on_build_success: false
   on_build_failure: false
   on_build_status_changed: true
+
+deploy:
+  release: schismtracker-$(appveyor_build_version)
+  description: $(appveyor_build_version)
+  provider: GitHub
+  auth_token:
+    secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F
+  artifact: /schismtracker-$(appveyor_build_version).zip
+  draft: false
+  prerelease: false
+  on:
+    # branch: master
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ install:
       $posixBuildFolder = $buildFolder -Replace '\\', '/'
       $env:PATH="C:\$msys\$mingw\bin;C:\$msys\usr\bin;$env:PATH"
       $artifact = "schismtracker-$tag-win$bits.zip"
+      [Environment]::SetEnvironmentVariable("SCHISMTRACKER_ARTIFACT_FILE", $artifact, "Machine")
 
       function bash($command, $dieOnError = $true) {
         ""
@@ -147,7 +148,7 @@ deploy:
   provider: GitHub
   auth_token:
     secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F
-  artifact: /.*schismtracker.*\.zip/
+  artifact: $(SCHISMTRACKER_ARTIFACT_FILE)
   draft: false
   prerelease: false
   on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,6 +112,7 @@ before_deploy:
       if (Test-Path "SDL.dll") { 7z a -tzip "$artifact" "SDL.dll" }
       if (Test-Path "libgcc_s_dw2-1.dll") { 7z a -tzip "$artifact" "libgcc_s_dw2-1.dll" }
       if (Test-Path "libwinpthread-1.dll") { 7z a -tzip "$artifact" "libwinpthread-1.dll" }
+      if (Test-Path $artifact) { appveyor PushArtifact "$artifact" }
 
 on_failure:
   - dir /s /b > dir.txt
@@ -124,14 +125,7 @@ on_failure:
   - if exist "C:\msys%bits%\mingw%bits%\bin\sdl-config" 7z a -tzip schismtracker_debug_logs.zip "C:\msys%bits%\mingw%bits%\bin\sdl-config" > nul
 
 on_finish:
-  - ps: |
-      Write-Host "$artifact"
-      if (Test-Path "schismtracker_debug_logs.zip") { appveyor PushArtifact "schismtracker_debug_logs.zip" }
-      if (Test-Path "schismtracker.exe") { 7z a -tzip "$artifact" "schismtracker.exe" }
-      if (Test-Path "SDL.dll") { 7z a -tzip "$artifact" "SDL.dll" }
-      if (Test-Path "libgcc_s_dw2-1.dll") { 7z a -tzip "$artifact" "libgcc_s_dw2-1.dll" }
-      if (Test-Path "libwinpthread-1.dll") { 7z a -tzip "$artifact" "libwinpthread-1.dll" }
-      if (Test-Path $artifact) { appveyor PushArtifact "$artifact" }
+  - ps: if (Test-Path "schismtracker_debug_logs.zip") { appveyor PushArtifact "schismtracker_debug_logs.zip" }
 
 artifacts:
   - path: '*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -147,7 +147,7 @@ deploy:
   provider: GitHub
   auth_token:
     secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F
-  artifact: $(artifact)
+  artifact: /.*\.zip/
   draft: false
   prerelease: false
   on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ install:
       $posixBuildFolder = $buildFolder -Replace '\\', '/'
       $env:PATH="C:\$msys\$mingw\bin;C:\$msys\usr\bin;$env:PATH"
       $artifact = "schismtracker-$tag-win$bits.zip"
-      [Environment]::SetEnvironmentVariable("SCHISMTRACKER_ARTIFACT_FILE", $artifact, "Machine")
 
       function bash($command, $dieOnError = $true) {
         ""
@@ -148,7 +147,7 @@ deploy:
   provider: GitHub
   auth_token:
     secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F
-  artifact: $(SCHISMTRACKER_ARTIFACT_FILE)
+  artifact: $(artifact)
   draft: false
   prerelease: false
   on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,12 +116,14 @@ on_failure:
 
 on_finish:
   - ps: |
+	  $artifact = "schismtracker-$appveyor_build_version-win$bits.zip"
+      Write-Host "$artifact"
       if (Test-Path "schismtracker_debug_logs.zip") { appveyor PushArtifact "schismtracker_debug_logs.zip" }
-      if (Test-Path "schismtracker.exe") { 7z a -tzip "schismtracker-$(appveyor_build_version).zip" "schismtracker.exe" > nul }
-      if (Test-Path "SDL.dll") { 7z a -tzip "schismtracker-$(appveyor_build_version).zip" "SDL.dll" > nul }
-      if (Test-Path "libgcc_s_dw2-1.dll") { 7z a -tzip "schismtracker-$(appveyor_build_version).zip" "libgcc_s_dw2-1.dll" > nul }
-      if (Test-Path "libwinpthread-1.dll") { 7z a -tzip "schismtracker-$(appveyor_build_version).zip" "libwinpthread-1.dll" > nul }
-      if (Test-Path "schismtracker.zip") { appveyor PushArtifact "schismtracker-$(appveyor_build_version).zip" }
+      if (Test-Path "schismtracker.exe") { 7z a -tzip "$artifact" "schismtracker.exe" > nul }
+      if (Test-Path "SDL.dll") { 7z a -tzip "$artifact" "SDL.dll" > nul }
+      if (Test-Path "libgcc_s_dw2-1.dll") { 7z a -tzip "$artifact" "libgcc_s_dw2-1.dll" > nul }
+      if (Test-Path "libwinpthread-1.dll") { 7z a -tzip "$artifact" "libwinpthread-1.dll" > nul }
+      if (Test-Path $artifact) { appveyor PushArtifact "$artifact" }
 
 artifacts:
   - path: '*.zip'
@@ -137,7 +139,7 @@ deploy:
   provider: GitHub
   auth_token:
     secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F
-  artifact: /schismtracker-$(appveyor_build_version).zip
+  artifact: "schismtracker-$appveyor_build_version-win$bits.zip"
   draft: false
   prerelease: false
   on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -145,5 +145,5 @@ deploy:
   draft: false
   prerelease: false
   on:
-    # branch: master
+    branch: master
     appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,6 +106,13 @@ test_script:
         exit 1
       }
 
+before_deploy:
+  - ps: |
+      if (Test-Path "schismtracker.exe") { 7z a -tzip "$artifact" "schismtracker.exe" }
+      if (Test-Path "SDL.dll") { 7z a -tzip "$artifact" "SDL.dll" }
+      if (Test-Path "libgcc_s_dw2-1.dll") { 7z a -tzip "$artifact" "libgcc_s_dw2-1.dll" }
+      if (Test-Path "libwinpthread-1.dll") { 7z a -tzip "$artifact" "libwinpthread-1.dll" }
+
 on_failure:
   - dir /s /b > dir.txt
   - if exist "stdout.txt" 7z a -tzip schismtracker_debug_logs.zip "stdout.txt" > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ install:
       $buildFolder = $env:APPVEYOR_BUILD_FOLDER
       $posixBuildFolder = $buildFolder -Replace '\\', '/'
       $env:PATH="C:\$msys\$mingw\bin;C:\$msys\usr\bin;$env:PATH"
+      $artifact = "schismtracker-$appveyor_build_version-win$bits.zip"
 
       function bash($command, $dieOnError = $true) {
         ""
@@ -116,7 +117,6 @@ on_failure:
 
 on_finish:
   - ps: |
-	  $artifact = "schismtracker-$appveyor_build_version-win$bits.zip"
       Write-Host "$artifact"
       if (Test-Path "schismtracker_debug_logs.zip") { appveyor PushArtifact "schismtracker_debug_logs.zip" }
       if (Test-Path "schismtracker.exe") { 7z a -tzip "$artifact" "schismtracker.exe" > nul }
@@ -139,7 +139,7 @@ deploy:
   provider: GitHub
   auth_token:
     secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F
-  artifact: "schismtracker-$appveyor_build_version-win$bits.zip"
+  artifact: "$artifact"
   draft: false
   prerelease: false
   on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -147,7 +147,7 @@ deploy:
   provider: GitHub
   auth_token:
     secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F
-  artifact: "$artifact"
+  artifact: /.*schismtracker.*\.zip/
   draft: false
   prerelease: false
   on:


### PR DESCRIPTION
This PR modifies `appveyor.yml` to upload a `.zip` file for 32 and 64 bit Windows for every tag on GitHub. You can see an example of how this looks like [here](https://github.com/asbjornu/schismtracker/releases/tag/20170629).

What needs to be done before this PR starts working is replacing this gibberish:

```yaml
deploy:
  auth_token:
    secure: 0vYg3iWKoeqKmAggg8G9FqmTZ8/R9DmnZkePvNFAJH1BfAxrd/l3Mni0t4maPW8F
```
 
…with the same unencrypted Access Token created in #108, this time encrypted with [AppVeyor's Encryption Tool (requires login)](https://ci.appveyor.com/tools/encrypt).

This fixes the Windows part of #40.