### PR TITLE
Do not fill DMOZ directory for save dialog when initializing Schism Tracker

### DIFF
--- a/schism/config.c
+++ b/schism/config.c
@@ -31,6 +31,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <SDL_filesystem.h>
 
 #include "config-parser.h"
 #include "dmoz.h"
@@ -69,15 +70,15 @@ void cfg_init_dir(void)
 #if defined(__amigaos4__)
 	strcpy(cfg_dir_dotschism, "PROGDIR:");
 #else
-	char *cur_dir, *portable_file;
+	char *app_dir, *portable_file;
 
-	cur_dir = get_current_directory();
-	portable_file = dmoz_path_concat(cur_dir, "portable.txt");
+	app_dir = SDL_GetBasePath();
+	portable_file = dmoz_path_concat(app_dir, "portable.txt");
 
 	if(is_file(portable_file)) {
 		printf("In portable mode.\n");
 
-		strncpy(cfg_dir_dotschism, cur_dir, PATH_MAX);
+		strncpy(cfg_dir_dotschism, app_dir, PATH_MAX);
 		cfg_dir_dotschism[PATH_MAX] = 0;
 	} else {
 		char *dot_dir, *ptr;
@@ -99,7 +100,7 @@ void cfg_init_dir(void)
 		}
 	}
 
-	free(cur_dir);
+	SDL_free(app_dir);
 	free(portable_file);
 #endif
 }

--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -1119,7 +1119,6 @@ void save_module_load_page(struct page *page, int do_export)
 	current_file = current_dir = 0;
 	dir_list_reposition();
 	file_list_reposition();
-	read_directory();
 
 	page->draw_const = save_module_draw_const;
 	page->set_page = save_module_set_page;


### PR DESCRIPTION
This should fix #510 but I could only halfway verify it because I couldn't get MF support to compile (but I could at least see that Schism Tracker no longer performs the directory scan mentioned in that issue).

I didn't test it much but the save dialog still lists files (its `set_page` callback calls `update_directory`, which in return calls `change_dir` with the correct directory to display), so this should fix my problem without any side effects.

Edit: For good measure, this fixes #512 as well.