### PR TITLE
Add portable mode

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -171,6 +171,7 @@ char *str_concat(const char *s, ...);
 /* filesystem */
 int make_backup_file(const char *filename, int numbered);
 unsigned long long file_size(const char *filename);
+int is_file(const char *filename);
 int is_directory(const char *filename);
 /* following functions should free() the resulting strings */
 char *get_home_directory(void); /* "default" directory for user files, i.e. $HOME, My Documents, etc. */

--- a/schism/config.c
+++ b/schism/config.c
@@ -70,11 +70,8 @@ void cfg_init_dir(void)
 
 	cur_dir = get_current_directory();
 	portable_file = dmoz_path_concat(cur_dir, "portable.txt");
-	int is_portable_mode = is_file(portable_file);
-	free(cur_dir);
-	free(portable_file);
 
-	if(is_portable_mode) {
+	if(is_file(portable_file)) {
 		printf("In portable mode.\n");
 
 		strncpy(cfg_dir_dotschism, cur_dir, PATH_MAX);
@@ -98,6 +95,9 @@ void cfg_init_dir(void)
 			}
 		}
 	}
+
+	free(cur_dir);
+	free(portable_file);
 #endif
 }
 

--- a/schism/config.c
+++ b/schism/config.c
@@ -66,21 +66,36 @@ void cfg_init_dir(void)
 #if defined(__amigaos4__)
 	strcpy(cfg_dir_dotschism, "PROGDIR:");
 #else
-	char *dot_dir, *ptr;
+	char *cur_dir, *portable_file;
 
-	dot_dir = get_dot_directory();
-	ptr = dmoz_path_concat(dot_dir, DOT_SCHISM);
-	strncpy(cfg_dir_dotschism, ptr, PATH_MAX);
-	cfg_dir_dotschism[PATH_MAX] = 0;
-	free(dot_dir);
-	free(ptr);
+	cur_dir = get_current_directory();
+	portable_file = dmoz_path_concat(cur_dir, "portable.txt");
+	int is_portable_mode = is_file(portable_file);
+	free(cur_dir);
+	free(portable_file);
 
-	if (!is_directory(cfg_dir_dotschism)) {
-		printf("Creating directory %s\n", cfg_dir_dotschism);
-		printf("Schism Tracker uses this directory to store your settings.\n");
-		if (mkdir(cfg_dir_dotschism, 0777) != 0) {
-			perror("Error creating directory");
-			fprintf(stderr, "Everything will still work, but preferences will not be saved.\n");
+	if(is_portable_mode) {
+		printf("In portable mode.\n");
+
+		strncpy(cfg_dir_dotschism, cur_dir, PATH_MAX);
+		cfg_dir_dotschism[PATH_MAX] = 0;
+	} else {
+		char *dot_dir, *ptr;
+
+		dot_dir = get_dot_directory();
+		ptr = dmoz_path_concat(dot_dir, DOT_SCHISM);
+		strncpy(cfg_dir_dotschism, ptr, PATH_MAX);
+		cfg_dir_dotschism[PATH_MAX] = 0;
+		free(dot_dir);
+		free(ptr);
+
+		if (!is_directory(cfg_dir_dotschism)) {
+			printf("Creating directory %s\n", cfg_dir_dotschism);
+			printf("Schism Tracker uses this directory to store your settings.\n");
+			if (mkdir(cfg_dir_dotschism, 0777) != 0) {
+				perror("Error creating directory");
+				fprintf(stderr, "Everything will still work, but preferences will not be saved.\n");
+			}
 		}
 	}
 #endif

--- a/schism/util.c
+++ b/schism/util.c
@@ -755,6 +755,18 @@ unsigned long long file_size(const char *filename) {
 /* --------------------------------------------------------------------- */
 /* FILESYSTEM FUNCTIONS */
 
+int is_file(const char *filename)
+{
+	struct stat buf;
+
+	if (os_stat(filename, &buf) == -1) {
+		/* Well, at least we tried. */
+		return 0;
+	}
+
+	return S_ISREG(buf.st_mode);
+}
+
 int is_directory(const char *filename)
 {
 	struct stat buf;
@@ -798,7 +810,7 @@ char *get_home_directory(void)
 #elif defined(WIN32)
 	wchar_t buf[PATH_MAX + 1] = {L'\0'};
 	char* buf_utf8 = NULL;
-	
+
 	if (SHGetFolderPathW(NULL, CSIDL_PERSONAL, NULL, 0, buf) != S_OK)
 		return NULL;
 


### PR DESCRIPTION
If a file called "portable.txt" is placed next to the schismtracker executable, the program will enter portable mode where the config file is also saved next to the executable.