### PR TITLE
Only release self-created objects

### DIFF
--- a/sys/macosx/midi-macosx.c
+++ b/sys/macosx/midi-macosx.c
@@ -123,9 +123,7 @@ static char *get_ep_name(MIDIEndpointRef ep)
 			defaultEncoding);
 
 	/* clean up */
-	if (endpointName) CFRelease(endpointName);
-	if (deviceName) CFRelease(deviceName);
-	if (fullName) CFRelease(fullName);
+	if (fullName && !deviceName) CFRelease(fullName);
 
 	return newName;
 }


### PR DESCRIPTION
This PR changes the clean up part of `get_ep_name()` within `midi-macosx.c` such that it only performs `CFRelease` on the `fullName` variable if it was instantiated through the `CFStringCreateWithFormat()` function. This fixes #109, at least on my macOS 10.12.5 iMac.

Ideas on how to ensure that this continues to work in the future would be welcome. The current `schismtracker --version` test does not exercise the code in question, so it would be great if we could come up with a more extensive test to ensure that the `schismtracker` binary at least launches successfully on all platforms. Ideas?