### PR TITLE
drop MIDI note-offs that don't match last note

### DIFF
--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -105,6 +105,7 @@ int midi_playback_tracing = 0;
 static int panning_mode = 0;            /* for the volume column */
 int midi_bend_hit[64];
 int midi_last_bend_hit[64];
+int midi_last_note[64];
 
 /* blah; other forwards */
 static void pated_save(const char *descr);
@@ -2983,6 +2984,11 @@ static int pattern_editor_insert_midi(struct key_event *k)
 	if (k->midi_note == -1) {
 		/* nada */
 	} else if (k->state == KEY_RELEASE) {
+		/* don't record noteoffs of non-matching notes */
+		if (k->midi_note != midi_last_note[c]) {
+			return 0;
+		}
+
 		c = song_keyup(KEYJAZZ_NOINST, KEYJAZZ_NOINST, k->midi_note);
 
 		/* don't record noteoffs for no good reason... */
@@ -3006,7 +3012,7 @@ static int pattern_editor_insert_midi(struct key_event *k)
 		if (!((song_get_mode() & (MODE_PLAYING | MODE_PATTERN_LOOP)) && playback_tracing)) {
 			tick = 0;
 		}
-		n = k->midi_note;
+		midi_last_note[c] = n = k->midi_note;
 		c = song_keydown(KEYJAZZ_NOINST, KEYJAZZ_NOINST, n, v, current_channel);
 		cur_note = pattern + 64 * current_row + (c-1);
 		patedit_record_note(cur_note, c, current_row, n, 0);


### PR DESCRIPTION
imagine MIDI messages coming in this order into the midi insert routine:

<img width="217" alt="image" src="https://user-images.githubusercontent.com/32539816/212485756-7c5c383d-71ba-4d52-92e5-dd97d79709c6.png">

this happens frequently due to how I play the piano, when I press other keys before I release previous ones. Unfortunately, in schism, the C3 note-off is read as the C3# note-off, as they are both written to the same channel.

now, note-offs are recorded only if their note matches the last-note played. if there's no match, the note-off is dropped.