### PR TITLE
Fixup X11 selection handling

### DIFF
--- a/schism/clippy.c
+++ b/schism/clippy.c
@@ -185,7 +185,7 @@ static int _x11_clip_filter(const SDL_Event *ev)
 {
 	XSelectionRequestEvent *req;
 	XEvent sevent;
-	Atom seln_type;
+	Atom seln_type, seln_target;
 	int seln_format;
 	unsigned long nbytes;
 	unsigned long overflow;
@@ -231,27 +231,27 @@ static int _x11_clip_filter(const SDL_Event *ev)
 	sevent.xselection.type = SelectionNotify;
 	sevent.xselection.display = req->display;
 	sevent.xselection.selection = req->selection;
-	sevent.xselection.target = None;
+	sevent.xselection.target = req->target;
 	sevent.xselection.property = None;
 	sevent.xselection.requestor = req->requestor;
 	sevent.xselection.time = req->time;
 	if (XGetWindowProperty(SDL_Display, DefaultRootWindow(SDL_Display),
 			XA_CUT_BUFFER0, 0, 9000, False, req->target,
-			&sevent.xselection.target, &seln_format,
+			&seln_target, &seln_format,
 			&nbytes, &overflow, &seln_data) == Success) {
-		if (sevent.xselection.target == req->target) {
-			if (sevent.xselection.target == XA_STRING) {
+		if (seln_target == req->target) {
+			if (seln_target == XA_STRING) {
 				if (nbytes && seln_data[nbytes-1] == '\0')
 					nbytes--;
 			}
 			XChangeProperty(SDL_Display, req->requestor, req->property,
-				sevent.xselection.target, seln_format, PropModeReplace,
+				seln_target, seln_format, PropModeReplace,
 				seln_data, nbytes);
 			sevent.xselection.property = req->property;
 		}
 		XFree(seln_data);
 	}
-	XSendEvent(SDL_Display,req->requestor,False,0,&sevent);
+	XSendEvent(SDL_Display, req->requestor, False, 0, &sevent);
 	XSync(SDL_Display, False);
 	return 1;
 }

--- a/schism/clippy.c
+++ b/schism/clippy.c
@@ -100,7 +100,7 @@ static void _clippy_copy_to_sys(int do_sel)
 			}
 			XChangeProperty(SDL_Display,
 				DefaultRootWindow(SDL_Display),
-				XA_CUT_BUFFER1, XA_STRING, 8,
+				XA_CUT_BUFFER0, XA_STRING, 8,
 				PropModeReplace, (unsigned char *)dst, j);
 		} else {
 			if (XGetSelectionOwner(SDL_Display, atom_clip) != SDL_Window) {


### PR DESCRIPTION
Failed XSelectionRequestEvent scenarios are being replied to with a different target type than requested.  This confuses requestors so they ignore the response.  XA_CUT_BUFFER0 should also be the cut buffer used for the primary selection.

With these changes I can now paste directly from schism to xterm.  Without them I cannot, with only the first commit to use XA_CUT_BUFFER0 I can sort of paste, but it takes a very long time.