### PR TITLE
rocket: implement GNU Rocket integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gnurocket"]
+	path = rocket
+	url = https://github.com/rocket/rocket

--- a/Makefile.am
+++ b/Makefile.am
@@ -228,7 +228,12 @@ libs_flac=-lFLAC
 endif
 
 if USE_ROCKET
+# TODO: it's fragile to be intimately grabbing rocket/lib/*.[ch] stuff here,
+# and if we continue doing that we need to DTRT regarding os-specific defines
+# like USE_NODELAY
 files_rocket = \
+	include/rocket.h		\
+	schism/rocket.c			\
 	rocket/lib/base.h		\
 	rocket/lib/device.c		\
 	rocket/lib/device.h		\

--- a/Makefile.am
+++ b/Makefile.am
@@ -227,6 +227,17 @@ cflags_flac=-DUSE_FLAC
 libs_flac=-lFLAC
 endif
 
+if USE_ROCKET
+files_rocket = \
+	rocket/lib/base.h		\
+	rocket/lib/device.c		\
+	rocket/lib/device.h		\
+	rocket/lib/sync.h		\
+	rocket/lib/track.c		\
+	rocket/lib/track.h
+cflags_rocket=-DUSE_ROCKET
+endif
+
 if USE_NETWORK
 cflags_network=-DUSE_NETWORK
 endif
@@ -362,7 +373,8 @@ schismtracker_SOURCES = \
 	$(files_mmap)			\
 	$(files_wii)			\
 	$(files_windres)		\
-	$(files_flac)
+	$(files_flac)			\
+	$(files_rocket)
 
 # have version.o rely on all files
 schism/version.$(OBJEXT): $(filter-out schism/version.$(OBJEXT),$(schismtracker_OBJECTS)) $(HEADERS)
@@ -373,7 +385,7 @@ AM_CPPFLAGS = -D_USE_AUTOCONF -D_GNU_SOURCE -I$(srcdir)/include -I.
 AM_CFLAGS = $(SDL_CFLAGS) $(cflags_alsa) $(cflags_oss) \
 	$(cflags_network) $(cflags_x11) $(cflags_fmopl) \
 	$(cflags_version) $(cflags_win32) $(cflags_wii) \
-	$(cflags_macosx) $(cflags_flac)
+	$(cflags_macosx) $(cflags_flac) $(cflags_rocket)
 AM_OBJCFLAGS = $(AM_CFLAGS)
 
 schismtracker_DEPENDENCIES = $(files_windres)

--- a/configure.ac
+++ b/configure.ac
@@ -306,6 +306,11 @@ AC_ARG_WITH([flac],
 		[],
 		[with_flac=yes])
 
+AC_ARG_WITH([rocket],
+		[AS_HELP_STRING([--with-rocket],[Build with GNU Rocket support @<:@default=no@:>@])],
+		[with_rocket=yes],
+		[])
+
 dnl fortify needs -O; do this early so ADD_OPT can override with higher -O level
 if test x$ADD_FORTIFY \!= xno; then
         CFLAGS="$CFLAGS -O -D_FORTIFY_SOURCE=2"
@@ -332,6 +337,11 @@ if test "x$with_flac" = "xyes"; then
 		if test x"$libflac_found" = "xyes"; then
 				AM_CONDITIONAL([USE_FLAC], true)
 		fi
+fi
+
+AM_CONDITIONAL([USE_ROCKET], false)
+if test "x$with_rocket" = "xyes"; then
+	AM_CONDITIONAL([USE_ROCKET], true)
 fi
 
 dnl ... but put the warnings first, to make it possible to quiet certain

--- a/include/rocket.h
+++ b/include/rocket.h
@@ -1,0 +1,7 @@
+#ifndef _SCHISM_ROCKET_H
+#define _SCHISM_ROCKET_H
+
+int schism_rocket_connect(const char *host, const char *port, const char *bpm, const char *rpb);
+void schism_rocket_update(void);
+
+#endif

--- a/include/sndfile.h
+++ b/include/sndfile.h
@@ -602,7 +602,7 @@ typedef struct song {
 	// chaseback
 	int stop_at_order;
 	int stop_at_row;
-	unsigned int stop_at_time;
+	unsigned int stop_at_time_ms;
 
 	// multi-write stuff -- NULL if no multi-write is in progress, else array of one struct per channel
 	struct multi_write *multi_write;
@@ -663,7 +663,8 @@ int csf_process_tick(song_t *csf);
 int csf_read_note(song_t *csf);
 
 // snd_fx
-unsigned int csf_get_length(song_t *csf); // (in seconds)
+unsigned int csf_get_length_ms(song_t *csf);
+unsigned int csf_get_length_secs(song_t *csf);
 void csf_instrument_change(song_t *csf, song_voice_t *chn, uint32_t instr, int porta, int instr_column);
 void csf_note_change(song_t *csf, uint32_t chan, int note, int porta, int retrig, int have_inst);
 uint32_t csf_get_nna_channel(song_t *csf, uint32_t chan);

--- a/include/song.h
+++ b/include/song.h
@@ -254,6 +254,7 @@ const char *song_audio_driver(void);
 void song_toggle_multichannel_mode(void);
 int song_is_multichannel_mode(void);
 void song_change_current_play_channel(int relative, int wraparound);
+void main_song_mode_changed_cb(void);
 int song_get_current_play_channel(void);
 
 /* These return the channel that was used for the note.

--- a/include/song.h
+++ b/include/song.h
@@ -141,9 +141,9 @@ const char *song_get_tracker_id(void);
 char *song_get_title(void);     // editable
 char *song_get_message(void);   // editable
 
-// returned value = seconds
-unsigned int song_get_length_to(int order, int row);
-void song_get_at_time(unsigned int seconds, int *order, int *row);
+// returned value = milliseconds
+unsigned int song_get_length_to_ms(int order, int row);
+void song_get_at_time(unsigned int ms, int *order, int *row);
 
 // gee. can't just use malloc/free... no, that would be too simple.
 signed char *song_sample_allocate(int bytes);

--- a/player/effects.c
+++ b/player/effects.c
@@ -996,7 +996,7 @@ void csf_process_midi_macro(song_t *csf, uint32_t nchan, const char * macro, uin
 # error csf_get_length assumes 64 channels
 #endif
 
-unsigned int csf_get_length(song_t *csf)
+unsigned int csf_get_length_ms(song_t *csf)
 {
 	uint32_t elapsed = 0, row = 0, next_row = 0, cur_order = 0, next_order = 0, pat = csf->orderlist[0],
 		speed = csf->initial_speed, tempo = csf->initial_tempo, psize, n;
@@ -1047,9 +1047,9 @@ unsigned int csf_get_length(song_t *csf)
 		if (csf->stop_at_order > -1 && csf->stop_at_row > -1) {
 			if (csf->stop_at_order <= (signed) cur_order && csf->stop_at_row <= (signed) row)
 				break;
-			if (csf->stop_at_time > 0) {
+			if (csf->stop_at_time_ms > 0) {
 				/* stupid api decision */
-				if (((elapsed + 500) / 1000) >= csf->stop_at_time) {
+				if (elapsed >= csf->stop_at_time_ms) {
 					csf->stop_at_order = cur_order;
 					csf->stop_at_row = row;
 					break;
@@ -1130,9 +1130,13 @@ unsigned int csf_get_length(song_t *csf)
 		elapsed += (speed + speed_count) * 2500 / tempo;
 	}
 
-	return (elapsed + 500) / 1000;
+	return elapsed;
 }
 
+unsigned int csf_get_length_secs(song_t *csf)
+{
+	return (csf_get_length_ms(csf) + 500) / 1000;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // Effects

--- a/schism/disko.c
+++ b/schism/disko.c
@@ -736,7 +736,7 @@ int disko_export_song(const char *filename, const struct save_format *format)
 	export_format = format;
 	status.flags |= DISKWRITER_ACTIVE; /* tell main to care about us */
 
-	disko_dialog_setup((csf_get_length(&export_dwsong) * export_dwsong.mix_frequency) ?: 1);
+	disko_dialog_setup((csf_get_length_secs(&export_dwsong) * export_dwsong.mix_frequency) ?: 1);
 
 	return DW_OK;
 }

--- a/schism/mplink.c
+++ b/schism/mplink.c
@@ -40,33 +40,34 @@ song_t *current_song = NULL;
 // ------------------------------------------------------------------------
 // song information
 
-unsigned int song_get_length_to(int order, int row)
+unsigned int song_get_length_to_ms(int order, int row)
 {
 	unsigned int t;
 
 	song_lock_audio();
 	current_song->stop_at_order = order;
 	current_song->stop_at_row = row;
-	t = csf_get_length(current_song);
+	t = csf_get_length_ms(current_song);
 	current_song->stop_at_order = current_song->stop_at_row = -1;
 	song_unlock_audio();
 	return t;
 }
-void song_get_at_time(unsigned int seconds, int *order, int *row)
+
+void song_get_at_time(unsigned int ms, int *order, int *row)
 {
-	if (!seconds) {
+	if (!ms) {
 		if (order) *order = 0;
 		if (row) *row = 0;
 	} else {
 		song_lock_audio();
 		current_song->stop_at_order = MAX_ORDERS;
 		current_song->stop_at_row = 255; /* unpossible */
-		current_song->stop_at_time = seconds;
-		csf_get_length(current_song);
+		current_song->stop_at_time_ms = ms;
+		(void) csf_get_length_ms(current_song);
 		if (order) *order = current_song->stop_at_order;
 		if (row) *row = current_song->stop_at_row;
 		current_song->stop_at_order = current_song->stop_at_row = -1;
-		current_song->stop_at_time = 0;
+		current_song->stop_at_time_ms = 0;
 		song_unlock_audio();
 	}
 }

--- a/schism/page.c
+++ b/schism/page.c
@@ -123,7 +123,7 @@ static int check_time(void)
 			if (last_o == order && last_r == row) {
 				timep = last_timep;
 			} else {
-				last_timep = timep = song_get_length_to(order, row);
+				last_timep = timep = (song_get_length_to_ms(order, row) + 500) / 1000;
 				last_o = order;
 				last_r = row;
 			}
@@ -1802,7 +1802,7 @@ static void _timejump_ok(UNUSED void *ign)
 	int no, np, nr;
 	sec = (_timejump_widgets[0].d.numentry.value * 60)
 		+ _timejump_widgets[1].d.numentry.value;
-	song_get_at_time(sec, &no, &nr);
+	song_get_at_time(sec * 1000, &no, &nr);
 	set_current_order(no);
 	np = current_song->orderlist[no];
 	if (np < 200) {
@@ -1841,7 +1841,7 @@ void show_length_dialog(const char *label, unsigned int length)
 
 void show_song_length(void)
 {
-	show_length_dialog("Total song time", csf_get_length(current_song));
+	show_length_dialog("Total song time", csf_get_length_secs(current_song));
 }
 
 /* FIXME this is an illogical place to put this but whatever, i just want

--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -674,7 +674,7 @@ static void show_selected_song_length(void)
 		log_appendf(4, "%s: %s", ptr, fmt_strerror(errno));
 		return;
 	}
-	show_length_dialog(get_basename(ptr), csf_get_length(song));
+	show_length_dialog(get_basename(ptr), csf_get_length_secs(song));
 	csf_free(song);
 }
 

--- a/schism/rocket.c
+++ b/schism/rocket.c
@@ -1,0 +1,160 @@
+#include <errno.h>
+#include <stdio.h>
+
+#include "headers.h"
+#include "it.h"
+#include "song.h"
+
+#include "rocket/lib/device.h"
+#include "rocket/lib/sync.h"
+
+typedef struct schism_rocket_t {
+	int	last_set_current_order, last_set_current_row;
+} schism_rocket_t;
+
+static struct sync_device	*rocket_dev;
+static unsigned			rocket_ms_per_row;
+static schism_rocket_t		schism_rocket;
+
+/* returns 0 on success, -errno on error */
+/* host and/or port may be NULL for defaults: localhost and SYNC_DEFAULT_PORT */
+int schism_rocket_connect(const char *host, const char *port, const char *bpm, const char *rpb)
+{
+	const char	*_host = "localhost";
+	unsigned short	_port = SYNC_DEFAULT_PORT;
+	unsigned int	_bpm = 125;
+	unsigned int	_rpb = 8;
+
+	if (host)
+		_host = host;
+
+	if (port) /* TODO: check for parse errors */
+		sscanf(port, "%hu", &_port);
+
+	if (bpm) /* TODO: check for parse errors */
+		sscanf(bpm, "%u", &_bpm);
+
+	if (rpb) /* TODO: check for parse errors */
+		sscanf(rpb, "%u", &_rpb);
+
+	rocket_ms_per_row = 60000 / (_bpm * _rpb);
+
+	rocket_dev = sync_create_device("schism-rocket");
+	if (!rocket_dev)
+		return -ENOMEM;
+
+	if (sync_tcp_connect(rocket_dev, _host, _port)) {
+		sync_destroy_device(rocket_dev);
+		/* XXX: rocket should really give a proper errno back */
+		return -ECONNREFUSED;
+	}
+
+	return 0;
+}
+
+static void rocket_sync_pause(void *ctxt, int flag)
+{
+	printf("RKT GOT PAUSE flag=%i\n", flag);
+	/* flag = 1 to pause, flag = 0 to unpause */
+	/* TODO: either add a new song_pause() or modify existing to handle flag */
+	/* I'm just open coding it here for now to get things working. */
+	song_lock_audio();
+
+	if (!(current_song->flags & SONG_PAUSED) && flag) {
+		current_song->flags |= SONG_ENDREACHED;
+		/* we don't want to just pause the playback, we want to position the
+		 * pattern editor to the current location on pause as well.
+		 */
+		 set_current_order(song_get_current_order());
+		 set_current_pattern(song_get_playing_pattern());
+		 set_current_row(song_get_current_row());
+	} else if (!flag)
+		song_start_at_order(get_current_order(), get_current_row());
+
+	song_unlock_audio();
+	main_song_mode_changed_cb();
+}
+
+static void rocket_sync_set_row(void *ctxt, int row)
+{
+	unsigned	ms = row * rocket_ms_per_row;
+
+	printf("RKT GOT SET ROW row=%i ms=%u ms_per_row=%u\n", row, ms, rocket_ms_per_row);
+
+	/* sets the current schism pattern/order/row-in-pattern to Rocket's "row" */
+
+	{ /* this is copied from schism/page.c::_timejump_ok */
+		int	no, np, nr;
+
+		song_get_at_time(ms, &no, &nr);
+		set_current_order(no);
+		np = current_song->orderlist[no];
+		if (np < 200) { /* XXX: this is taken from _timejump_ok */
+			set_current_pattern(np);
+			set_current_row(nr);
+		}
+	}
+
+	schism_rocket.last_set_current_order = get_current_order();
+	schism_rocket.last_set_current_row = get_current_row();
+}
+
+static int rocket_sync_is_playing(void *ctxt)
+{
+	/* Note that in librocket this is only used to determine if we send our
+	 * row up to the editor w/SET_ROW when _varying_ in sync_update().
+	 *
+	 * So if there's a desire to send SET_ROW commands to the Editor even when just
+	 * moving around while paused within schism, we kind of always have to return true
+	 * here for song-editing SET_ROWs to get sent despite being paused.
+	 */
+	return 1;
+}
+
+static struct sync_cb rocket_sync_cb = {
+	rocket_sync_pause,
+	rocket_sync_set_row,
+	rocket_sync_is_playing,
+};
+
+void schism_rocket_update(void)
+{
+	int	row = rocket_dev->row; /* TODO: it'd be nice if sync_update() supported something like a -1 row for "whatever's in sync_device.row",
+					* for when we just need to run the update to service the socket
+					*/
+
+	if (!current_song)
+		return;
+
+	if (!(current_song->flags & SONG_PAUSED)) {
+		/* When playing the song, derive the current ms from samples_played. */
+		/* Note this is why I needed to change Schism to prefill samples_played
+		 * on play-from-order-row instead of always starting with 0, if that was
+		 * going to result in a remotely close ms/Rocket-row.  The old code would
+		 * always start from 0 for the Time/samples_played even on F7 where there's
+		 * an actual known temporal point for the order+row being played from.
+		 */
+		row = samples_played / (current_song->mix_frequency / 1000) / rocket_ms_per_row;
+	} else {
+		int	co, cr;
+
+		co = get_current_order();
+		cr = get_current_row();
+
+		/* Only update the rocket row using the editor's cursor position if it
+		 * was changed by schism - and not by a received SET_ROW.
+		 * The schism pattern data generally has less resolution than RocketEditor's,
+		 * so if we just always updated with a cursorpos-to-ms-derived-row, we'd
+		 * be basically rounding it to the nearest row schism could represent and
+		 * constantly fighting with the RocketEditor's finer-grained movements.
+		 */
+		if (co != schism_rocket.last_set_current_order ||
+		    cr != schism_rocket.last_set_current_row) {
+			row = song_get_length_to_ms(co, cr) / rocket_ms_per_row;
+			schism_rocket.last_set_current_order = co;
+			schism_rocket.last_set_current_row = cr;
+		}
+	}
+
+	sync_update(rocket_dev, row, &rocket_sync_cb, NULL);
+}


### PR DESCRIPTION
This adds a --with-rocket configure flag for enabling
experimental GNU Rocket support in Schism.

When enabled in the build, a series of new runtime flags are 
added:

--rocket (enable rocket mode)
all these overrides imply --rocket:
--rocket-host=HOST_OVERRIDE
--rocket-port=PORT_OVERRIDE
--rocket-bpm=BPM_OVERRIDE (beats per minute)
--rocket-rpb=RPB_OVERRIDE (rows per beat)

BPM and RPB are RocketEditor concepts, which the GNU Rocket
protocol is totally ignorant of.  But they're provided to aid in
keeping the Editor and Schism in agreement on what Rocket row 
maps to what millisecond within the song and within the Rocket
track data.  This doesn't override the speed/tempo setting for 
the song within Schism, and you'll have to take care to pick
those values such that it's consistent with the Rocket values, if
you want the RocketEditor's patterns and current row to align
with Schisms.  It's a little awkward due to how IT defined the 
speed/tempo semantics.  The default Rocket values of 125BPM/8RPB
do seem to align with the default IT/Schism speed/tempo of 6/125
though.

As-is this commit only attempts to connect to the Editor once at
startup.  So you'll need to have RocketEditor running before
starting SchismTracker w/--rocket.  This area could be made more
robust before merging upstream into SchismTracker, but it is
already usable.  If viewed as an experimental demo developer
mode, this is probably good enough to merge as-is.

See https://github.com/emoon/rocket/pull/165 for more context on
what this is all about.