### PR TITLE
Added MacPort instructions

### DIFF
--- a/docs/building_on_osx.md
+++ b/docs/building_on_osx.md
@@ -14,7 +14,7 @@ brew install automake autoconf sdl git
 
 Alternatively, if you have MacPorts installed, you can use this command instead:
 ```
-sudo port install automake autoconf libsdl git
+sudo port install automake autoconf libtool libsdl git
 ```
 In this case, you may have to open a new terminal shell, or else you may get warnings about the version of autoconf/automake you're using.
 

--- a/docs/building_on_osx.md
+++ b/docs/building_on_osx.md
@@ -12,6 +12,12 @@ After Homebrew has been successfully installed, you need to install `automake`, 
 brew install automake autoconf sdl git
 ```
 
+Alternatively, if you have MacPorts installed, you can use this command instead:
+```
+sudo port install automake autoconf libsdl git
+```
+In this case, you may have to open a new terminal shell, or else you may get warnings about the version of autoconf/automake you're using.
+
 Now clone the GitHub repo:
 
 ```


### PR DESCRIPTION
I decided to give building this program a go, since I encountered an incompatibility with the pre-built version (specifically, I got an illegal instruction error, and I figured it was a processor-related incompatibility, rather than anything to do with a version incompatibility). This was the first time I have done this since I had acquired the program way back in 2005-2006! (And I had been regularly using it since 2007.)

I did not use homebrew, as I already had MacPorts installed (and I recall abandoning homebrew since they weren't actively supporting my OS last time I recall). I had technical difficulties with AM_PATH_SDL before I did any of this. I checked and see if I could fix it using MacPorts. A lookup online said yes, and I proceeded with the installation. Then I had to get a new shell up and running (or restart Terminal, but not the computer itself) because I ran into an unusual versioning problem, considering the symlinks didn't update properly on the current session I was on. Once I did that, the build worked, and I did a quick test and it worked like a charm.

Since I followed the rest of the instructions showed here, I just added one little section. The only thing I did not do was install git (I had a special version already in use, although I cloned using SSH rather than HTTPS due to technical difficulties with later versions of protocols and a deprecation there too).

My apologies on the forked repo and it's "patch-x" branches... I edited directly via the Github page, and was... rather revision-happy. At least this is only a one-commit case anyways...