### PR TITLE
Set NSHighResolutionCapable to false in app bundle settings

### DIFF
--- a/sys/macosx/Schism_Tracker.app/Contents/Info.plist
+++ b/sys/macosx/Schism_Tracker.app/Contents/Info.plist
@@ -110,5 +110,7 @@
 	<string>NSApplication</string>
 	<key>CGDisableCoalescedUpdates</key>
 	<true/>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
This merge request mentions #268. Due to only affecting app bundles, it does not close
the issue: instead one of these two need to be implemented:
- Set wantsBestResolutionOpenGLSurface to NO. Requires Cocoa-side programming.
- Somehow figure out how to grab the aspect ratio and factor that in to the
  scaling already done by the program.