### PR TITLE
GitHub Actions: strip binaries, fix for macOS SDK caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,12 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +%Y%m%d)"
 
+      - name: 'chown SDK directory'
+        id: chown
+        run: |
+          sudo mkdir -p /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk
+          sudo chown $(whoami) /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk
+
       - name: 'Cache SDK'
         uses: actions/cache@v2
         id: cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
           cd build
           ../configure
           make CFLAGS="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk"
-          strip schismtracker
+          strip -S schismtracker
           cd ../sys/macosx/Schism_Tracker.app/Contents/
           sed -i .bak "s;<string>CFBundle.*Version.*</string>;<string>$(date +%Y%m%d)</string>;" Info.plist
           rm Info.plist.bak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
           cd build
           ../configure
           make CFLAGS="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk"
+          strip -g schismtracker
           cd ../sys/macosx/Schism_Tracker.app/Contents/
           sed -i .bak "s;<string>CFBundle.*Version.*</string>;<string>$(date +%Y%m%d)</string>;" Info.plist
           rm Info.plist.bak
@@ -166,6 +167,7 @@ jobs:
           cd build
           ../configure
           make
+          strip -g schismtracker
           cd ..
           cp build/schismtracker .
           cp docs/configuration.md .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
           cd build
           ../configure
           make CFLAGS="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk"
-          strip -g schismtracker
+          strip schismtracker
           cd ../sys/macosx/Schism_Tracker.app/Contents/
           sed -i .bak "s;<string>CFBundle.*Version.*</string>;<string>$(date +%Y%m%d)</string>;" Info.plist
           rm Info.plist.bak
@@ -173,7 +173,7 @@ jobs:
           cd build
           ../configure
           make
-          strip -g schismtracker
+          strip -S schismtracker
           cd ..
           cp build/schismtracker .
           cp docs/configuration.md .


### PR DESCRIPTION
Debug symbols took up ~71% of the binaries on Linux.
macOS caching was successfully uploading, but failing to download because we didn't have write access to the SDK directory. So, let's just `chown` the directory.