### PR TITLE
fmt/mod: rearrange fmt_mod_load_song()+friends

### DIFF
--- a/fmt/mod.c
+++ b/fmt/mod.c
@@ -105,23 +105,9 @@ int fmt_mod_read_info(dmoz_file_t *file, const uint8_t *data, size_t length)
 
 /* --------------------------------------------------------------------------------------------------------- */
 
-/* loads everything but old 15-instrument mods... yes, even FLT8 and WOW files
-   (and the definition of "everything" is always changing) */
-int fmt_mod31_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
-{
-	return fmt_mod_load_song(song, fp, lflags, 0);
-}
-
-/* loads everything including old 15-instrument mods. this is a separate
-   function so that it can be called later in the format-checking sequence. */
-int fmt_mod15_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
-{
-	return fmt_mod_load_song(song, fp, lflags, 1);
-}
-
 /* force determines whether the loader will force-read untagged files as
    15-sample mods */
-int fmt_mod_load_song(song_t *song, slurp_t *fp, unsigned int lflags, int force)
+static int fmt_mod_load_song(song_t *song, slurp_t *fp, unsigned int lflags, int force)
 {
 	uint8_t tag[4];
 	int n, npat, pat, chan, nchan, nord;
@@ -397,3 +383,16 @@ int fmt_mod_load_song(song_t *song, slurp_t *fp, unsigned int lflags, int force)
 	return LOAD_SUCCESS;
 }
 
+/* loads everything but old 15-instrument mods... yes, even FLT8 and WOW files
+   (and the definition of "everything" is always changing) */
+int fmt_mod31_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
+{
+	return fmt_mod_load_song(song, fp, lflags, 0);
+}
+
+/* loads everything including old 15-instrument mods. this is a separate
+   function so that it can be called later in the format-checking sequence. */
+int fmt_mod15_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
+{
+	return fmt_mod_load_song(song, fp, lflags, 1);
+}


### PR DESCRIPTION
The public wrappers get prototypes in fmt-types.h, but
the private common function doesn't.

Mark the private common function static to clarify this
situation, and move the public wrappers to after it so
it's declared when they use it.

Fixes https://github.com/schismtracker/schismtracker/issues/234