### PR TITLE
schism: drop NORETURN attribute use

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -53,9 +53,6 @@
 # ifndef UNUSED
 #  define UNUSED __attribute__((unused))
 # endif
-# ifndef NORETURN
-#  define NORETURN __attribute__((noreturn))
-# endif
 # ifndef PACKED
 #  define PACKED __attribute__((packed))
 # endif
@@ -68,9 +65,6 @@
 # endif
 # ifndef PACKED
 #  define PACKED
-# endif
-# ifndef NORETURN
-#  define NORETURN
 # endif
 # ifndef LIKELY
 #  define LIKELY(x)

--- a/schism/main.c
+++ b/schism/main.c
@@ -594,7 +594,6 @@ static void key_event_reset(struct key_event *kk, int start_x, int start_y)
 	kk->sy = start_y;
 }
 
-static void event_loop(void) NORETURN;
 static void event_loop(void)
 {
 	SDL_Event event;


### PR DESCRIPTION
This is just generating pointless noise from gcc:

```
gcc -DHAVE_CONFIG_H -I. -I..  -D_USE_AUTOCONF -D_GNU_SOURCE -I../include -I.  -I/usr/include/SDL2 -D_REENTRANT -DUSE_ALSA -DUSE_DLTRICK_ALSA -DUSE_OSS -DUSE_NETWORK -DUSE_X11 -DUSE_XV -DHAS_YM3812=1 -DHAS_Y8950=0 -DHAS_YM3526=0     -DUSE_FLAC -DUSE_ROCKET -g -O2 -MT schism/main.o -MD -MP -MF $depbase.Tpo -c -o schism/main.o ../schism/main.c &&\
mv -f $depbase.Tpo $depbase.Po
../schism/main.c: In function ‘event_loop’:
../schism/main.c:1086:1: warning: ‘noreturn’ function does return
 1086 | }
      | ^
```

I see no obvious reason why it's important for the compiler to be informed of event_loop()'s not returning, and right now it's just adding a false-positive warning to the build.