### PR TITLE
macOS: Legacy version support and OpenGL defaults

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,10 @@ jobs:
     
     steps:
       - name: 'Install dependencies'
-        run: brew install automake autoconf sdl git zip
+        run: |
+          brew install automake sdl zip
+          wget "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
+          sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
 
       - name: 'Checkout'
         uses: actions/checkout@v2
@@ -107,8 +110,6 @@ jobs:
 
       - name: 'Build package'
         run: |
-          wget "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
-          sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,8 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.9
     
     steps:
       - name: 'Install dependencies'
@@ -105,6 +107,8 @@ jobs:
 
       - name: 'Build package'
         run: |
+          curl -o sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
+          tar xf sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
     
     steps:
       - name: 'Install dependencies'
-        run: brew install automake autoconf sdl git zip
+        run: brew install automake autoconf sdl git zip xz
 
       - name: 'Checkout'
         uses: actions/checkout@v2
@@ -108,7 +108,7 @@ jobs:
       - name: 'Build package'
         run: |
           curl -o sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
-          tar xf sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
+          tar xJf sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           mkdir MacOS
           cd MacOS
           cp ../../../../../build/schismtracker .
-          cp /usr/local/lib/libSDL-* .
+          cp ../../../../../lib/libSDL-1.2.0.dylib .
           install_name_tool -change /usr/local/opt/sdl/lib/libSDL-1.2.0.dylib @executable_path/libSDL-1.2.0.dylib schismtracker
           cd ../../../../..
           cp -r sys/macosx/Schism_Tracker.app Schism\ Tracker.app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: 'Build package'
         run: |
-          wget -O "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
+          wget "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
           tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,9 @@ jobs:
 
       - name: 'Build package'
         run: |
-          curl -o sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
-          tar xJf sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
+          curl -o MacOSX10.9.sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
+          xz -d MacOSX10.9.sdk.tar.xz
+          tar xvf MacOSX10.9.sdk.tar -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,8 @@ jobs:
 
       - name: 'Build package'
         run: |
-          sudo wget "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
-          tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
+          wget "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
+          sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,9 +107,8 @@ jobs:
 
       - name: 'Build package'
         run: |
-          curl -o MacOSX10.9.sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
-          xz -d MacOSX10.9.sdk.tar.xz
-          tar xvf MacOSX10.9.sdk.tar -C /Library/Developer/CommandLineTools/SDKs/
+          curl -O MacOSX10.9.sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz
+          tar -xJf MacOSX10.9.sdk.tar -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
     
     steps:
       - name: 'Install dependencies'
-        run: brew install automake autoconf sdl git zip xz
+        run: brew install automake autoconf sdl git zip
 
       - name: 'Checkout'
         uses: actions/checkout@v2
@@ -107,8 +107,8 @@ jobs:
 
       - name: 'Build package'
         run: |
-          curl -O MacOSX10.9.sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
-          tar -xJf MacOSX10.9.sdk.tar -C /Library/Developer/CommandLineTools/SDKs/
+          wget -O "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
+          tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           mkdir -p build
           cd build
           ../configure
-          make
+          make CFLAGS="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk"
           cd ../sys/macosx/Schism_Tracker.app/Contents/
           sed -i .bak "s;<string>CFBundle.*Version.*</string>;<string>$(date +%Y%m%d)</string>;" Info.plist
           rm Info.plist.bak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: 'Build package'
         run: |
-          curl -O MacOSX10.9.sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz
+          curl -O MacOSX10.9.sdk.tar.xz "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
           tar -xJf MacOSX10.9.sdk.tar -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,14 +103,16 @@ jobs:
         uses: actions/cache@v2
         id: cache
         with:
-          path: MacOSX10.9.sdk.tar.xz
-          key: 10.9-SDK
+          path: '/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/'
+          key: 10.9-SDK-Folder
 
       - name: 'Install dependencies'
         run: |
           brew install automake sdl zip
-          wget "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
-          sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
+          if [ ! -f "/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/" ]; then
+            wget -nc "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
+            sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
+          fi
 
       - name: 'Checkout'
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           mkdir MacOS
           cd MacOS
           cp ../../../../../build/schismtracker .
-          cp ../../../../../lib/libSDL-1.2.0.dylib .
+          cp ../../../../../libs/libSDL-1.2.0.dylib .
           install_name_tool -change /usr/local/opt/sdl/lib/libSDL-1.2.0.dylib @executable_path/libSDL-1.2.0.dylib schismtracker
           cd ../../../../..
           cp -r sys/macosx/Schism_Tracker.app Schism\ Tracker.app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: 'Build package'
         run: |
-          wget "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
+          sudo wget "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
           tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
           autoreconf -i
           mkdir -p build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,17 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.9
     
     steps:
+      - name: 'Get current date'
+        id: date
+        run: echo "::set-output name=date::$(date +%Y%m%d)"
+
+      - name: 'Cache SDK'
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: MacOSX10.9.sdk.tar.xz
+          key: 10.9-SDK
+
       - name: 'Install dependencies'
         run: |
           brew install automake sdl zip
@@ -103,10 +114,6 @@ jobs:
 
       - name: 'Checkout'
         uses: actions/checkout@v2
-
-      - name: 'Get current date'
-        id: date
-        run: echo "::set-output name=date::$(date +%Y%m%d)"
 
       - name: 'Build package'
         run: |

--- a/Makefile.am
+++ b/Makefile.am
@@ -220,6 +220,7 @@ files_macosx = \
 	sys/macosx/midi-macosx.c	\
 	sys/macosx/volume-macosx.c	\
 	sys/macosx/osdefs.c
+cflags_macosx=-mmacosx-version-min=10.9
 endif
 
 if USE_NETWORK
@@ -367,7 +368,8 @@ cflags_fmopl=-DHAS_YM3812=1 -DHAS_Y8950=0 -DHAS_YM3526=0
 AM_CPPFLAGS = -D_USE_AUTOCONF -D_GNU_SOURCE -I$(srcdir)/include -I.
 AM_CFLAGS = $(SDL_CFLAGS) $(cflags_alsa) $(cflags_oss) \
 	$(cflags_network) $(cflags_x11) $(cflags_fmopl) \
-	$(cflags_version) $(cflags_win32) $(cflags_wii)
+	$(cflags_version) $(cflags_win32) $(cflags_wii) \
+	$(cflags_macosx)
 AM_OBJCFLAGS = $(AM_CFLAGS)
 
 schismtracker_DEPENDENCIES = $(files_windres)

--- a/schism/video.c
+++ b/schism/video.c
@@ -505,6 +505,10 @@ void video_setup(const char *driver)
 	if (!driver) {
 		driver = "yuv";
 	}
+#elif defined(__APPLE__)
+	if (!driver) {
+		driver = "opengl";
+	}
 #else
 	if (!driver) {
 		if (getenv("DISPLAY")) {


### PR DESCRIPTION
This PR provides fixes for issues #242 and #279.

Outline of changes:
* OpenGL drivers are now the default on macOS
* GitHub Actions builds *should* now support versions of macOS going back to 10.9 Mavericks (tested on 10.12 Sierra, can't install anything older at the moment)