### PR TITLE
XI instrument import/export fixes

### DIFF
--- a/fmt/xi.c
+++ b/fmt/xi.c
@@ -538,7 +538,13 @@ int fmt_xi_save_instrument(disko_t *fp, song_t *song, song_instrument_t *ins)
 		xmss.looplen = bswapLE32(xmss.looplen);
 
 		xmss.vol = smp->volume >> 2;
-		xmss.pan = smp->panning;
+
+		if(smp->flags & CHN_PANNING) {
+			xmss.pan = smp->panning;
+		} else {
+			// Default panning enabled--pan to center.
+			xmss.pan = 0x80;
+		}
 
 		int32_t transp = frequency_to_transpose(smp->c5speed);
 

--- a/fmt/xi.c
+++ b/fmt/xi.c
@@ -422,7 +422,7 @@ int fmt_xi_save_instrument(disko_t *fp, song_t *song, song_instrument_t *ins)
 			xi_nalloc++;
 		}
 
-		xi.xish.snum[j] = xi_map[o]+1;
+		xi.xish.snum[j] = xi_map[o];
 	}
 
 	if (xi_nalloc < 1)

--- a/fmt/xi.c
+++ b/fmt/xi.c
@@ -539,10 +539,12 @@ int fmt_xi_save_instrument(disko_t *fp, song_t *song, song_instrument_t *ins)
 
 		xmss.vol = smp->volume >> 2;
 
-		if(smp->flags & CHN_PANNING) {
+		if(ins->flags & ENV_SETPANNING) {
+			xmss.pan = ins->panning;
+		} else if(smp->flags & CHN_PANNING) {
 			xmss.pan = smp->panning;
 		} else {
-			// Default panning enabled--pan to center.
+			// Default panning enabled for instrument and sample--pan to center.
 			xmss.pan = 0x80;
 		}
 

--- a/fmt/xi.c
+++ b/fmt/xi.c
@@ -228,6 +228,7 @@ int fmt_xi_load_instrument(slurp_t *fp, int slot)
 	struct instrumentloader ii;
 	song_instrument_t *g;
 	int k, prevtick;
+	int smpdataoffset;
 
 	if (!xi_file_header_read(&xi, fp))
 		return 0;
@@ -307,6 +308,9 @@ int fmt_xi_load_instrument(slurp_t *fp, int slot)
 	xi.xish.volfade = bswapLE16(xi.xish.volfade);
 	xi.xish.nsamples = bswapLE16(xi.xish.nsamples);
 
+	// Determine where the sample data starts.
+	smpdataoffset = sizeof(xi) + (sizeof(struct xm_sample_header) * xi.xish.nsamples);
+
 	for (k = 0; k < xi.xish.nsamples; k++) {
 		struct xm_sample_header xmss;
 		song_sample_t *smp;
@@ -378,7 +382,16 @@ int fmt_xi_load_instrument(slurp_t *fp, int slot)
 		}
 
 		smp->c5speed = transpose_to_frequency(xmss.relnote, xmss.finetune);
-		slurp_seek(fp, csf_read_sample(current_song->samples + n, rs, fp), SEEK_CUR);
+
+		if(smp->length) {
+			// Save our spot, read the sample data, then jump back.
+			uint64_t smpheaderoffset;
+
+			smpheaderoffset = slurp_tell(fp);
+			slurp_seek(fp, smpdataoffset, SEEK_SET);
+			smpdataoffset += csf_read_sample(current_song->samples + n, rs, fp);
+			slurp_seek(fp, smpheaderoffset, SEEK_SET);
+		}
 	}
 
 	return 1;

--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -576,9 +576,6 @@ uint32_t csf_write_sample(disko_t *fp, song_sample_t *sample, uint32_t flags, ui
 	if(maxlengthmask != UINT32_MAX)
 		len = len > maxlengthmask ? maxlengthmask : (len & maxlengthmask);
 
-	if (sample->flags & CHN_16BIT)
-		len *= 2;
-
 	// validate the write flags, and set up the save params
 	switch (flags & SF_CHN_MASK) {
 	case SF_SI:


### PR DESCRIPTION
Greetings! I ended up stumbling upon a few regressions when I was trying to import some old XIs and went down a bit of a rabbit hole. Here goes:

- Fixed a regression introduced in 5912f37 that caused XI to read sample data from the wrong place (`header, data, header, data` rather than `header, header, data, data`).
- Corrected an oddity in the XI save function, likely stemming from its ITI roots, which would cause it to initially use 1-based indexing instead of XI's 0-based indexes.
- The default panning flags were not taken into account when exporting FT2 samples, which would usually cause samples to panned hard left. Panning is assigned using the following precedence: instrument panning, sample panning, centered.
- The sample save function was incorrectly doubling the size (in bytes) of 16-bit samples. At best this would cause them to take up double the space and at worst (particularly when exporting instruments) it would cause a segfault or, in the case of XIs, corrupted samples.

I've only tested these changes on Linux at this time, and have verified the exported XIs against Schism and Milky Tracker.