### PR TITLE
Preserve shared samples on "Delete instrument & all related samples"

### DIFF
--- a/fmt/xi.c
+++ b/fmt/xi.c
@@ -128,7 +128,7 @@ int fmt_xi_load_instrument(const uint8_t *data, size_t length, int slot)
 
 	end = data + length;
 
-	song_delete_instrument(slot);
+	song_delete_instrument(slot, 0);
 
 	g = instrument_loader_init(&ii, slot);
 	memcpy(g->name, xi->name, 22);

--- a/helptext/instrument-list
+++ b/helptext/instrument-list
@@ -10,6 +10,7 @@
 |   Spacebar        Edit instrument name (ESC to exit)
 |
 |   Alt-D           Delete instrument & all related samples
+|   Alt-Shift-D     Delete instrument & all related unused samples
 :   Alt-L           Post-Loop cut envelope
 |   Alt-N           Toggle Multichannel playback
 |   Alt-O           Save current instrument to disk

--- a/include/song.h
+++ b/include/song.h
@@ -349,7 +349,7 @@ void song_remove_sample_slot(int n);
 void song_insert_instrument_slot(int n);
 void song_remove_instrument_slot(int n);
 
-void song_delete_instrument(int n);
+void song_delete_instrument(int n, int preserve_samples);
 void song_wipe_instrument(int n);
 
 int song_instrument_is_empty(int n);

--- a/schism/page_instruments.c
+++ b/schism/page_instruments.c
@@ -1999,7 +1999,12 @@ static void instrument_save(void)
 
 static void do_delete_inst(UNUSED void *ign)
 {
-	song_delete_instrument(current_instrument);
+	song_delete_instrument(current_instrument, 0);
+}
+
+static void do_delete_inst_preserve(UNUSED void *ign)
+{
+	song_delete_instrument(current_instrument, 1);
 }
 
 static void instrument_list_handle_alt_key(struct key_event *k)
@@ -2032,9 +2037,15 @@ static void instrument_list_handle_alt_key(struct key_event *k)
 		song_wipe_instrument(current_instrument);
 		break;
 	case SDLK_d:
-		dialog_create(DIALOG_OK_CANCEL,
-			"Delete Instrument?",
-			do_delete_inst, NULL, 1, NULL);
+        if (k->mod & KMOD_SHIFT) {
+            dialog_create(DIALOG_OK_CANCEL,
+                "Delete Instrument? (used samples preserved)",
+                do_delete_inst_preserve, NULL, 1, NULL);
+        } else {
+            dialog_create(DIALOG_OK_CANCEL,
+                "Delete Instrument?",
+                do_delete_inst, NULL, 1, NULL);
+        }
 		return;
 	default:
 		return;


### PR DESCRIPTION
New instrument command: delete-with-preserve

This commit adds a new command to the instrument page:
```
Delete instrument & all related unused samples
```
This command is bound to Alt-Shift-D.

When executed, this command deletes the currently selected instrument and all related samples that are not used by any other instrument.  This is similar to Alt-D, except it does not delete samples used by other instruments.

Example: If instruments X and Y both use sample S, you can delete one instrument without breaking the other.