### PR TITLE
Set SDL_HINT_GRAB_KEYBOARD to "1", fix #373

### DIFF
--- a/schism/video.c
+++ b/schism/video.c
@@ -190,6 +190,10 @@ void video_shutdown(void)
 void video_setup(const char* quality)
 {
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, quality);
+
+	// Needed as of SDL2 so Ctrl-D SDL_SetWindowGrab will grab keyboard too,
+	// not just mouse.
+	SDL_SetHint(SDL_HINT_GRAB_KEYBOARD, "1");
 }
 
 static void set_icon(void)


### PR DESCRIPTION
`SDL_SetWindowGrab()` only grabs mouse in SDL2, unless this hint is set to 1. Fixes keyboard grabbing with Ctrl-D

`SDL_SetWindowGrab` intentionally only grabs mouse unless you set `SDL_HINT_GRAB_KEYBOARD` to "1"

If we wanted to ONLY grab keyboard, and not grab mouse, we could use `SDL_SetWindowKeyboardGrab()` instead. 

Note that under wayland specifically, this will only work with the `wayland` video driver. As a user I need to force that manually with the `SDL_VIDEODRIVER=wayland` env var, but thats just because its not considered stable in SDL2. I think SDL3 is trying to enable it by default. Not really relevant to schism I think.