### PR TITLE
Add working aspect ratio correction option (want_fixed)

### DIFF
--- a/include/it.h
+++ b/include/it.h
@@ -246,6 +246,7 @@ extern int show_default_volumes;        /* pattern-view.c */
 extern char cfg_video_interpolation[];
 /* TODO: consolidate these into cfg_video_flags */
 extern int cfg_video_fullscreen;
+extern int cfg_video_want_fixed;
 extern int cfg_video_mousecursor;
 extern int cfg_video_width, cfg_video_height;
 

--- a/schism/config.c
+++ b/schism/config.c
@@ -40,6 +40,7 @@ char cfg_dir_modules[PATH_MAX + 1], cfg_dir_samples[PATH_MAX + 1], cfg_dir_instr
 	cfg_dir_dotschism[PATH_MAX + 1], cfg_font[NAME_MAX + 1];
 char cfg_video_interpolation[8];
 int cfg_video_fullscreen = 0;
+int cfg_video_want_fixed = 0;
 int cfg_video_mousecursor = MOUSE_EMULATED;
 int cfg_video_width, cfg_video_height;
 
@@ -136,6 +137,7 @@ void cfg_load(void)
 	cfg_video_width = cfg_get_number(&cfg, "Video", "width", 640);
 	cfg_video_height = cfg_get_number(&cfg, "Video", "height", 400);
 	cfg_video_fullscreen = !!cfg_get_number(&cfg, "Video", "fullscreen", 0);
+	cfg_video_want_fixed = cfg_get_number(&cfg, "Video", "want_fixed", 0);
 	cfg_video_mousecursor = cfg_get_number(&cfg, "Video", "mouse_cursor", MOUSE_EMULATED);
 	cfg_video_mousecursor = CLAMP(cfg_video_mousecursor, 0, MOUSE_MAX_STATE);
 	ptr = cfg_get_string(&cfg, "Video", "aspect", NULL, 0, NULL);

--- a/schism/video.c
+++ b/schism/video.c
@@ -276,7 +276,13 @@ void video_startup(void)
 
 void video_resize(unsigned int width, unsigned int height)
 {
-	SDL_RenderSetLogicalSize(video.renderer, width, height);
+	/* Aspect ratio correction if it's wanted */
+	if (cfg_video_want_fixed)
+		SDL_RenderSetLogicalSize(video.renderer,
+					 NATIVE_SCREEN_WIDTH * 5, NATIVE_SCREEN_HEIGHT * 6); // 4:3
+	else 
+		SDL_RenderSetLogicalSize(video.renderer, width, height);
+
 	video.prev.width = video.width;
 	video.prev.height = video.height;
 	video.width = width;


### PR DESCRIPTION
This fixes issue: https://github.com/schismtracker/schismtracker/issues/311

I have used the name `want_fixed` for the option to match the docs, which mention it here:
https://github.com/schismtracker/schismtracker/blob/master/docs/configuration.md
but it wasn't implemented before.