### PR TITLE
build: resolve -Wreturn-type warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -452,6 +452,10 @@ if test x$ADD_WARN \!= xno; then
 	CFLAGS="$ADD_WARN $CFLAGS"
 fi
 
+dnl Unlike a grand -Werror, this one could be rather important:
+dnl functions returning random values are no good under any circumstances.
+AS_IF([test ${ac_cv_c_compiler_gnu+y}], [CFLAGS="$CFLAGS -Werror=return-type"])
+
 if test x$ADD_PROFILING \!= xno || test x$ADD_DEBUG \!= xno; then
 	CFLAGS="$CFLAGS -g -O0"
 	OBJCFLAGS="$OBJCFLAGS -g -O0"

--- a/fmt/iti.c
+++ b/fmt/iti.c
@@ -154,6 +154,7 @@ int load_it_instrument_old(song_instrument_t *instrument, slurp_t *fp)
 		instrument->vol_env.ticks[n] = node;
 		instrument->vol_env.values[n] = ihdr.nodes[2 * n + 1];
 	}
+	return 1;
 }
 
 int load_it_instrument(song_instrument_t *instrument, slurp_t *fp)
@@ -204,6 +205,7 @@ int load_it_instrument(song_instrument_t *instrument, slurp_t *fp)
 	instrument->flags |= load_it_envelope(&instrument->vol_env, &ihdr.volenv, 0, 0);
 	instrument->flags |= load_it_envelope(&instrument->pan_env, &ihdr.panenv, 1, 32);
 	instrument->flags |= load_it_envelope(&instrument->pitch_env, &ihdr.pitchenv, 2, 32);
+	return 1;
 }
 
 int fmt_iti_load_instrument(slurp_t *fp, int slot)

--- a/schism/controller.c
+++ b/schism/controller.c
@@ -40,7 +40,7 @@ struct controller_node {
 
 static struct controller_node *game_controller_list = NULL;
 
-static int game_controller_insert(SDL_GameController *controller)
+static void game_controller_insert(SDL_GameController *controller)
 {
 	struct controller_node *node = mem_alloc(sizeof(*node));
 
@@ -109,6 +109,7 @@ int controller_quit(void)
 {
 	game_controller_free();
 	SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+	return 1;
 }
 
 int controller_sdlevent(SDL_Event *event)


### PR DESCRIPTION
Functions without return can produce unpredictable behavior, and it goes without saying that is bad.
openSUSE has added -Werror=return-type distro-wide, so it is perhaps fair to do the same here.

```
fmt/iti.c: In function ‘load_it_instrument_old’:
fmt/iti.c:157:1: error: control reaches end of non-void function [-Werror=return-type]
  157 | }
fmt/iti.c: In function ‘load_it_instrument’:
fmt/iti.c:207:1: error: control reaches end of non-void function [-Werror=return-type]
```