### PR TITLE
Fixed resizing sample with interpolation.

### DIFF
--- a/player/mixer.c
+++ b/player/mixer.c
@@ -483,7 +483,7 @@ DEFINE_MIX_INTERFACE(16)
 	BEGIN_RESAMPLE_INTERFACE(ResampleMono##bits##BitFirFilter, int##bits##_t, 1) \
 		SNDMIX_GETMONOVOLFIRFILTER(bits) \
 		vol  >>= (WFIR_16SHIFT-WFIR_##bits##SHIFT);  /* This is used to compensate, since the code assumes that it always outputs to 16bits */ \
-		vol = CLAMP(vol, INT##bits##_MIN, INT ##bits##_MAX); \
+		vol = CLAMP(vol, INT##bits##_MIN, INT##bits##_MAX); \
 	END_RESAMPLE_INTERFACE_MONO()
 
 #define DEFINE_STEREO_RESAMPLE_INTERFACE(bits) \

--- a/player/mixer.c
+++ b/player/mixer.c
@@ -483,7 +483,7 @@ DEFINE_MIX_INTERFACE(16)
 	BEGIN_RESAMPLE_INTERFACE(ResampleMono##bits##BitFirFilter, int##bits##_t, 1) \
 		SNDMIX_GETMONOVOLFIRFILTER(bits) \
 		vol  >>= (WFIR_16SHIFT-WFIR_##bits##SHIFT);  /* This is used to compensate, since the code assumes that it always outputs to 16bits */ \
-		vol = CLAMP(vol, INT ## bits ## _MIN, INT ## bits ## _MIN); \
+		vol = CLAMP(vol, INT##bits##_MIN, INT ##bits##_MAX); \
 	END_RESAMPLE_INTERFACE_MONO()
 
 #define DEFINE_STEREO_RESAMPLE_INTERFACE(bits) \
@@ -491,8 +491,8 @@ DEFINE_MIX_INTERFACE(16)
 		SNDMIX_GETSTEREOVOLFIRFILTER(bits) \
 		vol_l  >>= (WFIR_16SHIFT-WFIR_##bits##SHIFT);  /* This is used to compensate, since the code assumes that it always outputs to 16bits */ \
 		vol_r  >>= (WFIR_16SHIFT-WFIR_##bits##SHIFT);  /* This is used to compensate, since the code assumes that it always outputs to 16bits */ \
-		vol_l = CLAMP(vol_l, INT ## bits ## _MIN, INT ## bits ## _MIN); \
-		vol_r = CLAMP(vol_r, INT ## bits ## _MIN, INT ## bits ## _MIN); \
+		vol_l = CLAMP(vol_l, INT##bits##_MIN, INT##bits##_MAX); \
+		vol_r = CLAMP(vol_r, INT##bits##_MIN, INT##bits##_MAX); \
 	END_RESAMPLE_INTERFACE_STEREO()
 
 DEFINE_MONO_RESAMPLE_INTERFACE(8)


### PR DESCRIPTION
It fixed #533.

I found this bug and cheked this issue myself. I found the typo in resize with aa code at this 2c64682 commit.

I tested it on linux environment.
I couldn't find the contribution guidelines, so I made a fix on my own and submitted a pull request. I apologize for that. Also, I’m not very good at English, so I ask for your understanding.