### PR TITLE
Mouse cursor type switching

### DIFF
--- a/include/video.h
+++ b/include/video.h
@@ -39,13 +39,18 @@ void video_resize(unsigned int width, unsigned int height);
 void video_fullscreen(int new_fs_flag);
 void video_translate(int vx, int vy, unsigned int *x, unsigned int *y);
 void video_blit(void);
-void video_mousecursor(int z);
-int video_mousecursor_visible(void);
-enum {
- CURSOR_ARROW,
- CURSOR_CROSSHAIR,
+
+/* cursor-specific stuff */
+enum video_mousecursor_shape {
+	CURSOR_SHAPE_ARROW,
+	CURSOR_SHAPE_CROSSHAIR,
 };
-void video_set_mousecursor_type(int);
+
+void video_mousecursor(int z); /* takes in the MOUSE_* enum from it.h (why is it there?) */
+int video_mousecursor_visible(void);
+void video_set_mousecursor_shape(enum video_mousecursor_shape shape);
+
+/* getters, will sometimes poll SDL */
 
 int video_is_fullscreen(void);
 int video_is_wm_available(void);
@@ -53,7 +58,7 @@ int video_is_focused(void);
 int video_is_visible(void);
 int video_width(void);
 int video_height(void);
-SDL_Window * video_window(void);
+SDL_Window *video_window(void);
 
 void video_get_logical_coordinates(int x, int y, int *trans_x, int *trans_y);
 

--- a/include/video.h
+++ b/include/video.h
@@ -41,6 +41,11 @@ void video_translate(int vx, int vy, unsigned int *x, unsigned int *y);
 void video_blit(void);
 void video_mousecursor(int z);
 int video_mousecursor_visible(void);
+enum {
+ CURSOR_ARROW,
+ CURSOR_CROSSHAIR,
+};
+void video_set_mousecursor_type(int);
 
 int video_is_fullscreen(void);
 int video_is_wm_available(void);

--- a/schism/page_instruments.c
+++ b/schism/page_instruments.c
@@ -1557,7 +1557,7 @@ static int _env_handle_mouse(struct key_event *k, song_envelope_t *env, int *cur
 	if (k->state == KEY_RELEASE) {
 		/* mouse release */
 		if (envelope_mouse_edit) {
-			video_set_mousecursor_type(CURSOR_ARROW);
+			video_set_mousecursor_shape(CURSOR_SHAPE_ARROW);
 			if (current_node && *current_node) {
 				for (i = 0; i < env->nodes-1; i++) {
 					if (*current_node == i) continue;
@@ -1583,7 +1583,7 @@ static int _env_handle_mouse(struct key_event *k, song_envelope_t *env, int *cur
 		max_ticks *= 2;
 
 	if (envelope_mouse_edit) {
-		video_set_mousecursor_type(CURSOR_CROSSHAIR);
+		video_set_mousecursor_shape(CURSOR_SHAPE_CROSSHAIR);
 		if (k->fx < 259)
 			x = 0;
 		else

--- a/schism/page_instruments.c
+++ b/schism/page_instruments.c
@@ -1557,6 +1557,7 @@ static int _env_handle_mouse(struct key_event *k, song_envelope_t *env, int *cur
 	if (k->state == KEY_RELEASE) {
 		/* mouse release */
 		if (envelope_mouse_edit) {
+			video_set_mousecursor_type(CURSOR_ARROW);
 			if (current_node && *current_node) {
 				for (i = 0; i < env->nodes-1; i++) {
 					if (*current_node == i) continue;
@@ -1582,6 +1583,7 @@ static int _env_handle_mouse(struct key_event *k, song_envelope_t *env, int *cur
 		max_ticks *= 2;
 
 	if (envelope_mouse_edit) {
+		video_set_mousecursor_type(CURSOR_CROSSHAIR);
 		if (k->fx < 259)
 			x = 0;
 		else

--- a/schism/video.c
+++ b/schism/video.c
@@ -414,7 +414,8 @@ static inline void make_mouseline(unsigned int x, unsigned int v, unsigned int y
 
 	if (video.mouse.visible != MOUSE_EMULATED
 		|| !video_is_focused()
-		|| y < video.mouse.y - cursor->center_y
+		|| (video.mouse.y >= cursor->center_y && y < video.mouse.y - cursor->center_y)
+		|| y < cursor->center_y
 		|| y >= video.mouse.y + cursor->height - cursor->center_y) {
 		return;
 	}

--- a/schism/video.c
+++ b/schism/video.c
@@ -46,47 +46,100 @@
 #endif
 
 /* leeto drawing skills */
-#define MOUSE_HEIGHT    16
-#define MOUSE_WIDTH     10
-static const unsigned int _mouse_pointer[] = {
-	/* ........ ........ */  0x0000,
-	/* .x...... ........ */  0x4000,
-	/* .xx..... ........ */  0x6000,
-	/* .xxx.... ........ */  0x7000,
-	/* .xxxx... ........ */  0x7800,
-	/* .xxxxx.. ........ */  0x7c00,
-	/* .xxxxxx. ........ */  0x7e00,
-	/* .xxxxxxx ........ */  0x7f00,
-	/* .xxxxxxx x....... */  0x7f80,
-	/* .xxxxxxx ........ */  0x7f00,
-	/* .xxxxx.. ........ */  0x7c00,
-	/* .x...xx. ........ */  0x4600,
-	/* .....xx. ........ */  0x0600,
-	/* ......xx ........ */  0x0300,
-	/* ......xx ........ */  0x0300,
-	/* ........ ........ */  0x0000,
-	0,0
-};
-
-static const unsigned int _mouse_pointer_mask[] = {
-	/* xx.. .... .... .... */  0xc000,
-	/* xxx. .... .... .... */  0xe000,
-	/* xxxx .... .... .... */  0xf000,
-	/* xxxx x... .... .... */  0xf800,
-	/* xxxx xx.. .... .... */  0xfc00,
-	/* xxxx xxx. .... .... */  0xfe00,
-	/* xxxx xxxx .... .... */  0xff00,
-	/* xxxx xxxx x... .... */  0xff80,
-	/* xxxx xxxx xx.. .... */  0xffc0,
-	/* xxxx xxxx x... .... */  0xff80,
-	/* xxxx xxx. .... .... */  0xfe00,
-	/* xxxx xxxx .... .... */  0xff00,
-	/* .x.. xxxx .... .... */  0x4f00,
-	/* .... .xxx x... .... */  0x0780,
-	/* .... .xxx x... .... */  0x0780,
-	/* .... ..xx .... .... */  0x0300,
-	0,0
-};
+static struct mouse_cursor {
+	unsigned int pointer[18];
+	unsigned int mask[18];
+	unsigned int height, width;
+	unsigned int center_x, center_y; //which point of the pointer does actually point
+}
+	cursor_arrow = {
+		.pointer = {    /* 0 -|-------------> */
+			0x0000, /* | ................ */
+			0x4000, /* - .x.............. */
+			0x6000, /* | .xx............. */
+			0x7000, /* | .xxx............ */
+			0x7800, /* | .xxxx........... */
+			0x7c00, /* | .xxxxx.......... */
+			0x7e00, /* | .xxxxxx......... */
+			0x7f00, /* | .xxxxxxx........ */
+			0x7f80, /* | .xxxxxxxx....... */
+			0x7f00, /* | .xxxxxxx........ */
+			0x7c00, /* | .xxxxx.......... */
+			0x4600, /* | .x...xx......... */
+			0x0600, /* | .....xx......... */
+			0x0300, /* | ......xx........ */
+			0x0300, /* | ......xx........ */
+			0x0000, /* v ................ */
+			0,0
+			},
+		.mask = {       /* 0 -|-------------> */
+			0xc000, /* | xx.............. */
+			0xe000, /* - xxx............. */
+			0xf000, /* | xxxx............ */
+			0xf800, /* | xxxxx........... */
+			0xfc00, /* | xxxxxx.......... */
+			0xfe00, /* | xxxxxxx......... */
+			0xff00, /* | xxxxxxxx........ */
+			0xff80, /* | xxxxxxxxx....... */
+			0xffc0, /* | xxxxxxxxxx...... */
+			0xff80, /* | xxxxxxxxx....... */
+			0xfe00, /* | xxxxxxx......... */
+			0xff00, /* | xxxxxxxx........ */
+			0x4f00, /* | .x..xxxx........ */
+			0x0780, /* | .....xxxx....... */
+			0x0780, /* | .....xxxx....... */
+			0x0300, /* v ......xx........ */
+			0,0
+			},
+		.height = 16,
+		.width = 10,
+		.center_x = 1,
+		.center_y = 1,
+	},
+	cursor_crosshair = {
+		.pointer = {  /* 0 ---|---> */
+			0x00, /* | ........ */
+			0x10, /* | ...x.... */
+			0x7c, /* - .xxxxx.. */
+			0x10, /* | ...x.... */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* v ........ */
+			0,0
+			},
+		.mask = {     /* 0 ---|---> */
+			0x10, /* | ...x.... */
+			0x7c, /* | .xxxxx.. */
+			0xfe, /* - xxxxxxx. */
+			0x7c, /* | .xxxxx.. */
+			0x10, /* | ...x.... */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* | ........ */
+			0x00, /* v ........ */
+			0,0
+			},
+		.height = 5,
+		.width = 7,
+		.center_x = 3,
+		.center_y = 2,
+	};
 
 struct video_cf {
 	SDL_Window *window;
@@ -98,6 +151,7 @@ struct video_cf {
 
 	struct {
 		unsigned int x, y;
+		int type;
 		int visible;
 	} mouse;
 
@@ -121,7 +175,8 @@ struct video_cf {
 /* don't stomp defaults */
 static struct video_cf video = {
 	.mouse = {
-		.visible = MOUSE_EMULATED
+		.visible = MOUSE_EMULATED,
+		.type = CURSOR_ARROW
 	}
 };
 
@@ -343,23 +398,35 @@ static inline void make_mouseline(unsigned int x, unsigned int v, unsigned int y
 {
 	unsigned int z;
 	unsigned int zm;
-	unsigned int c = ceil(MOUSE_WIDTH / 8.0); //cursor width in symbols
+	unsigned int c ; //cursor width in symbols
+	struct mouse_cursor cursor;
 
 	memset(mouseline, 0, 80*sizeof(unsigned int));
 	memset(mouseline_mask, 0, 80*sizeof(unsigned int));
+
+	switch (video.mouse.type) {
+		case CURSOR_ARROW : cursor = cursor_arrow; break;
+		case CURSOR_CROSSHAIR : cursor = cursor_crosshair; break;
+	}
+
 	if (video.mouse.visible != MOUSE_EMULATED
 		|| !video_is_focused()
 		|| y < video.mouse.y
-		|| y >= video.mouse.y+MOUSE_HEIGHT) {
+		|| y >= video.mouse.y+cursor.height) {
 		return;
 	}
 
-	z = _mouse_pointer[ y - video.mouse.y ];
-	zm = _mouse_pointer_mask[ y - video.mouse.y ];
+	z = cursor.pointer[ y - video.mouse.y ];
+	zm = cursor.mask[ y - video.mouse.y ];
+	c = ceil(cursor.width / 8.0);
 
-	for (unsigned int i = 0; i < c && x + i < 80; i++) {
-		mouseline[x+i] = (z >> (v+8*(c-i-1))) & 0xff;
-		mouseline_mask[x+i] = (zm >> (v+8*(c-i-1))) & 0xff;
+	mouseline[x] = (z >> (v + 8*(c-1))) & 0xff;
+	mouseline_mask[x] = (zm >> (v + 8 * (c-1))) & 0xff;
+	for (unsigned int i = 0; i < c && x + i < 79; i++) {
+		mouseline[x+i+1] = (z << (8 - v + 8 * i));
+		mouseline[x+i+1] >>= 8*(c-1);
+		mouseline_mask[x+i+1] = (zm << (8 - v + 8 * i));
+		mouseline_mask[x+i+1] >>= 8*(c-1);
 	}
 }
 
@@ -405,6 +472,10 @@ int video_mousecursor_visible(void)
 	return video.mouse.visible;
 }
 
+void video_set_mousecursor_type(int type)
+{
+	video.mouse.type = type;
+}
 void video_mousecursor(int vis)
 {
 	const char *state[] = {

--- a/schism/video.c
+++ b/schism/video.c
@@ -46,100 +46,104 @@
 #endif
 
 /* leeto drawing skills */
-static struct mouse_cursor {
+struct mouse_cursor {
 	unsigned int pointer[18];
 	unsigned int mask[18];
 	unsigned int height, width;
-	unsigned int center_x, center_y; //which point of the pointer does actually point
-}
-	cursor_arrow = {
-		.pointer = {    /*   -|-------------> */
-			0x0000, /* | ................ */
-			0x4000, /* - .x.............. */
-			0x6000, /* | .xx............. */
-			0x7000, /* | .xxx............ */
-			0x7800, /* | .xxxx........... */
-			0x7c00, /* | .xxxxx.......... */
-			0x7e00, /* | .xxxxxx......... */
-			0x7f00, /* | .xxxxxxx........ */
-			0x7f80, /* | .xxxxxxxx....... */
-			0x7f00, /* | .xxxxxxx........ */
-			0x7c00, /* | .xxxxx.......... */
-			0x4600, /* | .x...xx......... */
-			0x0600, /* | .....xx......... */
-			0x0300, /* | ......xx........ */
-			0x0300, /* | ......xx........ */
-			0x0000, /* v ................ */
+	unsigned int center_x, center_y; /* which point of the pointer does actually point */
+};
+
+/* ex. cursors[CURSOR_SHAPE_ARROW] */
+struct mouse_cursor cursors[] = {
+	[CURSOR_SHAPE_ARROW] = {
+		.pointer = { /* / -|-------------> */
+			0x0000,  /* | ................ */
+			0x4000,  /* - .x.............. */
+			0x6000,  /* | .xx............. */
+			0x7000,  /* | .xxx............ */
+			0x7800,  /* | .xxxx........... */
+			0x7c00,  /* | .xxxxx.......... */
+			0x7e00,  /* | .xxxxxx......... */
+			0x7f00,  /* | .xxxxxxx........ */
+			0x7f80,  /* | .xxxxxxxx....... */
+			0x7f00,  /* | .xxxxxxx........ */
+			0x7c00,  /* | .xxxxx.......... */
+			0x4600,  /* | .x...xx......... */
+			0x0600,  /* | .....xx......... */
+			0x0300,  /* | ......xx........ */
+			0x0300,  /* | ......xx........ */
+			0x0000,  /* v ................ */
 			0,0
-			},
-		.mask = {       /*   -|-------------> */
-			0xc000, /* | xx.............. */
-			0xe000, /* - xxx............. */
-			0xf000, /* | xxxx............ */
-			0xf800, /* | xxxxx........... */
-			0xfc00, /* | xxxxxx.......... */
-			0xfe00, /* | xxxxxxx......... */
-			0xff00, /* | xxxxxxxx........ */
-			0xff80, /* | xxxxxxxxx....... */
-			0xffc0, /* | xxxxxxxxxx...... */
-			0xff80, /* | xxxxxxxxx....... */
-			0xfe00, /* | xxxxxxx......... */
-			0xff00, /* | xxxxxxxx........ */
-			0x4f00, /* | .x..xxxx........ */
-			0x0780, /* | .....xxxx....... */
-			0x0780, /* | .....xxxx....... */
-			0x0300, /* v ......xx........ */
+		},
+		.mask = {    /* / -|-------------> */
+			0xc000,  /* | xx.............. */
+			0xe000,  /* - xxx............. */
+			0xf000,  /* | xxxx............ */
+			0xf800,  /* | xxxxx........... */
+			0xfc00,  /* | xxxxxx.......... */
+			0xfe00,  /* | xxxxxxx......... */
+			0xff00,  /* | xxxxxxxx........ */
+			0xff80,  /* | xxxxxxxxx....... */
+			0xffc0,  /* | xxxxxxxxxx...... */
+			0xff80,  /* | xxxxxxxxx....... */
+			0xfe00,  /* | xxxxxxx......... */
+			0xff00,  /* | xxxxxxxx........ */
+			0x4f00,  /* | .x..xxxx........ */
+			0x0780,  /* | .....xxxx....... */
+			0x0780,  /* | .....xxxx....... */
+			0x0300,  /* v ......xx........ */
 			0,0
-			},
+		},
 		.height = 16,
 		.width = 10,
 		.center_x = 1,
 		.center_y = 1,
 	},
-	cursor_crosshair = {
-		.pointer = {  /*   ---|---> */
-			0x00, /* | ........ */
-			0x10, /* | ...x.... */
-			0x7c, /* - .xxxxx.. */
-			0x10, /* | ...x.... */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* v ........ */
+	[CURSOR_SHAPE_CROSSHAIR] = {
+		.pointer = {  /* / ---|---> */
+			0x00,     /* | ........ */
+			0x10,     /* | ...x.... */
+			0x7c,     /* - .xxxxx.. */
+			0x10,     /* | ...x.... */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* v ........ */
 			0,0
-			},
-		.mask = {     /*   ---|---> */
-			0x10, /* | ...x.... */
-			0x7c, /* | .xxxxx.. */
-			0xfe, /* - xxxxxxx. */
-			0x7c, /* | .xxxxx.. */
-			0x10, /* | ...x.... */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* | ........ */
-			0x00, /* v ........ */
+		},
+		.mask = {     /* / ---|---> */
+			0x10,     /* | ...x.... */
+			0x7c,     /* | .xxxxx.. */
+			0xfe,     /* - xxxxxxx. */
+			0x7c,     /* | .xxxxx.. */
+			0x10,     /* | ...x.... */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* | ........ */
+			0x00,     /* v ........ */
 			0,0
-			},
+		},
 		.height = 5,
 		.width = 7,
 		.center_x = 3,
 		.center_y = 2,
-	};
+	},
+};
 
 struct video_cf {
 	SDL_Window *window;
@@ -151,7 +155,7 @@ struct video_cf {
 
 	struct {
 		unsigned int x, y;
-		int type;
+		enum video_mousecursor_shape shape;
 		int visible;
 	} mouse;
 
@@ -176,7 +180,7 @@ struct video_cf {
 static struct video_cf video = {
 	.mouse = {
 		.visible = MOUSE_EMULATED,
-		.type = CURSOR_ARROW
+		.shape = CURSOR_SHAPE_ARROW
 	}
 };
 
@@ -200,7 +204,7 @@ void video_update(void)
 	SDL_GetWindowSize(video.window, &video.width, &video.height);
 }
 
-const char * video_driver_name(void)
+const char *video_driver_name(void)
 {
 	return SDL_GetCurrentVideoDriver();
 }
@@ -233,7 +237,7 @@ void video_shutdown(void)
 	SDL_DestroyTexture(video.texture);
 }
 
-void video_setup(const char* quality)
+void video_setup(const char *quality)
 {
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, quality);
 }
@@ -398,19 +402,14 @@ static inline void make_mouseline(unsigned int x, unsigned int v, unsigned int y
 {
 	unsigned int z;
 	unsigned int zm;
-	unsigned int swidth; //cursor width in symbols
+	unsigned int swidth; // cursor width in symbols
 	unsigned int scenter;
 	unsigned int centeroffset;
 	unsigned int temp;
-	struct mouse_cursor *cursor;
+	struct mouse_cursor *cursor = &cursors[video.mouse.shape];
 
-	switch (video.mouse.type) {
-		case CURSOR_ARROW : cursor = &cursor_arrow; break;
-		case CURSOR_CROSSHAIR : cursor = &cursor_crosshair; break;
-	}
-
-	memset(mouseline, 0, 80*sizeof(unsigned int));
-	memset(mouseline_mask, 0, 80*sizeof(unsigned int));
+	memset(mouseline, 0, 80 * sizeof(unsigned int));
+	memset(mouseline_mask, 0, 80 * sizeof(unsigned int));
 
 	if (video.mouse.visible != MOUSE_EMULATED
 		|| !video_is_focused()
@@ -498,10 +497,11 @@ int video_mousecursor_visible(void)
 	return video.mouse.visible;
 }
 
-void video_set_mousecursor_type(int type)
+void video_set_mousecursor_shape(enum video_mousecursor_shape shape)
 {
-	video.mouse.type = type;
+	video.mouse.shape = shape;
 }
+
 void video_mousecursor(int vis)
 {
 	const char *state[] = {

--- a/schism/video.c
+++ b/schism/video.c
@@ -53,7 +53,7 @@ static struct mouse_cursor {
 	unsigned int center_x, center_y; //which point of the pointer does actually point
 }
 	cursor_arrow = {
-		.pointer = {    /* 0 -|-------------> */
+		.pointer = {    /*   -|-------------> */
 			0x0000, /* | ................ */
 			0x4000, /* - .x.............. */
 			0x6000, /* | .xx............. */
@@ -72,7 +72,7 @@ static struct mouse_cursor {
 			0x0000, /* v ................ */
 			0,0
 			},
-		.mask = {       /* 0 -|-------------> */
+		.mask = {       /*   -|-------------> */
 			0xc000, /* | xx.............. */
 			0xe000, /* - xxx............. */
 			0xf000, /* | xxxx............ */
@@ -97,7 +97,7 @@ static struct mouse_cursor {
 		.center_y = 1,
 	},
 	cursor_crosshair = {
-		.pointer = {  /* 0 ---|---> */
+		.pointer = {  /*   ---|---> */
 			0x00, /* | ........ */
 			0x10, /* | ...x.... */
 			0x7c, /* - .xxxxx.. */
@@ -116,7 +116,7 @@ static struct mouse_cursor {
 			0x00, /* v ........ */
 			0,0
 			},
-		.mask = {     /* 0 ---|---> */
+		.mask = {     /*   ---|---> */
 			0x10, /* | ...x.... */
 			0x7c, /* | .xxxxx.. */
 			0xfe, /* - xxxxxxx. */


### PR DESCRIPTION
Resolves #484

- Implemented cursor type switching.
- Reworked cursor drawing loop to make cursor "sprites" properly aligned to mouse coordinates.
- Cursor switches from an arrow to a crosshair while editing envelopes on the instruments page to mimic IT behavior.

 

https://github.com/user-attachments/assets/db646902-389c-4fb0-8edd-c3f45f4a38ba

