### PR TITLE
Fix segfault when SDL2 runs on Wayland or KMS/DRM.

### DIFF
--- a/include/it.h
+++ b/include/it.h
@@ -455,6 +455,9 @@ void memused_songchanged(void);
 
 void memused_get_pattern_saved(unsigned int *a, unsigned int *b); /* wtf */
 
+/* Shutdown the SDL2 system from anywhere without having to use atexit() */
+void schism_exit(int status);
+
 /* --------------------------------------------------------------------- */
 
 #endif /* ! IT_H */

--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -1411,7 +1411,7 @@ static void _audio_init_head(const char *driver_spec, int verbose)
 			fprintf(stderr, "%s: %s\n", driver_spec, err);
 		fprintf(stderr, "%s\n", err_default);
 		fprintf(stderr, "Couldn't initialise audio!\n");
-		exit(1);
+		schism_exit(1);
 	}
 }
 

--- a/schism/page.c
+++ b/schism/page.c
@@ -549,7 +549,7 @@ static int handle_key_global(struct key_event * k)
 			_mp_finish(NULL);
 			if (k->state == KEY_PRESS) {
 				if (k->mod & KMOD_SHIFT)
-					exit(0);
+					schism_exit(0);
 				show_exit_prompt();
 			}
 			return 1;
@@ -1716,7 +1716,7 @@ static void savecheck(void (*ok)(void *data), void (*cancel)(void *data), void *
 
 static void exit_ok_confirm(UNUSED void *data)
 {
-	exit(0);
+	schism_exit(0);
 }
 
 static void exit_ok(UNUSED void *data)
@@ -1747,7 +1747,7 @@ void show_exit_prompt(void)
 
 	if (status.current_page == PAGE_ABOUT) {
 		/* haven't even started up yet; don't bother confirming */
-		exit(0);
+		schism_exit(0);
 	} else if (status.current_page == PAGE_FONT_EDIT) {
 		if (status.flags & STARTUP_FONTEDIT) {
 			dialog_create(DIALOG_OK_CANCEL, "Exit Font Editor?",


### PR DESCRIPTION
There's a long-standing bug on MESA that causes a **segfault** if `SDL_Quit()` is called inside an `atexit()` handler, see:

https://github.com/libsdl-org/SDL/issues/3184
(There you can see the many SDL2 projects that are affected by this, and the information on the MESA mailing list where it was discussed).

It was ultimately left from SDL2 to MESA, where the MESA devs concluded that **freeing the GBM stuff in an atexit() handler is generally a bad idea.**
NOTE: _GBM is used by MESA and KMS/DRM on GNU/Linux for video buffer management. Calling SDL_Quit() implies freeing the GBM stuff._

This fixes several **segfaults** on `exit()` calls in Schismtracker if using SDL2 on Wayland (modern GNU/Linux graphics protocol) or KMS/DRM (dos-like SDL2 backend without X11 or Wayland).

This will have to be faced sooner or later, now that GNU/Linux distros are adopting Wayland and X11 is going away for good.