### PR TITLE
main: cease accessing event.key in mouse events

### DIFF
--- a/schism/main.c
+++ b/schism/main.c
@@ -729,7 +729,7 @@ static void event_loop(void)
 		case SDL_MOUSEBUTTONDOWN:
 		case SDL_MOUSEBUTTONUP:
 			if (kk.state == KEY_PRESS) {
-				modkey = event.key.keysym.mod;
+				modkey = SDL_GetModState();
 #if defined(WIN32)
 				win32_get_modkey(&modkey);
 #endif


### PR DESCRIPTION
Use SDL_GetModState() to get the modkey state, the key member
is invalid for the mouse event types, accessing it is a bug.