### PR TITLE
build: change python to perl in error message

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -168,7 +168,7 @@ if HAVE_PERL
 	${MKDIR_P} auto
 	$(PERL) $(srcdir)/scripts/genhelp.pl $(srcdir) $(helptexts) >$@
 else
-	@echo "*** python is required to regenerate $(@) ***"; exit 1;
+	@echo "*** perl is required to regenerate $(@) ***"; exit 1;
 endif
 
 if USE_ALSA


### PR DESCRIPTION
Python was removed in favor of perl in e4d1cffbe9b402091dee46ba53349fe948e2ca00