### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET to 10.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
   - ARTIFACT_FILE="$TRAVIS_BUILD_DIR/build/schismtracker-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz"
   - YEAR=$(date +'%Y')
+  - MACOSX_DEPLOYMENT_TARGET=10.11
 matrix:
   include:
   - os: linux


### PR DESCRIPTION
This PR sets the `MACOSX_DEPLOYMENT_TARGET` environment variable to `10.11` in Travis to hopefully fix #172.