### PR TITLE
page_patedit.c: provide undo for "revert pattern data"

### DIFF
--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -3461,6 +3461,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	case SDLK_BACKSPACE:
 		if (k->state == KEY_PRESS)
 			return 1;
+		pated_save("Undo revert pattern data (Alt-BkSpace)");
 		snap_paste(&fast_save, 0, 0, 0);
 		return 1;
 


### PR DESCRIPTION
Impulse tracker does that and this action is marked with star in the help text.
Also it is easy to destroy your pattern edits by accidentally pressing  Alt+Backspace instead of Ctrl+Backspace.