### PR TITLE
Actual functioning step-by-step OSX compile instructions

### DIFF
--- a/docs/building_on_osx.md
+++ b/docs/building_on_osx.md
@@ -1,76 +1,59 @@
 # Building on OS X
 
-Building on Mac OS X is fairly straightforward once you've installed the Apple
-Developer's kit. If you have [Homebrew](http://brew.sh/) available, you should
-be able to install SDL with a simple `brew install sdl`, after which you can
-mostly follow the Linux instructions and you'll end up with a unix-style
-`schismtracker` binary that you can run from `Terminal.app`.
+Start by installing [Homebrew](http://brew.sh/). Open up the Terminal and paste in the following command.
 
-Alternately, you can also install the [SDL Developers
-Library](http://libsdl.org/download-1.2.php), but this tends to be somewhat
-more complicated as all the required pieces aren't shipped in the same package.
-Make sure to grab both the source and the Runtime Libraries, and some reports
-suggest that you might have to fiddle with paths to get `sdl.m4` working. But
-really, there's not much advantage over just using `brew`.
+```
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
 
-If you want a "normal" application that you could drop into `/Applications`,
-put in your dock, etc., copy that `schismtracker` binary into
-`sys/macosx/Schism Tracker.app/Contents/MacOS/`, and then you can copy that
-bundle around like any other app. It will associate itself with .IT (and other)
-files, so you can double-click them and the Finder will load Schism Tracker
-automatically.
+After Homebrew has been successfully installed, you need to install `automake`, `autoconf`, `SDL` and `git`.
 
-However, if you want to build an application bundle *for distribution*, there's
-a few potential snags. In particular, SDK versions are backward-incompatible,
-so you need to make note of what version you're building with; and if you also
-want to support the dwindling population of PowerPC users, you'll have to build
-a Universal binary. Plus, since SDL is not normally present on OS X, you'll
-need to bundle it in with the application.
+```
+brew install automake autoconf sdl git
+```
 
-There used to be somewhat lengthy instructions here elaborating on various
-nuances of installing Fink and managing multiple SDKs, but these have become
-rather outdated and probably less than thoroughly useful. If anyone has current
-and first-hand experience with building on OS X which might be helpful to
-others, please feel free to share.
+Now clone the GitHub repo:
 
-## Cross-compiling on a Linux host
+```
+git clone https://github.com/schismtracker/schismtracker.git
+```
 
-[This page](http://devs.openttd.org/~truebrain/compile-farm/apple-darwin9.txt)
-has some notes that might be of use in building a cross-compilation toolchain.
-Building a cross-compiler is *not* an easy process, and will probably take the
-better part of a day; however, it is definitely possible, and in fact is what I
-use for compiling the "official" OS X packages. The build process is rather
-messy, but it goes something like:
+Enter the Schismtracker folder and run `autoreconf -i`
 
-    mkdir -p osx/{x86,ppc}
-    cd osx/x86
-    env PATH=/usr/i686-apple-darwin9/bin:${PATH}                        \
-        {C,CXX,OBJC}FLAGS='-g0 -O2' LDFLAGS=-s                          \
-        ../../configure --with-sdl-prefix=/usr/i686-apple-darwin9       \
-                     --{target,host}=i686-apple-darwin9                 \
-                     --build-i686-linux
-    env PATH=/usr/i686-apple-darwin9/bin:${PATH} make
-    cd ../ppc
-    env PATH=/usr/powerpc-apple-darwin9/bin:${PATH}                     \
-        {C,CXX,OBJC}FLAGS='-g0 -O2' LDFLAGS=-s                          \
-        ../../configure --with-sdl-prefix=/usr/powerpc-apple-darwin9    \
-                     --{target,host}=powerpc-apple-darwin9              \
-                     --build-i686-linux
-    env PATH=/usr/powerpc-apple-darwin9/bin:${PATH} make
-    cd ..
-    /usr/i686-apple-darwin9/bin/lipo -create -o {.,x86,ppc}/schismtracker
-    /usr/i686-apple-darwin9/bin/install_name_tool -change               \
-        '@executable_path/../Frameworks/SDL.framework/Versions/A/SDL'   \
-        '@executable_path/sdl.dylib' schismtracker
+```
+cd schismtracker
+autoreconf -i
+```
 
-Then copy the `lipo`'ed `schismtracker` and `sdl.dylib` both into the `MacOS/`
-folder in the bundle, and it Should Work. The versions I have installed are GCC
-4.0.1 (SVN v5493), ODCCTools SVN v280, and XCode SDK 3.1.3. This SDK version
-advertises compatibility with 10.4 at minimum, although people have reported
-success in running Schism Tracker on 10.3.9.
+Now you will need to create the `build` -folder, enter it and start `../configure`
 
-Note: because parts of the debugging information are conspicuously absent,
-cross-compiling with debugging symbols simply isn't possible. This isn't very
-likely to be useful anyway; if you can run the program in a debugger, then
-you're *probably* running OS X, in which case you might as well just build
-natively and eliminate the hassle.
+```
+mkdir -p build
+cd build
+../configure && make
+```
+
+Test Schismtracker from the commandline by typing
+
+```
+./schismtracker
+```
+
+If it worked, you are ready to start the updating of the **Schism Tracker.app**
+
+# Baking Schism Tracker into an App ready to be put in /Applications
+
+If you are in the `build` -folder, discover the `Schism_Tracker.app` subfolder `Contents` and, after creating the `MacOS` -folder, copy the newly built `schismtracker` there - then test the `Schism_Tracker.app` by clicking on it in Finder. Here are the instructions on how to do it (this will open a Finder window showing the `sys/macosx` -folder, where-in you will see the app itself. 
+
+```
+cd ../sys/macosx/Schism_Tracker.app/Contents/
+mkdir MacOS
+cd MacOS
+cp ../../../../../build/schismtracker .
+cd ../../../
+open .
+```
+
+If this newly baked version of `Schism_Tracker.app` worked, just copy it to your `/Applications` -folder.
+
+Enjoy.


### PR DESCRIPTION
Here are instructions on how to clone the repo, install homebrew, get the required dependencies, compile the app and update the .app and copying it to /Applications.

@jangler By following these instructions, I was able to create a fully working ./schismtracker and a fully working Schism_Tracker.app. 

~This documentation is also a reaction to your "hey it's the same as linux - maybe i should specify it more clearly" - no it bloody well ain't the same, and no, instructions on compiling it to MacOSX do not in _any way_ benefit from being told to check some other bit of documentation unrelated to MacOSX...!!!!~

Hope you will find this change worth merging into the repo itself.
  

Closes #131 