### PR TITLE
Better keyjazz note-off matching

### DIFF
--- a/include/it.h
+++ b/include/it.h
@@ -167,6 +167,7 @@ struct tracker_status {
 	enum tracker_time_display time_display;
 	enum tracker_vis_style vis_style;
 	SDL_Keysym last_keysym;
+	SDL_Keysym last_keyupsym;
 
 	time_t last_midi_time;
 	unsigned char last_midi_event[64];

--- a/include/song.h
+++ b/include/song.h
@@ -268,6 +268,7 @@ select sample #0. (note: this is a hack to work around another hack) */
 int song_keydown(int samp, int ins, int note, int vol, int chan);
 int song_keyrecord(int samp, int ins, int note, int vol, int chan, int effect, int param);
 int song_keyup(int samp, int ins, int note);
+int song_keyup_channel(int samp, int ins, int note, int chan);
 
 void song_start(void);
 void song_start_once(void);

--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -251,7 +251,7 @@ This will break if the same note was keydown'd twice without a keyup, but I thin
 fairly unlikely scenario that you'd have to TRY to bring about. */
 static int keyjazz_note_to_chan[128];
 /* last note played by channel tracking */
-static int keyjazz_chan_to_note[MAX_CHANNELS+1];
+static int keyjazz_chan_to_note[257];
 
 /* **** chan ranges from 1 to 64   */
 static int song_keydown_ex(int samp, int ins, int note, int vol, int chan, int effect, int param)

--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -246,10 +246,12 @@ int song_is_multichannel_mode(void)
 
 
 /* Channel corresponding to each note played.
-That is, keydown_channels[66] will indicate in which channel F-5 was played most recently.
+That is, keyjazz_note_to_chan[66] will indicate in which channel F-5 was played most recently.
 This will break if the same note was keydown'd twice without a keyup, but I think that's a
 fairly unlikely scenario that you'd have to TRY to bring about. */
-static int keyjazz_channels[128];
+static int keyjazz_note_to_chan[128];
+/* last note played by channel tracking */
+static int keyjazz_chan_to_note[MAX_CHANNELS+1];
 
 /* **** chan ranges from 1 to 64   */
 static int song_keydown_ex(int samp, int ins, int note, int vol, int chan, int effect, int param)
@@ -277,7 +279,13 @@ static int song_keydown_ex(int samp, int ins, int note, int vol, int chan, int e
 
 	if (NOTE_IS_NOTE(note)) {
 		// keep track of what channel this note was played in so we can note-off properly later
-		keyjazz_channels[note] = chan;
+		if (keyjazz_chan_to_note[chan]) {
+			// reset note-off pending state for last note in channel
+			keyjazz_note_to_chan[keyjazz_chan_to_note[chan]] = 0;
+		}
+
+		keyjazz_note_to_chan[note] = chan;
+		keyjazz_chan_to_note[chan] = note;
 
 		// handle blank instrument values and "fake" sample #0 (used by sample loader)
 		if (samp == 0)
@@ -428,7 +436,21 @@ int song_keyrecord(int samp, int ins, int note, int vol, int chan, int effect, i
 
 int song_keyup(int samp, int ins, int note)
 {
-	return song_keydown_ex(samp, ins, NOTE_OFF, KEYJAZZ_DEFAULTVOL, keyjazz_channels[note], 0, 0);
+	int chan = keyjazz_note_to_chan[note];
+	if (!chan) {
+		// could not find channel, drop.
+		return -1;
+	};
+	return song_keyup_channel(samp, ins, note, chan);
+}
+
+int song_keyup_channel(int samp, int ins, int note, int chan) {
+	if (keyjazz_chan_to_note[chan] != note) {
+		return -1;
+	}
+	keyjazz_chan_to_note[chan] = 0;
+	keyjazz_note_to_chan[note] = 0;
+	return song_keydown_ex(samp, ins, NOTE_OFF, KEYJAZZ_DEFAULTVOL, chan, 0, 0);
 }
 
 void song_single_step(int patno, int row)
@@ -476,7 +498,8 @@ static void song_reset_play_state(void)
 {
 	memset(midi_bend_hit, 0, sizeof(midi_bend_hit));
 	memset(midi_last_bend_hit, 0, sizeof(midi_last_bend_hit));
-	memset(keyjazz_channels, 0, sizeof(keyjazz_channels));
+	memset(keyjazz_note_to_chan, 0, sizeof(keyjazz_note_to_chan));
+	memset(keyjazz_chan_to_note, 0, sizeof(keyjazz_chan_to_note));
 
 	// turn this crap off
 	current_song->mix_flags &= ~(SNDMIX_NOBACKWARDJUMPS | SNDMIX_DIRECTTODISK);

--- a/schism/main.c
+++ b/schism/main.c
@@ -600,6 +600,7 @@ static void event_loop(void)
 	unsigned int lx = 0, ly = 0; /* last x and y position (character) */
 	uint32_t last_mouse_down, ticker;
 	SDL_Keysym last_key = {};
+	SDL_Keysym last_keyup = {};
 	int modkey;
 	time_t startdown;
 #ifdef USE_X11
@@ -748,7 +749,8 @@ static void event_loop(void)
 						(int)event.key.keysym.scancode,
 						kk.sym.sym, kk.unicode);
 			}
-			if (event.type == SDL_KEYDOWN && last_key.sym == kk.sym.sym) {
+			if (event.type == SDL_KEYDOWN && last_key.sym == kk.sym.sym ||
+				event.type == SDL_KEYUP && last_keyup.sym == kk.sym.sym) {
 				sawrep = kk.is_repeat = 1;
 			} else {
 				kk.is_repeat = 0;
@@ -757,8 +759,8 @@ static void event_loop(void)
 				kk.unicode = '\r';
 			handle_key(&kk);
 			if (event.type == SDL_KEYUP) {
-				status.last_keysym.sym = kk.sym.sym;
-				last_key.sym = 0;
+				status.last_keyupsym.sym = kk.sym.sym;
+				last_keyup.sym = 0;
 			} else {
 				status.last_keysym.sym = 0;
 				last_key.sym = kk.sym.sym;

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -2984,6 +2984,10 @@ static int pattern_editor_insert_midi(struct key_event *k)
 		/* nada */
 	} else if (k->state == KEY_RELEASE) {
 		c = song_keyup(KEYJAZZ_NOINST, KEYJAZZ_NOINST, k->midi_note);
+		if (c <= 0) {
+			/* song_keyup didn't find find note off channel, abort */
+			return 0;
+		}
 
 		/* don't record noteoffs for no good reason... */
 		if (!((midi_flags & MIDI_RECORD_NOTEOFF)

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -105,7 +105,6 @@ int midi_playback_tracing = 0;
 static int panning_mode = 0;            /* for the volume column */
 int midi_bend_hit[64];
 int midi_last_bend_hit[64];
-int midi_last_note[64];
 
 /* blah; other forwards */
 static void pated_save(const char *descr);
@@ -2984,11 +2983,6 @@ static int pattern_editor_insert_midi(struct key_event *k)
 	if (k->midi_note == -1) {
 		/* nada */
 	} else if (k->state == KEY_RELEASE) {
-		/* don't record noteoffs of non-matching notes */
-		if (k->midi_note != midi_last_note[c]) {
-			return 0;
-		}
-
 		c = song_keyup(KEYJAZZ_NOINST, KEYJAZZ_NOINST, k->midi_note);
 
 		/* don't record noteoffs for no good reason... */
@@ -3012,7 +3006,7 @@ static int pattern_editor_insert_midi(struct key_event *k)
 		if (!((song_get_mode() & (MODE_PLAYING | MODE_PATTERN_LOOP)) && playback_tracing)) {
 			tick = 0;
 		}
-		midi_last_note[c] = n = k->midi_note;
+		n = k->midi_note;
 		c = song_keydown(KEYJAZZ_NOINST, KEYJAZZ_NOINST, n, v, current_channel);
 		cur_note = pattern + 64 * current_row + (c-1);
 		patedit_record_note(cur_note, c, current_row, n, 0);


### PR DESCRIPTION
So after doing #348 I noticed there's probably a better way to tackle the issue at hand.
- my previous PR solved the issue only for the pattern editor
  - this works seamlessly in sample/instrument page for example.
- this version also keeps all keyjazzing state arrays near each other which is also a plus

I also fixed some interesting bug here related to key repeats: I noticed that in master, holding two keys, then releasing one outputs a keyoff event, **then another keyon**, which means releasing a key plays note sound, which is undesirable.

This happens because previously keyoffs would throw off the key repeat check, which decides if a key is repeat based on equality to the previous key. so given you hold two keys, your last one is gonna stream keydown repeats. when releasing a key, momently a single keydown will not match the previous note-off and play a sound.

To fix it, I started tracking note-offs in designated variable for repeat check, so they won't disrupt each other.

after all that, i reverted the previous fix in #348 