### PR TITLE
build: stop overriding CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 ## vi:set bd=syn\ make: for elvis
 
 AUTOMAKE_OPTIONS = foreign dist-bzip2 no-dist-gzip
+AM_CFLAGS = $(project_CFLAGS)
+AM_OBJCFLAGS = $(project_OBJCFLAGS)
 
 ## NOTE: helptexts should be in the same order as the enum in page.h
 docs = \
@@ -446,14 +448,15 @@ schismtracker_SOURCES = \
 # have version.o rely on all files
 schism/version.$(OBJEXT): $(filter-out schism/version.$(OBJEXT),$(schismtracker_OBJECTS)) $(HEADERS)
 
-schismtracker_CPPFLAGS = -I$(srcdir)/include -I. $(cppflags_wii) $(cppflags_wiiu)
-schismtracker_CFLAGS = $(SDL_CFLAGS) $(cflags_alsa) $(cflags_oss) \
+component_cflags = $(SDL_CFLAGS) $(cflags_alsa) $(cflags_oss) \
 	$(cflags_network) $(cflags_x11) $(cflags_fmopl) \
 	$(cflags_version) $(cflags_win32) $(cflags_wii) \
 	$(cflags_macosx) $(cflags_flac) $(cflags_jack) \
 	$(cflags_wiiu) \
 	$(UTF8PROC_CFLAGS)
-schismtracker_OBJCFLAGS = $(schismtracker_CFLAGS)
+schismtracker_CPPFLAGS = -I$(srcdir)/include -I. $(cppflags_wii) $(cppflags_wiiu)
+schismtracker_CFLAGS = $(AM_CFLAGS) $(component_cflags)
+schismtracker_OBJCFLAGS = $(AM_OBJCFLAGS) $(component_cflags)
 
 schismtracker_DEPENDENCIES = $(files_windres)
 schismtracker_LDADD = $(LIB_MATH) $(libs_wii) $(libs_wiiu) $(libs_jack) $(libs_macosx) $(lib_asound) $(lib_win32) $(libs_network) $(libs_flac) $(lib_mediafoundation) $(UTF8PROC_LIBS) $(SDL_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -425,8 +425,9 @@ fi
 dnl --------------------------------------------------------------------------
 
 dnl fortify needs -O; do this early so ADD_OPT can override with higher -O level
+project_CFLAGS=""
 if test x$ADD_FORTIFY \!= xno; then
-	CFLAGS="$CFLAGS -O -D_FORTIFY_SOURCE=2"
+	project_CFLAGS="$project_CFLAGS -O -D_FORTIFY_SOURCE=2"
 fi
 
 dnl place extra optimizations after existing cflags so that they can override
@@ -436,12 +437,12 @@ if test x$ADD_OPT \!= xno; then
 		AC_MSG_NOTICE([You aren't supposed to use --enable-debug or --enable-profiling together with --enable-extra-opt!!])
 	fi
 	ADD_OPT="-Ofast -g0 -s -fno-exceptions -march=native"
-	CFLAGS="$CFLAGS $ADD_OPT"
+	project_CFLAGS="$project_CFLAGS $ADD_OPT"
 fi
 
 if test x$ADD_LUDICROUS \!= xno; then
 	ADD_WARN=yes
-	CFLAGS="$CFLAGS -Werror"
+	project_CFLAGS="$project_CFLAGS -Werror"
 fi
 
 dnl ... but put the warnings first, to make it possible to quiet certain
@@ -449,7 +450,7 @@ dnl warnings if necessary, while still providing most of the benefit
 if test x$ADD_WARN \!= xno; then
 	ADD_WARN="-Wall -Wextra -Winline -Wshadow -Wwrite-strings -Waggregate-return -Wpacked"
 	ADD_WARN="$ADD_WARN -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wnested-externs"
-	CFLAGS="$ADD_WARN $CFLAGS"
+	project_CFLAGS="$ADD_WARN $project_CFLAGS"
 fi
 
 dnl Unlike a grand -Werror, this one could be rather important:
@@ -457,20 +458,22 @@ dnl functions returning random values are no good under any circumstances.
 AS_IF([test ${ac_cv_c_compiler_gnu+y}], [CFLAGS="$CFLAGS -Werror=return-type"])
 
 if test x$ADD_PROFILING \!= xno || test x$ADD_DEBUG \!= xno; then
-	CFLAGS="$CFLAGS -g -O0"
-	OBJCFLAGS="$OBJCFLAGS -g -O0"
+	project_CFLAGS="$project_CFLAGS -g -O0"
+	project_OBJCFLAGS="$project_OBJCFLAGS -g -O0"
 	SDL_LIBS="$SDL_LIBS -g -O0"
 	AC_SUBST(SDL_LIBS)
 fi
 if test x$ADD_PROFILING \!= xno; then
-	CFLAGS="$CFLAGS -pg"
-	OBJCFLAGS="$OBJCFLAGS -pg"
+	project_CFLAGS="$project_CFLAGS -pg"
+	project_OBJCFLAGS="$project_OBJCFLAGS -pg"
 	SDL_LIBS="$SDL_LIBS -pg"
 	AC_SUBST(SDL_LIBS)
 fi
 
 dnl --------------------------------------------------------------------------
 
+AC_SUBST([project_CFLAGS])
+AC_SUBST([project_OBJCFLAGS])
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
 


### PR DESCRIPTION
``CFLAGS`` is reserved for the user. configure must finish in an idempotent state and not touch it, pursuant to automake.info §3.6 "Variables reserved for the user".

Observed:

```
$ ./configure --enable-profiling
[...]
$ make V=1 CFLAGS=-Wall
[...]
gcc -DHAVE_CONFIG_H -I. -I./include -I. -I/usr/include/SDL2 -D_REENTRANT
-DUTF8PROC_EXPORTS -Wall -MT fmt/schismtracker-it.o -MD -MP -MF
fmt/.deps/schismtracker-it.Tpo -c -o fmt/schismtracker-it.o `test -f 'fmt/it.c'
|| echo './'`fmt/it.c
```

Expected:

Don't lose -pg.

```
gcc -DHAVE_CONFIG_H -I. -I./include -I. -g -O0 -pg -I/usr/include/SDL2
-D_REENTRANT -DUTF8PROC_EXPORTS -Wall -MT fmt/schismtracker-it.o -MD -MP -MF
fmt/.deps/schismtracker-it.Tpo -c -o fmt/schismtracker-it.o `test -f 'fmt/it.c'
|| echo './'`fmt/it.c
```