### PR TITLE
Fix for exit prompt stacking

### DIFF
--- a/schism/main.c
+++ b/schism/main.c
@@ -612,8 +612,7 @@ static void event_loop(void)
 				}
 				break;
 			case SDL_QUIT:
-				if (status.dialog_type == DIALOG_NONE)
-					show_exit_prompt();
+				show_exit_prompt();
 				break;
 			case SDL_WINDOWEVENT:
 				/* reset this... */

--- a/schism/main.c
+++ b/schism/main.c
@@ -612,7 +612,8 @@ static void event_loop(void)
 				}
 				break;
 			case SDL_QUIT:
-				show_exit_prompt();
+				if (status.dialog_type == DIALOG_NONE)
+					show_exit_prompt();
 				break;
 			case SDL_WINDOWEVENT:
 				/* reset this... */

--- a/schism/page.c
+++ b/schism/page.c
@@ -1763,7 +1763,8 @@ void show_exit_prompt(void)
 			dialog_destroy_all();
 			set_page(fontedit_return_page);
 		}
-	} else {
+	} else if (status.dialog_type != DIALOG_OK_CANCEL) {
+		/* don't draw an exit prompt on top of an existing one */
 		dialog_create(DIALOG_OK_CANCEL,
 			      ((status.flags & CLASSIC_MODE)
 			       ? "Exit Impulse Tracker?"


### PR DESCRIPTION
Fixes #487

It looks like the code handling exiting via Ctrl+q already has a check for presence of other dialogs 
https://github.com/schismtracker/schismtracker/blob/e444afa0da227c4b114768a779e7c4cc3992a6d0/schism/page.c#L558C2-L560C13
so i added a similar check to the handling of the `SDL_QUIT` event.

Maybe the check should be moved inside the  `show_exit_prompt()` function since it already checks the current page status, I'm not sure.