### PR TITLE
Fix out of bounds memory access while rendering samples

### DIFF
--- a/schism/sample-view.c
+++ b/schism/sample-view.c
@@ -73,23 +73,33 @@ static void _draw_sample_data_8(struct vgamem_overlay *r,
 		xs = 0;
 		ys = (np - 1) - level;
 		ys = CLAMP(ys, 0, r->height - 1);
-		do {
+
+
+		if (length == 1) {
+			// When we only have one sample to draw, we need to just draw a
+			// horizontal line of whatever that value is, because we don't have
+			// a second sample to draw a line between in the loop below.
+			vgamem_ovl_drawline(r, 0, ys, r->width - 1, ys, SAMPLE_DATA_COLOR);
+		} else {
 			pos += step;
-			co = 0;
-			level=0;
-			do {
-				level+=ceil(data[(pos * inputchans) + cc+co] * nh / (SCHAR_MAX - SCHAR_MIN + 1));
-			} while (co++ < inputchans-outputchans);
-			xe = pos * r->width / length;
-			ye = (np - 1) - level;
-			xe = CLAMP(xe, 0, r->width - 1);
-			ye = CLAMP(ye, 0, r->height - 1);
-			// 'ye' is more or less useless for small samples, but this is much cleaner
-			// code than writing nearly the same loop four different times :P
-			vgamem_ovl_drawline(r, xs, ys, xe, chip ? ys : ye, SAMPLE_DATA_COLOR);
-			xs = xe;
-			ys = ye;
-		} while (pos < length);
+			while (pos < length) {
+				co = 0;
+				level = 0;
+				do {
+					level += ceil(data[(pos * inputchans) + cc + co] * nh / (SCHAR_MAX - SCHAR_MIN + 1));
+				} while (co++ < inputchans - outputchans);
+				xe = pos * r->width / length;
+				ye = (np - 1) - level;
+				xe = CLAMP(xe, 0, r->width - 1);
+				ye = CLAMP(ye, 0, r->height - 1);
+				// 'ye' is more or less useless for small samples, but this is much cleaner
+				// code than writing nearly the same loop four different times :P
+				vgamem_ovl_drawline(r, xs, ys, xe, chip ? ys : ye, SAMPLE_DATA_COLOR);
+				xs = xe;
+				ys = ye;
+				pos += step;
+			}
+		}
 		np -= nh;
 	}
 }
@@ -120,21 +130,30 @@ static void _draw_sample_data_16(struct vgamem_overlay *r,
 		xs = 0;
 		ys = (np - 1) - level;
 		ys = CLAMP(ys, 0, r->height - 1);
-		do {
+
+		if (length == 1) {
+			// When we only have one sample to draw, we need to just draw a
+			// horizontal line of whatever that value is, because we don't have
+			// a second sample to draw a line between in the loop below.
+			vgamem_ovl_drawline(r, 0, ys, r->width - 1, ys, SAMPLE_DATA_COLOR);
+		} else {
 			pos += step;
-			co = 0;
-			level = 0;
-			do {
-				level = ceil(data[(pos * inputchans) + cc+co] * nh / (float)(SHRT_MAX - SHRT_MIN + 1));
-			} while (co++ < inputchans-outputchans);
-			xe = pos * r->width / length;
-			ye = (np - 1) - level;
-			xe = CLAMP(xe, 0, r->width - 1);
-			ye = CLAMP(ye, 0, r->height - 1);
-			vgamem_ovl_drawline(r, xs, ys, xe, chip ? ys : ye, SAMPLE_DATA_COLOR);
-			xs = xe;
-			ys = ye;
-		} while (pos < length);
+			while (pos < length) {
+				co = 0;
+				level = 0;
+				do {
+					level = ceil(data[(pos * inputchans) + cc + co] * nh / (float) (SHRT_MAX - SHRT_MIN + 1));
+				} while (co++ < inputchans - outputchans);
+				xe = pos * r->width / length;
+				ye = (np - 1) - level;
+				xe = CLAMP(xe, 0, r->width - 1);
+				ye = CLAMP(ye, 0, r->height - 1);
+				vgamem_ovl_drawline(r, xs, ys, xe, chip ? ys : ye, SAMPLE_DATA_COLOR);
+				xs = xe;
+				ys = ye;
+				pos += step;
+			}
+		}
 		np -= nh;
 	}
 }


### PR DESCRIPTION
Right now the sample renderer will perform out of bounds reads after the end of the sample data. As far as I can tell, this always happens. Usually this doesn't result in a crash and will at worst result in a rendering error, but with particularly large samples, `step` is big enough that it will read so far past the end of the sample data that it can generate a segfault.

This fixes the rendering code to stay in bounds, with special handling of 1-length samples. I've tested this on my long samples that generated a crash 100% of the time, as well as on 1-length 8-bit mono and 16-bit stereo/mono samples. And normal-people-sized 8/16-bit mono/stereo samples.

fixes #376

also lmk if the issue + pr combo is annoying when contributing stuff I've already figured out and fixed, i could just do a PR for small things like this and explain everything in the PR, doing issue+pr is just sort of habit for me because of work lol