### PR TITLE
Build our own SDL dylib off of master with Actions: possible solution to #231

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
       - name: 'Build SDL 1.2'
         run: |
           cd sdl
-          curl -o build-scripts/clang-fat.sh https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh
+          curl -O build-scripts/clang-fat.sh https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh
           sed 's/10.6/10.9/g' build-scripts/clang-fat.sh
           sed 's/1060/1090/g' build-scripts/clang-fat.sh
           ./configure CC="sh clang-fat.sh"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,8 @@ jobs:
         run: |
           cd sdl
           wget -O 'build-scripts/clang-fat.sh' 'https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh'
-          sed 's/10.6/10.9/g' build-scripts/clang-fat.sh
-          sed 's/1060/1090/g' build-scripts/clang-fat.sh
+          sed -e 's/10.6/10.9/g' build-scripts/clang-fat.sh
+          sed -e 's/1060/1090/g' build-scripts/clang-fat.sh
           ./configure CC="sh build-scripts/clang-fat.sh"
           make
           sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           mkdir -p build
           cd build
           ../configure
-          make CFLAGS="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk"
+          make CFLAGS="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
           strip -S schismtracker
           cd ../sys/macosx/Schism_Tracker.app/Contents/
           sed -i .bak "s;<string>CFBundle.*Version.*</string>;<string>$(date +%Y%m%d)</string>;" Info.plist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
           wget -O 'build-scripts/clang-fat.sh' 'https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh'
           sed 's/10.6/10.9/g' build-scripts/clang-fat.sh
           sed 's/1060/1090/g' build-scripts/clang-fat.sh
-          ./configure CC="sh clang-fat.sh"
+          ./configure CC="sh build-scripts/clang-fat.sh"
           make
           sudo make install
           rm -rf arm64 x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,8 @@ jobs:
 
       - name: 'Build SDL 1.2'
         run: |
-          if [ -f /usr/local/lib/libSDL-1.2.0.dylib ]:
+          if [ -f /usr/local/lib/libSDL-1.2.0.dylib ]
+          then
             exit 0
           fi
           cd sdl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
           key: SDL-1.2-dylib
 
       - name: 'Checkout SDL 1.2'
-        if: success()
+        if: failure()
         uses: actions/checkout@v3
         with:
           repository: libsdl-org/SDL-1.2
@@ -139,7 +139,9 @@ jobs:
 
       - name: 'Build SDL 1.2'
         run: |
-          test -f /usr/local/lib/libSDL-1.2.0.dylib || exit # if file exists, exit
+          if [ -f /usr/local/lib/libSDL-1.2.0.dylib ]:
+            exit 0
+          fi
           cd sdl
           wget -O 'build-scripts/clang-fat.sh' 'https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh'
           sed -i.bak 's/10.6/10.9/g' build-scripts/clang-fat.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
       - name: 'Build SDL 1.2'
         run: |
           cd sdl
-          curl -O build-scripts/clang-fat.sh https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh
+          wget -O 'build-scripts/clang-fat.sh' 'https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh'
           sed 's/10.6/10.9/g' build-scripts/clang-fat.sh
           sed 's/1060/1090/g' build-scripts/clang-fat.sh
           ./configure CC="sh clang-fat.sh"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,8 @@ jobs:
         run: |
           cd sdl
           wget -O 'build-scripts/clang-fat.sh' 'https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh'
-          sed -e 's/10.6/10.9/g' build-scripts/clang-fat.sh
-          sed -e 's/1060/1090/g' build-scripts/clang-fat.sh
+          sed -i.bak 's/10.6/10.9/g' build-scripts/clang-fat.sh
+          sed -i.bak 's/1060/1090/g' build-scripts/clang-fat.sh
           ./configure CC="sh build-scripts/clang-fat.sh"
           make
           sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
       - name: 'Install dependencies'
         run: |
           brew install automake zip
+          brew cask install xquartz
           if [ ! -f "/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/" ]; then
             wget -nc "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
             sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,8 @@ jobs:
         run: |
           cd sdl
           curl -o build-scripts/clang-fat.sh https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh
-          sed -i 's/10.6/10.9/g' build-scripts/clang-fat.sh
-          sed -i 's/1060/1090/g' build-scripts/clang-fat.sh
+          sed 's/10.6/10.9/g' build-scripts/clang-fat.sh
+          sed 's/1060/1090/g' build-scripts/clang-fat.sh
           ./configure CC="sh clang-fat.sh"
           make
           sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,6 @@ jobs:
       - name: 'Install dependencies'
         run: |
           brew install automake zip
-          brew install xquartz --cask
           if [ ! -f "/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/" ]; then
             wget -nc "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
             sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           sudo chown $(whoami) /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk /usr/local/lib
 
       - name: 'Cache SDK'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: '/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/'
@@ -123,15 +123,7 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v3
 
-      - name: 'Cache SDL 1.2 dylib'
-        uses: actions/cache@v2
-        id: cacheSDL
-        with:
-          path: '/usr/local/lib/libSDL-1.2.0.dylib'
-          key: SDL-1.2-dylib
-
       - name: 'Checkout SDL 1.2'
-        if: failure()
         uses: actions/checkout@v3
         with:
           repository: libsdl-org/SDL-1.2
@@ -139,10 +131,6 @@ jobs:
 
       - name: 'Build SDL 1.2'
         run: |
-          if [ -f /usr/local/lib/libSDL-1.2.0.dylib ]
-          then
-            exit 0
-          fi
           cd sdl
           wget -O 'build-scripts/clang-fat.sh' 'https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh'
           sed -i.bak 's/10.6/10.9/g' build-scripts/clang-fat.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: 'Install dependencies'
         run: |
-          brew install automake sdl zip
+          brew install automake zip
           if [ ! -f "/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/" ]; then
             wget -nc "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
             sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,8 @@ jobs:
         run: |
           cd sdl
           curl -o build-scripts/clang-fat.sh https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh
+          sed -i 's/10.6/10.9/g' build-scripts/clang-fat.sh
+          sed -i 's/1060/1090/g' build-scripts/clang-fat.sh
           ./configure CC="sh clang-fat.sh"
           make
           sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       - name: 'Install dependencies'
         run: |
           brew install automake zip
-          if [ ! -f "/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/" ]; then
+          if [ ! -d "/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/" ]; then
             wget -nc "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
             sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,23 @@ jobs:
           fi
 
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: 'Checkout SDL 1.2'
+        uses: actions/checkout@v3
+        with:
+          repository: libsdl-org/SDL-1.2
+          path: sdl
+      
+      - name: 'Build SDL 1.2'
+        run: |
+          cd sdl
+          curl -o build-scripts/clang-fat.sh https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh
+          ./configure CC="sh clang-fat.sh"
+          make
+          sudo make install
+          rm -rf arm64 x64
+          cd ..
 
       - name: 'Build package'
         run: |
@@ -137,8 +153,8 @@ jobs:
           mkdir MacOS
           cd MacOS
           cp ../../../../../build/schismtracker .
-          cp ../../../../../libs/libSDL-1.2.0.dylib .
-          install_name_tool -change /usr/local/opt/sdl/lib/libSDL-1.2.0.dylib @executable_path/libSDL-1.2.0.dylib schismtracker
+          cp /usr/local/lib/libSDL-1.2.0.dylib .
+          install_name_tool -change /usr/local/lib/libSDL-1.2.0.dylib @executable_path/libSDL-1.2.0.dylib schismtracker
           cd ../../../../..
           cp -r sys/macosx/Schism_Tracker.app Schism\ Tracker.app
           cp docs/configuration.md .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         id: chown
         run: |
           sudo mkdir -p /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk
-          sudo chown $(whoami) /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk
+          sudo chown $(whoami) /Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk /usr/local/lib
 
       - name: 'Cache SDK'
         uses: actions/cache@v2
@@ -141,6 +141,13 @@ jobs:
           sudo make install
           rm -rf arm64 x64
           cd ..
+
+      - name: 'Cache SDL 1.2 dylib'
+        uses: actions/cache@v2
+        id: cacheSDL
+        with:
+          path: '/usr/local/lib/libSDL-1.2.0.dylib'
+          key: SDL-1.2-dylib
 
       - name: 'Build package'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,14 +123,23 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v3
 
+      - name: 'Cache SDL 1.2 dylib'
+        uses: actions/cache@v2
+        id: cacheSDL
+        with:
+          path: '/usr/local/lib/libSDL-1.2.0.dylib'
+          key: SDL-1.2-dylib
+
       - name: 'Checkout SDL 1.2'
+        if: success()
         uses: actions/checkout@v3
         with:
           repository: libsdl-org/SDL-1.2
           path: sdl
-      
+
       - name: 'Build SDL 1.2'
         run: |
+          test -f /usr/local/lib/libSDL-1.2.0.dylib || exit # if file exists, exit
           cd sdl
           wget -O 'build-scripts/clang-fat.sh' 'https://raw.githubusercontent.com/libsdl-org/SDL/main/build-scripts/clang-fat.sh'
           sed -i.bak 's/10.6/10.9/g' build-scripts/clang-fat.sh
@@ -140,13 +149,6 @@ jobs:
           sudo make install
           rm -rf arm64 x64
           cd ..
-
-      - name: 'Cache SDL 1.2 dylib'
-        uses: actions/cache@v2
-        id: cacheSDL
-        with:
-          path: '/usr/local/lib/libSDL-1.2.0.dylib'
-          key: SDL-1.2-dylib
 
       - name: 'Build package'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       - name: 'Install dependencies'
         run: |
           brew install automake zip
-          brew cask install xquartz
+          brew install xquartz --cask
           if [ ! -f "/Library/Developer/CommandLineTools/SDKs/MacOSX10.9.sdk/" ]; then
             wget -nc "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz"
             sudo tar -xJf MacOSX10.9.sdk.tar.xz -C /Library/Developer/CommandLineTools/SDKs/


### PR DESCRIPTION
We're using an SDL 1.2 version from 2012, while bugfixes have been coming on master [regularly](http://htmlpreview.github.io/?https://raw.githubusercontent.com/libsdl-org/SDL-1.2/main/docs.html) for the 10 years it's been out of support.

It seems they're even planning a new release of SDL 1.2, which would be good to hear.

(This also solves the video driver problem with OS X too afaik)

You can also build SDL for other platforms as well if you'd like.