### PR TITLE
Palette page improvements

### DIFF
--- a/include/it.h
+++ b/include/it.h
@@ -227,7 +227,6 @@ extern struct tracker_status status;
 extern uint8_t *font_data; /* ... which is 2048 bytes */
 extern struct it_palette palettes[];
 extern uint8_t current_palette[16][3];
-extern uint8_t user_palette[16][3];
 extern int current_palette_index;
 
 extern int playback_tracing, midi_playback_tracing;
@@ -357,6 +356,8 @@ void main_song_changed_cb(void);
 int font_load(const char *filename);
 void palette_apply(void);
 void palette_load_preset(int palette_index);
+void palette_to_string(char *str_out);
+int set_palette_from_string(const char *str_in);
 
 /* mostly for the itf editor */
 int font_save(const char *filename);

--- a/include/it.h
+++ b/include/it.h
@@ -227,6 +227,7 @@ extern struct tracker_status status;
 extern uint8_t *font_data; /* ... which is 2048 bytes */
 extern struct it_palette palettes[];
 extern uint8_t current_palette[16][3];
+extern uint8_t user_palette[16][3];
 extern int current_palette_index;
 
 extern int playback_tracing, midi_playback_tracing;

--- a/schism/clippy.c
+++ b/schism/clippy.c
@@ -187,12 +187,11 @@ struct widget *clippy_owner(int cb)
 
 void clippy_yank(void)
 {
-	_free_current_clipboard();
-	_current_clipboard = _current_selection;
-	_widget_owner[CLIPPY_BUFFER] = _widget_owner[CLIPPY_SELECT];
-
 	if (_current_selection && strlen(_current_selection) > 0) {
-		status_text_flash("Copied to selection buffer");
+		_free_current_clipboard();
+		_current_clipboard = str_dup(_current_selection);
+		_widget_owner[CLIPPY_BUFFER] = _widget_owner[CLIPPY_SELECT];
 		_clippy_copy_to_sys(CLIPPY_BUFFER);
+		status_text_flash("Copied to selection buffer");
 	}
 }

--- a/schism/clippy.c
+++ b/schism/clippy.c
@@ -32,9 +32,23 @@
 #include "sdlmain.h"
 #include "video.h"
 
-static char *_current_selection = NULL;
-static char *_current_clipboard = NULL;
-static struct widget *_widget_owner[16] = {NULL};
+static char* _current_selection = NULL;
+static char* _current_clipboard = NULL;
+static struct widget* _widget_owner[16] = {NULL};
+
+static void _free_current_selection(void) {
+	if (_current_selection) {
+		free(_current_selection);
+		_current_selection = NULL;
+	}
+}
+
+static void _free_current_clipboard(void) {
+	if (_current_clipboard) {
+		free(_current_clipboard);
+		_current_clipboard = NULL;
+	}
+}
 
 static void _clippy_copy_to_sys(int cb)
 {
@@ -91,8 +105,10 @@ static void _string_paste(UNUSED int cb, const char *cbptr)
 	event.user.type = SCHISM_EVENT_PASTE;
 	event.user.data1 = str_dup(cbptr); /* current_clipboard... is it safe? */
 	if (!event.user.data1) return; /* eh... */
-	if (SDL_PushEvent(&event) == -1)
+	if (SDL_PushEvent(&event) == -1) {
 		free(event.user.data1);
+		event.user.data1 = NULL;
+	}
 }
 
 static char *_internal_clippy_paste(int cb)
@@ -102,14 +118,14 @@ static char *_internal_clippy_paste(int cb)
 #if SDL_VERSION_ATLEAST(2, 26, 0)
 			/* is this even remotely useful? */
 			if (SDL_HasPrimarySelectionText()) {
-				if (_current_selection)
-					free(_current_selection);
+				_free_current_selection();
 
 				char* sel = SDL_GetPrimarySelectionText();
 
 				if (charset_iconv((uint8_t*)sel, (uint8_t**)&_current_selection, CHARSET_UTF8, CHARSET_CP437)) {
 					SDL_free(sel);
-					return (_current_selection = NULL);
+					_free_current_selection();
+					return NULL;
 				}
 
 				SDL_free(sel);
@@ -120,14 +136,14 @@ static char *_internal_clippy_paste(int cb)
 			return _current_selection;
 		case CLIPPY_BUFFER:
 			if (SDL_HasClipboardText()) {
-				if (_current_clipboard)
-					free(_current_clipboard);
+				_free_current_clipboard();
 
 				char* cb = SDL_GetClipboardText();
 
 				if (charset_iconv((uint8_t*)cb, (uint8_t**)&_current_clipboard, CHARSET_UTF8, CHARSET_CP437)) {
 					SDL_free(cb);
-					return (_current_clipboard = NULL);
+					_free_current_clipboard();
+					return NULL;
 				}
 
 				SDL_free(cb);
@@ -151,12 +167,9 @@ void clippy_paste(int cb)
 void clippy_select(struct widget *w, char *addr, int len)
 {
 	int i;
-
-	if (_current_selection != _current_clipboard)
-		free(_current_selection);
+	_free_current_selection();
 
 	if (!addr) {
-		_current_selection = NULL;
 		_widget_owner[CLIPPY_SELECT] = NULL;
 	} else {
 		_current_selection = (len < 0) ? str_dup(addr) : strn_dup(addr, len);
@@ -166,6 +179,7 @@ void clippy_select(struct widget *w, char *addr, int len)
 		_clippy_copy_to_sys(CLIPPY_SELECT);
 	}
 }
+
 struct widget *clippy_owner(int cb)
 {
 	return (cb == CLIPPY_SELECT || cb == CLIPPY_BUFFER) ? _widget_owner[cb] : NULL;
@@ -173,9 +187,7 @@ struct widget *clippy_owner(int cb)
 
 void clippy_yank(void)
 {
-	if (_current_selection != _current_clipboard)
-		free(_current_clipboard);
-
+	_free_current_clipboard();
 	_current_clipboard = _current_selection;
 	_widget_owner[CLIPPY_BUFFER] = _widget_owner[CLIPPY_SELECT];
 

--- a/schism/config.c
+++ b/schism/config.c
@@ -107,35 +107,23 @@ void cfg_init_dir(void)
 static const char palette_trans[64] = ".0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
 static void cfg_load_palette(cfg_file_t *cfg)
 {
-	uint8_t colors[48];
-	int n;
 	char palette_text[49] = "";
-	const char *ptr;
 	cfg_get_string(cfg, "General", "palette_cur", palette_text, 48, "");
-	for (n = 0; n < 48; n++) {
-		if (palette_text[n] == '\0' || (ptr = memchr(palette_trans, palette_text[n], sizeof(palette_trans))) == NULL)
-			return;
-		colors[n] = ptr - palette_trans;
+
+	if(palette_text[0]) {
+		set_palette_from_string(palette_text);
 	}
-	memcpy(user_palette, colors, sizeof(current_palette));
 
 	palette_load_preset(cfg_get_number(cfg, "General", "palette", 2));
 }
 
 static void cfg_save_palette(cfg_file_t *cfg)
 {
-	int n;
-	char palette_text[49] = "";
-
 	cfg_set_number(cfg, "General", "palette", current_palette_index);
 
 	if(current_palette_index == -1) {
-		for (n = 0; n < 48; n++) {
-			/* Changed older implementation for this, since it is not vital
-			to have speed here and the compiler printed a warning */
-			palette_text[n] = palette_trans[current_palette[n/3][n%3]];
-		}
-		palette_text[48] = '\0';
+		char palette_text[49] = "";
+		palette_to_string(palette_text);
 		cfg_set_string(cfg, "General", "palette_cur", palette_text);
 	}
 }

--- a/schism/config.c
+++ b/schism/config.c
@@ -111,16 +111,15 @@ static void cfg_load_palette(cfg_file_t *cfg)
 	int n;
 	char palette_text[49] = "";
 	const char *ptr;
-
-	palette_load_preset(cfg_get_number(cfg, "General", "palette", 2));
-
 	cfg_get_string(cfg, "General", "palette_cur", palette_text, 48, "");
 	for (n = 0; n < 48; n++) {
 		if (palette_text[n] == '\0' || (ptr = memchr(palette_trans, palette_text[n], sizeof(palette_trans))) == NULL)
 			return;
 		colors[n] = ptr - palette_trans;
 	}
-	memcpy(current_palette, colors, sizeof(current_palette));
+	memcpy(user_palette, colors, sizeof(current_palette));
+
+	palette_load_preset(cfg_get_number(cfg, "General", "palette", 2));
 }
 
 static void cfg_save_palette(cfg_file_t *cfg)
@@ -130,13 +129,15 @@ static void cfg_save_palette(cfg_file_t *cfg)
 
 	cfg_set_number(cfg, "General", "palette", current_palette_index);
 
-	for (n = 0; n < 48; n++) {
-		/* Changed older implementation for this, since it is not vital
-		to have speed here and the compiler printed a warning */
-		palette_text[n] = palette_trans[current_palette[n/3][n%3]];
+	if(current_palette_index == -1) {
+		for (n = 0; n < 48; n++) {
+			/* Changed older implementation for this, since it is not vital
+			to have speed here and the compiler printed a warning */
+			palette_text[n] = palette_trans[current_palette[n/3][n%3]];
+		}
+		palette_text[48] = '\0';
+		cfg_set_string(cfg, "General", "palette_cur", palette_text);
 	}
-	palette_text[48] = '\0';
-	cfg_set_string(cfg, "General", "palette_cur", palette_text);
 }
 
 /* --------------------------------------------------------------------------------------------------------- */

--- a/schism/config.c
+++ b/schism/config.c
@@ -121,7 +121,7 @@ static void cfg_save_palette(cfg_file_t *cfg)
 {
 	cfg_set_number(cfg, "General", "palette", current_palette_index);
 
-	if(current_palette_index == -1) {
+	if(current_palette_index == 0) {
 		char palette_text[49] = "";
 		palette_to_string(palette_text);
 		cfg_set_string(cfg, "General", "palette_cur", palette_text);

--- a/schism/page_palette.c
+++ b/schism/page_palette.c
@@ -118,6 +118,7 @@ static void palette_list_draw(void)
 static int palette_list_handle_key_on_list(struct key_event * k)
 {
 	int new_palette = selected_palette;
+	int load_selected_palette = 0;
 	const int focus_offsets[] = { 0, 1, 1, 2, 3, 3, 4, 4, 5, 6, 6, 7, 7, 8, 9, 9, 10, 10, 11, 12 };
 
 	if(k->mouse == MOUSE_DBLCLICK) {
@@ -125,17 +126,14 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 			return 0;
 		if (k->x < 55 || k->y < 26 || k->y > 40 || k->x > 76) return 0;
 		new_palette = (k->y - 27);
-		selected_palette = new_palette;
-		palette_load_preset(selected_palette);
-		palette_apply();
-		update_thumbbars();
-		status.flags |= NEED_UPDATE;
-		return 1;
+		load_selected_palette = 1;
 	} else if (k->mouse == MOUSE_CLICK) {
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (k->x < 55 || k->y < 26 || k->y > 40 || k->x > 76) return 0;
 		new_palette = (k->y - 27);
+		if(new_palette == selected_palette)
+			load_selected_palette = 1;
 	} else {
 		if (k->state == KEY_RELEASE)
 			return 0;
@@ -221,8 +219,15 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 	else if (new_palette >= (max_palette-1))
 		new_palette = (max_palette-1);
 
-	if (new_palette != selected_palette) {
+	if (new_palette != selected_palette || load_selected_palette) {
 		selected_palette = new_palette;
+
+		if(load_selected_palette) {
+			palette_load_preset(selected_palette);
+			palette_apply();
+			update_thumbbars();
+		}
+
 		status.flags |= NEED_UPDATE;
 	}
 

--- a/schism/page_palette.c
+++ b/schism/page_palette.c
@@ -29,11 +29,13 @@
 
 #include "sdlmain.h"
 
+#define NUM_PALETTES 15
+
 /* --------------------------------------------------------------------- */
 
 static struct widget widgets_palette[51];
 
-static int selected_palette, max_palette = 0;
+static int selected_palette;
 
 /* --------------------------------------------------------------------- */
 /*
@@ -93,7 +95,7 @@ static void palette_list_draw(void)
 
 	draw_fill_chars(55, 26, 76, 40, 0);
 
-	for (n = -1; n < 14; n++) {
+	for (n = 0; n < NUM_PALETTES; n++) {
 		fg = 6;
 		bg = 0;
 		if (focused && n == selected_palette) {
@@ -104,16 +106,12 @@ static void palette_list_draw(void)
 		}
 
 		if(n == current_palette_index)
-			draw_text_len("*", 1, 55, 27 + n, fg, bg);
+			draw_text_len("*", 1, 55, 26 + n, fg, bg);
 		else
-			draw_text_len(" ", 1, 55, 27 + n, fg, bg);
+			draw_text_len(" ", 1, 55, 26 + n, fg, bg);
 
-		if(n == -1)
-			draw_text_len("User Defined", 21, 56, 26, fg, bg);
-		else
-			draw_text_len(palettes[n].name, 21, 56, 27 + n, fg, bg);
+		draw_text_len(palettes[n].name, 21, 56, 26 + n, fg, bg);
 	}
-	max_palette = n;
 }
 
 static int palette_list_handle_key_on_list(struct key_event * k)
@@ -126,13 +124,13 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (k->x < 55 || k->y < 26 || k->y > 40 || k->x > 76) return 0;
-		new_palette = (k->y - 27);
+		new_palette = (k->y - 26);
 		load_selected_palette = 1;
 	} else if (k->mouse == MOUSE_CLICK) {
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (k->x < 55 || k->y < 26 || k->y > 40 || k->x > 76) return 0;
-		new_palette = (k->y - 27);
+		new_palette = (k->y - 26);
 		if(new_palette == selected_palette)
 			load_selected_palette = 1;
 	} else {
@@ -148,7 +146,7 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 	case SDLK_UP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
-		if (--new_palette < -1) {
+		if (--new_palette < 0) {
 			change_focus_to(47);
 			return 1;
 		}
@@ -157,7 +155,7 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		// new_palette++;
-		if (++new_palette > 13) {
+		if (++new_palette >= NUM_PALETTES) {
 			change_focus_to(49);
 			return 1;
 		}
@@ -170,7 +168,7 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 	case SDLK_PAGEUP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
-		if (new_palette == -1) {
+		if (new_palette == 0) {
 			change_focus_to(45);
 			return 1;
 		}
@@ -179,7 +177,7 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 	case SDLK_END:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
-		new_palette = max_palette - 1;
+		new_palette = NUM_PALETTES - 1;
 		break;
 	case SDLK_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
@@ -217,8 +215,8 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 
 	if (new_palette < -1)
 		new_palette = -1;
-	else if (new_palette >= (max_palette-1))
-		new_palette = (max_palette-1);
+	else if (new_palette >= (NUM_PALETTES - 1))
+		new_palette = (NUM_PALETTES - 1);
 
 	if (new_palette != selected_palette || load_selected_palette) {
 		selected_palette = new_palette;
@@ -294,13 +292,15 @@ static int palette_paste_callback(UNUSED int cb, const void *data)
 		return 0;
 	}
 
-	selected_palette = -1;
+	selected_palette = 0;
 	palette_load_preset(selected_palette);
 	palette_apply();
 	update_thumbbars();
 	status.flags |= NEED_UPDATE;
+
 	status_text_flash("Palette pasted");
 	printf("Got palette paste: %s\n", str);
+
 	return 1;
 }
 
@@ -319,7 +319,7 @@ static void update_palette(void)
 		current_palette[n][1] = widgets_palette[3 * n + 1].d.thumbbar.value;
 		current_palette[n][2] = widgets_palette[3 * n + 2].d.thumbbar.value;
 	}
-	selected_palette = current_palette_index = -1;
+	selected_palette = current_palette_index = 0;
 	palette_apply();
 	cfg_save();
 	status.flags |= NEED_UPDATE;

--- a/schism/page_palette.c
+++ b/schism/page_palette.c
@@ -121,20 +121,22 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 	int new_palette = selected_palette;
 	const int focus_offsets[] = { 0, 1, 1, 2, 3, 3, 4, 4, 5, 6, 6, 7, 7, 8, 9, 9, 10, 10, 11, 12 };
 
-	if (k->mouse == MOUSE_CLICK) {
+	if(k->mouse == MOUSE_DBLCLICK) {
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (k->x < 56 || k->y < 27 || k->y > 46 || k->x > 76) return 0;
 		new_palette = (k->y - 28);
-		if (new_palette == selected_palette) {
-			// alright
-			if (selected_palette == -1) return 1;
-			palette_load_preset(selected_palette);
-			palette_apply();
-			update_thumbbars();
-			status.flags |= NEED_UPDATE;
-			return 1;
-		}
+		selected_palette = new_palette;
+		palette_load_preset(selected_palette);
+		palette_apply();
+		update_thumbbars();
+		status.flags |= NEED_UPDATE;
+		return 1;
+	} else if (k->mouse == MOUSE_CLICK) {
+		if (k->state == KEY_PRESS)
+			return 0;
+		if (k->x < 56 || k->y < 27 || k->y > 46 || k->x > 76) return 0;
+		new_palette = (k->y - 28);
 	} else {
 		if (k->state == KEY_RELEASE)
 			return 0;

--- a/schism/page_palette.c
+++ b/schism/page_palette.c
@@ -216,8 +216,11 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 			return 0;
 	}
 
-	if (new_palette < -1) new_palette = -1;
-	else if (new_palette >= (max_palette-1)) new_palette = (max_palette-1);
+	if (new_palette < -1)
+		new_palette = -1;
+	else if (new_palette >= (max_palette-1))
+		new_palette = (max_palette-1);
+
 	if (new_palette != selected_palette) {
 		selected_palette = new_palette;
 		status.flags |= NEED_UPDATE;
@@ -393,7 +396,7 @@ void palette_load_page(struct page *page)
 
 	create_other(widgets_palette + 48, 0, palette_list_handle_key_on_list, NULL, palette_list_draw);
 	widgets_palette[48].x = 56;
-	widgets_palette[48].y = 27;
+	widgets_palette[48].y = 26;
 	widgets_palette[48].width = 20;
 	widgets_palette[48].height = 15;
 

--- a/schism/palettes.c
+++ b/schism/palettes.c
@@ -314,10 +314,30 @@ uint8_t current_palette[16][3] = {
 	/* 14 */ {63, 63, 21},
 	/* 15 */ {63, 63, 63},
 };
+
+uint8_t user_palette[16][3] = {
+	/* Defaults to Camouflage */
+	/*  0 */ { 0,  0,  0},
+	/*  1 */ {31, 22, 17},
+	/*  2 */ {45, 37, 30},
+	/*  3 */ {58, 58, 50},
+	/*  4 */ {44,  0, 21},
+	/*  5 */ {63, 63, 21},
+	/*  6 */ {17, 38, 18},
+	/*  7 */ {19,  3,  6},
+	/*  8 */ { 8, 21,  0},
+	/*  9 */ { 6, 29, 11},
+	/* 10 */ {14, 39, 29},
+	/* 11 */ {55, 58, 56},
+	/* 12 */ {40, 40, 40},
+	/* 13 */ {35,  5, 21},
+	/* 14 */ {22, 16, 15},
+	/* 15 */ {13, 12, 11},
+};
+
 /* this should be changed only with palette_load_preset() (which doesn't call
 palette_apply() automatically, so do that as well) */
-int current_palette_index;
-
+int current_palette_index = -2;
 
 void palette_apply(void)
 {
@@ -342,12 +362,19 @@ void palette_apply(void)
 
 void palette_load_preset(int palette_index)
 {
-	if (palette_index < -1 || palette_index >= NUM_PALETTES)
+	if (palette_index < -1 || palette_index >= NUM_PALETTES || palette_index == current_palette_index)
 		return;
 
+	if (current_palette_index == -1)
+		memcpy(user_palette, current_palette, sizeof(current_palette));
+
 	current_palette_index = palette_index;
-	if (palette_index == -1) return;
-	memcpy(current_palette, palettes[palette_index].colors, sizeof(current_palette));
+
+	if (palette_index == -1) {
+		memcpy(current_palette, user_palette, sizeof(current_palette));
+	} else {
+		memcpy(current_palette, palettes[palette_index].colors, sizeof(current_palette));
+	}
+
 	cfg_save();
 }
-

--- a/schism/palettes.c
+++ b/schism/palettes.c
@@ -348,5 +348,6 @@ void palette_load_preset(int palette_index)
 	current_palette_index = palette_index;
 	if (palette_index == -1) return;
 	memcpy(current_palette, palettes[palette_index].colors, sizeof(current_palette));
+	cfg_save();
 }
 

--- a/schism/palettes.c
+++ b/schism/palettes.c
@@ -66,7 +66,7 @@ struct it_palette palettes[] = {
 		/* 14 */ {18, 16, 15},
 		/* 15 */ {12, 11, 10},
 	}},
-	{"Camouflage", {
+	{"Camouflage (default)", {
 		/*  0 */ { 0,  0,  0},
 		/*  1 */ {31, 22, 17},
 		/*  2 */ {45, 37, 30},

--- a/schism/palettes.c
+++ b/schism/palettes.c
@@ -30,6 +30,24 @@
 /* --------------------------------------------------------------------- */
 
 struct it_palette palettes[] = {
+	{"User Defined", {
+		/*  0 */ { 0,  0,  0},
+		/*  1 */ {31, 22, 17},
+		/*  2 */ {45, 37, 30},
+		/*  3 */ {58, 58, 50},
+		/*  4 */ {44,  0, 21},
+		/*  5 */ {63, 63, 21},
+		/*  6 */ {17, 38, 18},
+		/*  7 */ {19,  3,  6},
+		/*  8 */ { 8, 21,  0},
+		/*  9 */ { 6, 29, 11},
+		/* 10 */ {14, 39, 29},
+		/* 11 */ {55, 58, 56},
+		/* 12 */ {40, 40, 40},
+		/* 13 */ {35,  5, 21},
+		/* 14 */ {22, 16, 15},
+		/* 15 */ {13, 12, 11},
+	}},
 	{"Light Blue", {
 		/*  0 */ { 0,  0,  0},
 		/*  1 */ {10, 25, 45},
@@ -45,24 +63,6 @@ struct it_palette palettes[] = {
 		/* 11 */ {51, 58, 63},
 		/* 12 */ {44, 44, 44},
 		/* 13 */ {21, 63, 21},
-		/* 14 */ {18, 16, 15},
-		/* 15 */ {12, 11, 10},
-	}},
-	{"Gold", { /* hey, this is the ST3 palette! (sort of) */
-		/*  0 */ { 0,  0,  0},
-		/*  1 */ {20, 17, 10},
-		/*  2 */ {41, 36, 21},
-		/*  3 */ {63, 55, 33},
-		/*  4 */ {63, 21, 21},
-		/*  5 */ {18, 53, 18},
-		/*  6 */ {38, 37, 36},
-		/*  7 */ {22, 22, 22},
-		/*  8 */ { 0,  0, 32},
-		/*  9 */ { 0,  0, 42},
-		/* 10 */ {41, 36, 21},
-		/* 11 */ {48, 49, 46},
-		/* 12 */ {44, 44, 44},
-		/* 13 */ {21, 50, 21},
 		/* 14 */ {18, 16, 15},
 		/* 15 */ {12, 11, 10},
 	}},
@@ -83,6 +83,24 @@ struct it_palette palettes[] = {
 		/* 13 */ {35,  5, 21},
 		/* 14 */ {22, 16, 15},
 		/* 15 */ {13, 12, 11},
+	}},
+	{"Gold", { /* hey, this is the ST3 palette! (sort of) */
+		/*  0 */ { 0,  0,  0},
+		/*  1 */ {20, 17, 10},
+		/*  2 */ {41, 36, 21},
+		/*  3 */ {63, 55, 33},
+		/*  4 */ {63, 21, 21},
+		/*  5 */ {18, 53, 18},
+		/*  6 */ {38, 37, 36},
+		/*  7 */ {22, 22, 22},
+		/*  8 */ { 0,  0, 32},
+		/*  9 */ { 0,  0, 42},
+		/* 10 */ {41, 36, 21},
+		/* 11 */ {48, 49, 46},
+		/* 12 */ {44, 44, 44},
+		/* 13 */ {21, 50, 21},
+		/* 14 */ {18, 16, 15},
+		/* 15 */ {12, 11, 10},
 	}},
 	{"Midnight Tracking", {
 		/*  0 */ { 0,  0,  0},
@@ -315,29 +333,31 @@ uint8_t current_palette[16][3] = {
 	/* 15 */ {63, 63, 63},
 };
 
-uint8_t user_palette[16][3] = {
-	/* Defaults to Camouflage */
-	/*  0 */ { 0,  0,  0},
-	/*  1 */ {31, 22, 17},
-	/*  2 */ {45, 37, 30},
-	/*  3 */ {58, 58, 50},
-	/*  4 */ {44,  0, 21},
-	/*  5 */ {63, 63, 21},
-	/*  6 */ {17, 38, 18},
-	/*  7 */ {19,  3,  6},
-	/*  8 */ { 8, 21,  0},
-	/*  9 */ { 6, 29, 11},
-	/* 10 */ {14, 39, 29},
-	/* 11 */ {55, 58, 56},
-	/* 12 */ {40, 40, 40},
-	/* 13 */ {35,  5, 21},
-	/* 14 */ {22, 16, 15},
-	/* 15 */ {13, 12, 11},
-};
+#define USER_PALETTE (&palettes[0].colors)
+
+// uint8_t user_palette[16][3] = {
+// 	/* Defaults to Camouflage */
+// 	/*  0 */ { 0,  0,  0},
+// 	/*  1 */ {31, 22, 17},
+// 	/*  2 */ {45, 37, 30},
+// 	/*  3 */ {58, 58, 50},
+// 	/*  4 */ {44,  0, 21},
+// 	/*  5 */ {63, 63, 21},
+// 	/*  6 */ {17, 38, 18},
+// 	/*  7 */ {19,  3,  6},
+// 	/*  8 */ { 8, 21,  0},
+// 	/*  9 */ { 6, 29, 11},
+// 	/* 10 */ {14, 39, 29},
+// 	/* 11 */ {55, 58, 56},
+// 	/* 12 */ {40, 40, 40},
+// 	/* 13 */ {35,  5, 21},
+// 	/* 14 */ {22, 16, 15},
+// 	/* 15 */ {13, 12, 11},
+// };
 
 /* this should be changed only with palette_load_preset() (which doesn't call
 palette_apply() automatically, so do that as well) */
-int current_palette_index = -2;
+int current_palette_index = -1;
 
 void palette_apply(void)
 {
@@ -362,19 +382,11 @@ void palette_apply(void)
 
 void palette_load_preset(int palette_index)
 {
-	if (palette_index < -1 || palette_index >= NUM_PALETTES || palette_index == current_palette_index)
+	if (palette_index < 0 || palette_index >= NUM_PALETTES)
 		return;
 
-	if (current_palette_index == -1)
-		memcpy(user_palette, current_palette, sizeof(current_palette));
-
 	current_palette_index = palette_index;
-
-	if (palette_index == -1) {
-		memcpy(current_palette, user_palette, sizeof(current_palette));
-	} else {
-		memcpy(current_palette, palettes[palette_index].colors, sizeof(current_palette));
-	}
+	memcpy(current_palette, palettes[palette_index].colors, sizeof(current_palette));
 
 	cfg_save();
 }
@@ -402,6 +414,6 @@ int set_palette_from_string(const char *str_in) {
 		colors[n] = ptr - palette_trans;
 	}
 
-	memcpy(user_palette, colors, sizeof(current_palette));
+	memcpy(USER_PALETTE, colors, sizeof(colors));
 	return 1;
 }

--- a/schism/palettes.c
+++ b/schism/palettes.c
@@ -379,7 +379,7 @@ void palette_load_preset(int palette_index)
 	cfg_save();
 }
 
-static const char palette_trans[64] = ".0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
+static const char palette_trans[65] = ".0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
 
 void palette_to_string(char *str_out) {
 	for (int n = 0; n < 48; n++)
@@ -391,6 +391,10 @@ void palette_to_string(char *str_out) {
 int set_palette_from_string(const char *str_in) {
 	uint8_t colors[48];
 	const char *ptr;
+
+	// Remove bad characters from beginning (spaces etc.).
+	str_in = strpbrk(str_in, palette_trans);
+	if(!str_in) return 0;
 
 	for (int n = 0; n < 48; n++) {
 		if (str_in[n] == '\0' || (ptr = memchr(palette_trans, str_in[n], sizeof(palette_trans))) == NULL)

--- a/schism/palettes.c
+++ b/schism/palettes.c
@@ -378,3 +378,26 @@ void palette_load_preset(int palette_index)
 
 	cfg_save();
 }
+
+static const char palette_trans[64] = ".0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
+
+void palette_to_string(char *str_out) {
+	for (int n = 0; n < 48; n++)
+		str_out[n] = palette_trans[current_palette[n / 3][n % 3]];
+
+	str_out[48] = '\0';
+}
+
+int set_palette_from_string(const char *str_in) {
+	uint8_t colors[48];
+	const char *ptr;
+
+	for (int n = 0; n < 48; n++) {
+		if (str_in[n] == '\0' || (ptr = memchr(palette_trans, str_in[n], sizeof(palette_trans))) == NULL)
+			return 0;
+		colors[n] = ptr - palette_trans;
+	}
+
+	memcpy(user_palette, colors, sizeof(current_palette));
+	return 1;
+}


### PR DESCRIPTION
Fixed some issues and added improvements to color palettes (Ctrl+F12 screen).

* The active palette is now shown with an asterisk next to the name.
* Default palette is clearly marked as default.
* User defined palette is now saved separately so it won't be lost when switching palette.
* Any palette can be copied to the system clipboard.
* You can paste from system clipboard into the user defined palette. This makes it easier to share palettes with other people.
* Shift-tabbing is fixed for some items on the left side.
