### PR TITLE
* Make the original Time Information shortcut actually work on Window…

### DIFF
--- a/schism/page.c
+++ b/schism/page.c
@@ -872,7 +872,11 @@ static int handle_key_global(struct key_event * k)
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		_mp_finish(NULL);
-		if (k->mod & SCHISM_KEYMOD_ALT) {
+		if ((k->mod & SCHISM_KEYMOD_LSHIFT) && (k->mod & SCHISM_KEYMOD_LALT) && (k->mod & SCHISM_KEYMOD_RALT) && (k->mod & SCHISM_KEYMOD_RCTRL))
+			// Hack to make the wonderful time info shortcut work under Windows.
+			k->sym = SCHISM_KEYSYM_SCROLLLOCK;
+			// Fall through.
+		else if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_PRESS) {
 				midi_flags ^= (MIDI_DISABLE_RECORD);
 				status_text_flash("MIDI Input %s",
@@ -891,7 +895,6 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 
-		return 1;
 	case SCHISM_KEYSYM_PAUSE:
 		if ((k->mod & SCHISM_KEYMOD_LSHIFT) && (k->mod & SCHISM_KEYMOD_LALT) && (k->mod & SCHISM_KEYMOD_RALT) && (k->mod & SCHISM_KEYMOD_RCTRL)) {
 			_mp_finish(NULL);
@@ -1144,19 +1147,13 @@ void handle_key(struct key_event *k)
 	case SCHISM_KEYSYM_SLASH:
 		if (k->state == KEY_RELEASE) return;
 		if (status.flags & DISKWRITER_ACTIVE) return;
-		break;
-	case SCHISM_KEYSYM_KP_DIVIDE:
-		if (k->state == KEY_RELEASE) return;
-		if (status.flags & DISKWRITER_ACTIVE) return;
+		if (k->orig_sym != SCHISM_KEYSYM_KP_DIVIDE) return;
 		kbd_set_current_octave(kbd_get_current_octave() - 1);
 		return;
 	case SCHISM_KEYSYM_ASTERISK:
 		if (k->state == KEY_RELEASE) return;
 		if (status.flags & DISKWRITER_ACTIVE) return;
-		break;
-	case SCHISM_KEYSYM_KP_MULTIPLY:
-		if (k->state == KEY_RELEASE) return;
-		if (status.flags & DISKWRITER_ACTIVE) return;
+		if (k->orig_sym != SCHISM_KEYSYM_KP_MULTIPLY) return;
 		kbd_set_current_octave(kbd_get_current_octave() + 1);
 		return;
 	case SCHISM_KEYSYM_LEFTBRACKET:


### PR DESCRIPTION
…s. Since Ctrl-Pause is in fact Ctrl-Scroll Lock, catch it as well.

* Fix octave switching with KP / and KP *.