### PR TITLE
video: provide SDL2 hint define when missing

### DIFF
--- a/schism/video.c
+++ b/schism/video.c
@@ -250,6 +250,10 @@ void video_startup(void)
 
 	video_setup(cfg_video_interpolation);
 
+#ifndef SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR
+/* older SDL2 versions don't define this, don't fail the build for it */
+#define SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR "SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR"
+#endif
 	SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
 
 	video.x = SDL_WINDOWPOS_CENTERED;


### PR DESCRIPTION
I tripped over this when cross-compiling using a dated but validated mingw toolchain I've built win32 SDL2 games using in the past.

It has SDL 2.0.7 and there's no define for:
SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR

But nothing stops us from defining it ourselves...