### PR TITLE
Always used frequency instead of periods internally

### DIFF
--- a/include/sndfile.h
+++ b/include/sndfile.h
@@ -669,6 +669,7 @@ void csf_note_change(song_t *csf, uint32_t chan, int note, int porta, int retrig
 uint32_t csf_get_nna_channel(song_t *csf, uint32_t chan);
 void csf_check_nna(song_t *csf, uint32_t chan, uint32_t instr, int note, int force_cut);
 void csf_process_effects(song_t *csf, int firsttick);
+int32_t csf_fx_do_freq_slide(uint32_t flags, int32_t period, int32_t slide);
 
 void fx_note_cut(song_t *csf, uint32_t chan, int clear_note);
 void fx_key_off(song_t *csf, uint32_t chan);
@@ -679,8 +680,8 @@ song_sample_t *csf_translate_keyboard(song_t *csf, song_instrument_t *ins, uint3
 
 // various utility functions in snd_fx.c
 int get_note_from_period(int period);
-int get_period_from_note(int note, unsigned int c5speed, int linear);
-unsigned int get_freq_from_period(int period, int linear);
+int get_period_from_note(int note, unsigned int c5speed);
+unsigned int get_freq_from_period(int period);
 unsigned int transpose_to_frequency(int transp, int ftune);
 int frequency_to_transpose(unsigned int freq);
 unsigned long calc_halftone(unsigned long hz, int rel);

--- a/include/sndfile.h
+++ b/include/sndfile.h
@@ -430,7 +430,7 @@ typedef struct song_voice {
 	int32_t final_panning; // range 0-256 (but can temporarily exceed that range during calculations)
 	int32_t volume, panning; // range 0-256 (?); these are the current values set for the channel
 	int32_t fadeout_volume;
-	int32_t period;
+	int32_t frequency;
 	int32_t c5speed;
 	int32_t sample_freq; // only used on the info page (F5)
 	int32_t portamento_target;
@@ -669,7 +669,7 @@ void csf_note_change(song_t *csf, uint32_t chan, int note, int porta, int retrig
 uint32_t csf_get_nna_channel(song_t *csf, uint32_t chan);
 void csf_check_nna(song_t *csf, uint32_t chan, uint32_t instr, int note, int force_cut);
 void csf_process_effects(song_t *csf, int firsttick);
-int32_t csf_fx_do_freq_slide(uint32_t flags, int32_t period, int32_t slide);
+int32_t csf_fx_do_freq_slide(uint32_t flags, int32_t frequency, int32_t slide);
 
 void fx_note_cut(song_t *csf, uint32_t chan, int clear_note);
 void fx_key_off(song_t *csf, uint32_t chan);
@@ -679,9 +679,8 @@ void csf_process_midi_macro(song_t *csf, uint32_t chan, const char *midi_macro, 
 song_sample_t *csf_translate_keyboard(song_t *csf, song_instrument_t *ins, uint32_t note, song_sample_t *def);
 
 // various utility functions in snd_fx.c
-int get_note_from_period(int period);
-int get_period_from_note(int note, unsigned int c5speed);
-unsigned int get_freq_from_period(int period);
+int get_note_from_frequency(int frequency, unsigned int c5speed);
+int get_frequency_from_note(int note, unsigned int c5speed);
 unsigned int transpose_to_frequency(int transp, int ftune);
 int frequency_to_transpose(unsigned int freq);
 unsigned long calc_halftone(unsigned long hz, int rel);

--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -473,7 +473,7 @@ void csf_set_current_order(song_t *csf, uint32_t position)
 	for (uint32_t j = 0; j < MAX_VOICES; j++) {
 		song_voice_t *v = csf->voices + j;
 
-		v->period = 0;
+		v->frequency = 0;
 		v->note = v->new_note = v->new_instrument = 0;
 		v->portamento_target = 0;
 		v->n_command = 0;
@@ -1209,7 +1209,7 @@ void csf_stop_sample(song_t *csf, song_sample_t *smp)
 			v->note = v->new_note = v->new_instrument = 0;
 			v->fadeout_volume = 0;
 			v->flags |= CHN_KEYOFF | CHN_NOTEFADE;
-			v->period = 0;
+			v->frequency = 0;
 			v->position = v->length = 0;
 			v->loop_start = 0;
 			v->loop_end = 0;

--- a/player/sndmix.c
+++ b/player/sndmix.c
@@ -104,15 +104,6 @@ static unsigned int find_volume(unsigned short vol)
 }
 
 
-unsigned int get_freq_from_period(int period)
-{
-	if (period <= 0)
-		return INT_MAX;
-	else
-		return period;
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////////////////
 //
 // XXX * I prefixed these with `rn_' to avoid any namespace conflicts
@@ -131,7 +122,7 @@ static inline void rn_tremor(song_voice_t *chan, int *vol)
 }
 
 
-static inline int rn_vibrato(song_t *csf, song_voice_t *chan, int period)
+static inline int rn_vibrato(song_t *csf, song_voice_t *chan, int frequency)
 {
 	unsigned int vibpos = chan->vibrato_position & 0xFF;
 	int vdelta;
@@ -161,17 +152,17 @@ static inline int rn_vibrato(song_t *csf, song_voice_t *chan, int period)
 	}
 	vdelta = (vdelta * (int)chan->vibrato_depth) >> vdepth;
 
-	period = csf_fx_do_freq_slide(csf->flags, period, vdelta);
+	frequency = csf_fx_do_freq_slide(csf->flags, frequency, vdelta);
 
 	// handle on tick-N, or all ticks if not in old-effects mode
 	if (!(csf->flags & SONG_FIRSTTICK) || !(csf->flags & SONG_ITOLDEFFECTS)) {
 		chan->vibrato_position = (vibpos + 4 * chan->vibrato_speed) & 0xFF;
 	}
 
-	return period;
+	return frequency;
 }
 
-static inline int rn_sample_vibrato(song_t *csf, song_voice_t *chan, int period)
+static inline int rn_sample_vibrato(song_t *csf, song_voice_t *chan, int frequency)
 {
 	unsigned int vibpos = chan->autovib_position & 0xFF;
 	int vdelta, adepth;
@@ -218,17 +209,17 @@ static inline int rn_sample_vibrato(song_t *csf, song_voice_t *chan, int period)
 	if (vdelta < 0) {
 		linear_slide_table = linear_slide_up_table;
 		fine_linear_slide_table = fine_linear_slide_up_table;
-			vdelta += _muldiv(period, fine_linear_slide_up_table[l & 0x03], 0x10000) - period;
+			vdelta += _muldiv(frequency, fine_linear_slide_up_table[l & 0x03], 0x10000) - frequency;
 	} else {
 		linear_slide_table = linear_slide_down_table;
 		fine_linear_slide_table = fine_linear_slide_down_table;
 	}
 
-	vdelta = _muldiv(period, linear_slide_table[l >> 2], 0x10000) - period;
+	vdelta = _muldiv(frequency, linear_slide_table[l >> 2], 0x10000) - frequency;
 	if (l & 0x03)
-		vdelta += _muldiv(period, fine_linear_slide_table[l & 0x03], 0x10000) - period;
+		vdelta += _muldiv(frequency, fine_linear_slide_table[l & 0x03], 0x10000) - frequency;
 
-	return period - vdelta;
+	return frequency - vdelta;
 }
 
 
@@ -345,7 +336,7 @@ static inline void rn_process_envelope(song_voice_t *chan, int *nvol)
 }
 
 
-static inline int rn_arpeggio(song_t *csf, song_voice_t *chan, int period)
+static inline int rn_arpeggio(song_t *csf, song_voice_t *chan, int frequency)
 {
 	int a;
 
@@ -361,20 +352,20 @@ static inline int rn_arpeggio(song_t *csf, song_voice_t *chan, int period)
 	}
 
 	if (!a)
-		return period;
+		return frequency;
 
 	a = linear_slide_up_table[a * 16];
-	return _muldiv(period, a, 65536);
+	return _muldiv(frequency, a, 65536);
 }
 
 
 static inline void rn_pitch_filter_envelope(song_t *csf, song_voice_t *chan,
-	int *nenvpitch, int *nperiod)
+	int *nenvpitch, int *nfrequency)
 {
 	song_instrument_t *penv = chan->ptr_instrument;
 	int envpos = chan->pitch_env_position;
 	unsigned int pt = penv->pitch_env.nodes - 1;
-	int period = *nperiod;
+	int frequency = *nfrequency;
 	int envpitch = *nenvpitch;
 
 	for (unsigned int i = 0; i < (unsigned int)(penv->pitch_env.nodes - 1); i++) {
@@ -417,10 +408,10 @@ static inline void rn_pitch_filter_envelope(song_t *csf, song_voice_t *chan,
 			l = 255;
 
 		int ratio = (envpitch < 0 ? linear_slide_down_table : linear_slide_up_table)[l];
-		period = _muldiv(period, ratio, 0x10000);
+		frequency = _muldiv(frequency, ratio, 0x10000);
 	}
 
-	*nperiod = period;
+	*nfrequency = frequency;
 	*nenvpitch = envpitch;
 }
 
@@ -1096,7 +1087,7 @@ int csf_read_note(song_t *csf)
 	for (cn = 0, chan = csf->voices; cn < MAX_VOICES; cn++, chan++) {
 		/*if(cn == 0 || cn == 1)
 		fprintf(stderr, "considering channel %d (per %d, pos %d/%d, flags %X)\n",
-			(int)cn, chan->period, chan->position, chan->length, chan->flags);*/
+			(int)cn, chan->frequency, chan->position, chan->length, chan->flags);*/
 
 		if (chan->flags & CHN_NOTEFADE &&
 		    !(chan->fadeout_volume | chan->right_volume | chan->left_volume)) {
@@ -1118,7 +1109,7 @@ int csf_read_note(song_t *csf)
 		chan->ramp_length = 0;
 
 		// Calc Frequency
-		if (chan->period && (chan->length || (chan->flags & CHN_ADLIB))) {
+		if (chan->frequency && (chan->length || (chan->flags & CHN_ADLIB))) {
 			int vol = chan->volume;
 
 			if (chan->flags & CHN_TREMOLO)
@@ -1157,36 +1148,34 @@ int csf_read_note(song_t *csf)
 					 1 << 19);
 			}
 
-			int period = chan->period;
+			int frequency = chan->frequency;
 
 			if ((chan->flags & (CHN_GLISSANDO|CHN_PORTAMENTO)) == (CHN_GLISSANDO|CHN_PORTAMENTO)) {
-				period = get_period_from_note(get_note_from_period(period), chan->c5speed);
+				frequency = get_frequency_from_note(get_note_from_frequency(frequency, chan->c5speed), chan->c5speed);
 			}
 
 			// Arpeggio ?
 			if (chan->n_command == FX_ARPEGGIO)
-				period = rn_arpeggio(csf, chan, period);
+				frequency = rn_arpeggio(csf, chan, frequency);
 
 			// Pitch/Filter Envelope
 			int envpitch = 0;
 
 			if ((csf->flags & SONG_INSTRUMENTMODE) && chan->ptr_instrument
 				&& (chan->flags & CHN_PITCHENV) && chan->ptr_instrument->pitch_env.nodes)
-				rn_pitch_filter_envelope(csf, chan, &envpitch, &period);
+				rn_pitch_filter_envelope(csf, chan, &envpitch, &frequency);
 
 			// Vibrato
 			if (chan->flags & CHN_VIBRATO)
-				period = rn_vibrato(csf, chan, period);
+				frequency = rn_vibrato(csf, chan, frequency);
 
 			// Sample Auto-Vibrato
 			if (chan->ptr_sample && chan->ptr_sample->vib_depth) {
-				period = rn_sample_vibrato(csf, chan, period);
+				frequency = rn_sample_vibrato(csf, chan, frequency);
 			}
 
-			unsigned int freq = get_freq_from_period(period);
-
 			if (!(chan->flags & CHN_NOTEFADE))
-				rn_gen_key(csf, chan, cn, freq, vol);
+				rn_gen_key(csf, chan, cn, frequency, vol);
 
 			// Filter Envelope: controls cutoff frequency
 			if (chan && chan->ptr_instrument && chan->ptr_instrument->flags & ENV_FILTER) {
@@ -1194,9 +1183,9 @@ int csf_read_note(song_t *csf)
 					!(chan->flags & CHN_FILTER), envpitch, csf->mix_frequency);
 			}
 
-			chan->sample_freq = freq;
+			chan->sample_freq = frequency;
 
-			unsigned int ninc = _muldiv(freq, 0x10000, csf->mix_frequency);
+			unsigned int ninc = _muldiv(frequency, 0x10000, csf->mix_frequency);
 
 			if (ninc >= 0xFFB0 && ninc <= 0x10090)
 				ninc = 0x10000;


### PR DESCRIPTION
Fixes #252 ...and hopefully doesn't break anything! In fact this also fixes glissando mode, which was broken with linear slides since those were handled with frequency instead of periods. All in all, this brings pitch slides much closer to how IT handles them internally.