### PR TITLE
build: workaround pedantic requirements

### DIFF
--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -1507,6 +1507,7 @@ fail:
 	const char* err = SDL_GetError();
 	if (err) fprintf(stderr, "%s\n", err);
 	schism_exit(1);
+	return 0;
 }
 
 // Set up audio_buffer, reset the sample count, and kick off the mixer


### PR DESCRIPTION
Yeah yeah, schism_exit isn't supposed to return, but short of adding a non-portable `__attribute__((noreturn))`, let's just add a return to make the compiler happy.

```
schism/audio_playback.c: In function "_audio_init_head": schism/audio_playback.c:1510:1: error: control reaches end of non-void function [-Werror=return-type]
 1510 | }
```