### PR TITLE
video: Fix OOB memory access on 24-bit displays

### DIFF
--- a/schism/video.c
+++ b/schism/video.c
@@ -1510,7 +1510,15 @@ static void _blit1n(int bpp, unsigned char *pixels, unsigned int pitch)
 				break;
 			case 3:
 				/* inline MapRGB */
-				(*(unsigned int *)pixels) = (outr << 16) | (outg << 8) | outb;
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+				pixels[0] = outr;
+				pixels[1] = outg;
+				pixels[2] = outb;
+#else
+				pixels[2] = outr;
+				pixels[1] = outg;
+				pixels[0] = outb;
+#endif
 				break;
 			case 2:
 				/* inline MapRGB if possible */


### PR DESCRIPTION
SchismTracker will write 32-bits at a time to a 24-bit display when scaling, which means it can overflow the end of the surface its writing into. This usually isn't a problem: many implementations will be tolerant of writing an extra byte or two past the end of the surface, but sdl12-compat, for instance, isn't. See:
https://github.com/libsdl-org/sdl12-compat/issues/183

I don't know if this (or something similar) is also the cause of the OpenGL issues in #71, but OpenGL drivers on Linux these days tend to be pretty sensitive to this sort of thing.