### PR TITLE
Including AudioVideo category in schism.desktop file

### DIFF
--- a/sys/fd.org/schism.desktop
+++ b/sys/fd.org/schism.desktop
@@ -9,7 +9,7 @@ TryExec=schismtracker
 Exec=schismtracker %f
 Type=Application
 Icon=schism-icon-128
-Categories=Audio;Midi;Sequencer;Player;Music;
+Categories=AudioVideo;Audio;Midi;Sequencer;Player;Music;
 MimeType=audio/x-it;audio/x-s3m;audio/x-xm;audio/x-mod;
 Keywords=impulse;module;midi;music;
 


### PR DESCRIPTION
Several desktop environments on Linux place the Schism Tracker shortcut in the "Other" category.
The shortcut only appears in the "Multimedia" group if the file is registered with the category "AudioVideo".
The freedesktop.org website contains more information about this:
https://specifications.freedesktop.org/menu-spec/1.0/apa.html