### PR TITLE
Mention pkg-config in building_on_osx.md

### DIFF
--- a/docs/building_on_osx.md
+++ b/docs/building_on_osx.md
@@ -8,12 +8,12 @@ in the following command:
 After Homebrew has been successfully installed, you need to install `automake`,
 `autoconf`, `sdl2` and `git`.
 
-    brew install automake autoconf sdl2 git perl pkgconf
+    brew install automake autoconf sdl2 git perl pkg-config
 
 Alternatively, if you have MacPorts installed, you can use this command
 instead:
 
-    sudo port install automake autoconf libtool libsdl2 git perl5 pkgconf
+    sudo port install automake autoconf libtool libsdl2 git perl5 pkg-config
 
 For FLAC sample loading support, you will also need development versions of the
 `flac` and `libogg` libraries.


### PR DESCRIPTION
Wouldn't configure on my system without png-config. Possibly this can be solved by adjusting paths, but.. using png-config just worked..