### PR TITLE
fmt/mid: fix message_left underflow

### DIFF
--- a/fmt/mid.c
+++ b/fmt/mid.c
@@ -331,7 +331,7 @@ int fmt_mid_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 					case 0x5: // lyric
 					case 0x6: // marker
 					case 0x7: // cue point
-						y = MIN(vlen, message_left - 1);
+						y = MIN(vlen, message_left ? message_left - 1 : 0);
 						slurp_read(fp, message_cur, y);
 						if (x == 3 && y && !song->title[0]) {
 							strncpy(song->title, message_cur, MIN(y, 25));


### PR DESCRIPTION
message_left can reach zero, don't assume it can always have 1
subtracted.

This code is fragile and frankly a mess, but this minor change seems to
prevent a crash with at least one probably corrupted midi file.

See https://github.com/schismtracker/schismtracker/issues/149