### PR TITLE
Fix for the user defined colors not getting saved bug

### DIFF
--- a/schism/page_palette.c
+++ b/schism/page_palette.c
@@ -343,7 +343,7 @@ static void update_palette(void)
 		current_palette[n][2] = widgets_palette[3 * n + 2].d.thumbbar.value;
 	}
 	selected_palette = current_palette_index = 0;
-	memcpy(palettes[selected_palette].colors, current_palette, sizeof(current_palette));
+	memcpy(palettes[0].colors, current_palette, sizeof(current_palette));
 	palette_apply();
 	cfg_save();
 	status.flags |= NEED_UPDATE;

--- a/schism/page_palette.c
+++ b/schism/page_palette.c
@@ -343,6 +343,7 @@ static void update_palette(void)
 		current_palette[n][2] = widgets_palette[3 * n + 2].d.thumbbar.value;
 	}
 	selected_palette = current_palette_index = 0;
+	memcpy(palettes[selected_palette].colors, current_palette, sizeof(current_palette));
 	palette_apply();
 	cfg_save();
 	status.flags |= NEED_UPDATE;


### PR DESCRIPTION
This fixes a bug which prevents user defined colors from being saved to the "User Defined" palette or copied to clipboard.

Behavior before the fix:
https://github.com/user-attachments/assets/937db1ad-edbc-4dd4-806b-66b88a1c4358

After:
https://github.com/user-attachments/assets/3c469ed3-c972-4411-8ddb-67c6a22f0859

