### PR TITLE
Actions: install Git on Windows enviroments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         msystem: ${{ matrix.sys }}
         update: true
-        install: mingw-w64-${{ matrix.env }}-toolchain libtool autoconf automake make mingw-w64-${{ matrix.env }}-SDL2 zip dos2unix
+        install: git mingw-w64-${{ matrix.env }}-toolchain libtool autoconf automake make mingw-w64-${{ matrix.env }}-SDL2 zip dos2unix
   
     - name: 'Get current date'
       id: date


### PR DESCRIPTION
Before this, Schism Tracker was building with an ugly "Schism Tracker built...", instead of a "Schism Tracker 20220807".