### PR TITLE
Update macOS .app bundle and include it in the gzipped artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ after_success:
     cp -r ./sys/macosx/Schism_Tracker.app/* ./schismtracker/Schism\ Tracker.app/
     sed -i '' "s/<string>Copyright<\/string>/<string>Schism Tracker $TRAVIS_TAG Copyright 2003-$YEAR Storlek<\/string>/g" ./schismtracker/Schism\ Tracker.app/Contents/Info.plist
     sed -i '' "s/<string>CFBundleShortVersionString<\/string>/<string>$TRAVIS_TAG<\/string>/g" ./schismtracker/Schism\ Tracker.app/Contents/Info.plist
-    cp build/schismtracker ./schismtracker/Schism\ Tracker.app/Contents/MacOS/
+    sed -i '' "s/<string>CFBundleVersion<\/string>/<string>$TRAVIS_BUILD_NUMBER<\/string>/g" ./schismtracker/Schism\ Tracker.app/Contents/Info.plist
+    cp build/schismtracker ./schismtracker/Schism\ Tracker.app/Contents/MacOS/    
   else
     cp build/schismtracker \
        sys/posix/schismtracker.1 \

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,14 @@ after_success:
     sys/posix/schismtracker.1 schismtracker/
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    echo "TODO: macosx app"
+    mkdir -p sys/macosx/Schism_Tracker.app/Contents/MacOS
+    cp build/schismtracker sys/macosx/Schism_Tracker.app/Contents/MacOS/
+    cd sys/macosx
+    tar -cvzf "$ARTIFACT_FILE" Schism_Tracker.app
   else
     cp sys/fd.org/schism.desktop schismtracker/
+    tar -cvzf "$ARTIFACT_FILE" schismtracker
   fi
-- tar -cvzf "$ARTIFACT_FILE" schismtracker
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ after_success:
     mkdir -p ./schismtracker/Schism\ Tracker.app/Contents/MacOS
     cp -r ./sys/macosx/Schism_Tracker.app/* ./schismtracker/Schism\ Tracker.app/
     sed -i '' "s/<string>Copyright<\/string>/<string>Schism Tracker $TRAVIS_TAG Copyright 2003-$YEAR Storlek<\/string>/g" ./schismtracker/Schism\ Tracker.app/Contents/Info.plist
+    sed -i '' "s/<string>CFBundleShortVersionString<\/string>/<string>$TRAVIS_TAG<\/string>/g" ./schismtracker/Schism\ Tracker.app/Contents/Info.plist
     cp build/schismtracker ./schismtracker/Schism\ Tracker.app/Contents/MacOS/
   else
     cp build/schismtracker \

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,16 +46,20 @@ after_success:
 - cd ..
 - mkdir -p schismtracker
 - |
-  cp build/schismtracker README.md COPYING docs/configuration.md \
-    sys/posix/schismtracker.1 schismtracker/
+  cp README.md \
+     COPYING \
+     docs/configuration.md \
+     schismtracker/
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     mkdir -p sys/macosx/Schism_Tracker.app/Contents/MacOS
     cp build/schismtracker sys/macosx/Schism_Tracker.app/Contents/MacOS/
-    cd sys/macosx
-    tar -cvzf "$ARTIFACT_FILE" Schism_Tracker.app
+    tar -cvzf "$ARTIFACT_FILE" -C $TRAVIS_BUILD_DIR/schismtracker . -C $TRAVIS_BUILD_DIR/sys/macosx Schism_Tracker.app
   else
-    cp sys/fd.org/schism.desktop schismtracker/
+    cp build/schismtracker \
+       sys/posix/schismtracker.1 \
+       sys/fd.org/schism.desktop \
+       schismtracker/
     tar -cvzf "$ARTIFACT_FILE" schismtracker
   fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,16 +52,16 @@ after_success:
      schismtracker/
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    mkdir -p sys/macosx/Schism_Tracker.app/Contents/MacOS
-    cp build/schismtracker sys/macosx/Schism_Tracker.app/Contents/MacOS/
-    tar -cvzf "$ARTIFACT_FILE" -C $TRAVIS_BUILD_DIR/schismtracker . -C $TRAVIS_BUILD_DIR/sys/macosx Schism_Tracker.app
+    mkdir -p ./schismtracker/Schism\ Tracker.app/Contents/MacOS
+    cp -r ./sys/macosx/Schism_Tracker.app/* ./schismtracker/Schism\ Tracker.app/
+    cp build/schismtracker ./schismtracker/Schism\ Tracker.app/Contents/MacOS/
   else
     cp build/schismtracker \
        sys/posix/schismtracker.1 \
        sys/fd.org/schism.desktop \
        schismtracker/
-    tar -cvzf "$ARTIFACT_FILE" schismtracker
   fi
+  tar -cvzf "$ARTIFACT_FILE" schismtracker
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ os:
 - linux
 - osx
 env:
-- ARTIFACT_FILE="$TRAVIS_BUILD_DIR/build/schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz"
-- YEAR=$(date +'%Y')
+  global:
+  - ARTIFACT_FILE="$TRAVIS_BUILD_DIR/build/schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz"
+  - YEAR=$(date +'%Y')
 matrix:
   include:
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ after_success:
        sys/fd.org/schism.desktop \
        schismtracker/
   fi
-  tar -cvzf "$ARTIFACT_FILE" schismtracker
+- tar -cvzf "$ARTIFACT_FILE" schismtracker
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
 - osx
 env:
 - ARTIFACT_FILE="$TRAVIS_BUILD_DIR/build/schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz"
+- YEAR=$(date +'%Y')
 matrix:
   include:
   - os: linux
@@ -54,6 +55,7 @@ after_success:
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     mkdir -p ./schismtracker/Schism\ Tracker.app/Contents/MacOS
     cp -r ./sys/macosx/Schism_Tracker.app/* ./schismtracker/Schism\ Tracker.app/
+    sed -i '' "s/<string>Copyright<\/string>/<string>Schism Tracker $TRAVIS_TAG Copyright 2003-$YEAR Storlek<\/string>/g" ./schismtracker/Schism\ Tracker.app/Contents/Info.plist
     cp build/schismtracker ./schismtracker/Schism\ Tracker.app/Contents/MacOS/
   else
     cp build/schismtracker \

--- a/sys/macosx/Schism_Tracker.app/Contents/Info.plist
+++ b/sys/macosx/Schism_Tracker.app/Contents/Info.plist
@@ -86,6 +86,8 @@
 	</array>
 	<key>CFBundleGetInfoString</key>
 	<string>Copyright</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright</string>
 	<key>CFBundleIconFile</key>
 	<string>appIcon.icns</string>
 	<key>CFBundleIdentifier</key>

--- a/sys/macosx/Schism_Tracker.app/Contents/Info.plist
+++ b/sys/macosx/Schism_Tracker.app/Contents/Info.plist
@@ -85,7 +85,7 @@
 		</dict>
 	</array>
 	<key>CFBundleGetInfoString</key>
-	<string>Schism Tracker Copyright 2003-2012 Storlek</string>
+	<string>Copyright</string>
 	<key>CFBundleIconFile</key>
 	<string>appIcon.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -97,11 +97,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>hg</string>
+	<string>CFBundleShortVersionString</string>
 	<key>CFBundleSignature</key>
 	<string>Schm</string>
 	<key>CFBundleVersion</key>
-	<string>hg</string>
+	<string>CFBundleVersion</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
This PR basically takes the instructions from #132 and codifies them in the `.travis.yml` file such that the `schismtracker` binary is copied to `Schism Tracker.app` and the whole `.app` is gzipped in the resulting artifact that is uploaded to the GitHub release (on `git tag`).

The PR also performs some string replacements inside the `Info.plist` file so we get updated copyright and version information in the bundle. Fixes #125.