### PR TITLE
Fixed parent directory crashing 

### DIFF
--- a/schism/util.c
+++ b/schism/util.c
@@ -305,22 +305,19 @@ const char *get_extension(const char *filename)
 
 char *get_parent_directory(const char *dirname)
 {
-	if (!dirname || strlen(dirname) == 0)
+	if (!dirname || !dirname[0])
 		return NULL;
 
 	int n = strlen(dirname) - 1;
 
-	if (dirname[n] == DIR_SEPARATOR) {
+	if (dirname[n] == DIR_SEPARATOR)
 		n--;
-	}
 
 	if (n <= 0) return NULL;
 
-	for(; n > 0; n--) {
-		if(dirname[n - 1] == DIR_SEPARATOR) {
-			n--;
+	while (n > 0) {
+		if (dirname[--n] == DIR_SEPARATOR)
 			break;
-		}
 	}
 
 	char *ret = mem_alloc((n + 1) * sizeof(char));
@@ -328,7 +325,7 @@ char *get_parent_directory(const char *dirname)
 	ret[n] = '\0';
 
 	if(strcmp(dirname, ret) == 0) return NULL;
-	if(strlen(ret) == 0) return NULL;
+	if(!ret[0]) return NULL;
 
 	return ret;
 }

--- a/schism/util.c
+++ b/schism/util.c
@@ -305,30 +305,30 @@ const char *get_extension(const char *filename)
 
 char *get_parent_directory(const char *dirname)
 {
-	const char *pos;
-	char *ret;
-	int n;
-
-	if (!dirname || !dirname[0])
+	if (!dirname || strlen(dirname) == 0)
 		return NULL;
 
-	n = strlen(dirname) - 1;
-	if (dirname[n] == DIR_SEPARATOR)
+	int n = strlen(dirname) - 1;
+
+	if (dirname[n] == DIR_SEPARATOR) {
 		n--;
+	}
 
-	if (n < 0)
-		return NULL;
+	if (n <= 0) return NULL;
 
-	pos = dirname + (n * sizeof(char));
-	do {
-		if (*(--pos) == DIR_SEPARATOR)
+	for(; n > 0; n--) {
+		if(dirname[n - 1] == DIR_SEPARATOR) {
+			n--;
 			break;
-	} while (--n);
+		}
+	}
 
-	/* copy the resulting value */
-	ret = mem_alloc((n * sizeof(char)) + sizeof(char));
+	char *ret = mem_alloc((n + 1) * sizeof(char));
 	memcpy(ret, dirname, n * sizeof(char));
 	ret[n] = '\0';
+
+	if(strcmp(dirname, ret) == 0) return NULL;
+	if(strlen(ret) == 0) return NULL;
 
 	return ret;
 }


### PR DESCRIPTION
On windows the parent directory ".." would show when browsing files, even if a parent directory doesn't exist. Selecting that option would crash ST. With this fix the ".." doesn't show up if there's no parent directory. Also added a bunch of checks when getting the parent dir. Needs to be tested on linux since I only use windows.