### PR TITLE
build: fix gcc warning for handle_text_input functions

### DIFF
--- a/schism/page_loadinst.c
+++ b/schism/page_loadinst.c
@@ -380,6 +380,7 @@ static int file_list_handle_text_input(const uint8_t* text) {
 			return 1;
 		}
 	}
+	return 0;
 }
 
 static int file_list_handle_key(struct key_event * k)

--- a/schism/page_loadsample.c
+++ b/schism/page_loadsample.c
@@ -639,6 +639,7 @@ static int file_list_handle_text_input(const uint8_t* text) {
 			return 1;
 		}
 	}
+	return 0;
 }
 
 static int file_list_handle_key(struct key_event * k)


### PR DESCRIPTION
```
page_loadinst.c: In function "file_list_handle_text_input":
page_loadinst.c:383:1: error: control reaches end of non-void function [-Werror=return-type]
```