### PR TITLE
Add a simple "test suite" of sorts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,6 +178,11 @@ AC_ARG_ENABLE(avformat-linking,
 	AVFORMAT_LINKING=$enableval,
 	AVFORMAT_LINKING=no)
 
+AC_ARG_ENABLE(test,
+	AS_HELP_STRING([--enable-test], [Override main function with test suite]),
+	TEST=$enableval,
+	TEST=no)
+
 dnl These are used in the Win32 build so that we can intermix mingw32 and mingw-w64 parts.
 dnl This is really a hack, and it would be nicer if we could avoid this, but unfortunately
 dnl there is no real windows toolchain available that allows to target super old windows
@@ -394,28 +399,27 @@ posix_fseek=unknown
 
 have_loadso=no
 
-case "$host_os" in
-darwin*)
+AS_CASE([$host_os],
+[darwin*], [
 	AC_MSG_RESULT([found Darwin host])
 
+	AC_MSG_CHECKING([for Mac OS X El Capitan SDK])
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+		#include <AvailabilityMacros.h>
 
-		AC_MSG_CHECKING([for Mac OS X El Capitan SDK])
-		AC_COMPILE_IFELSE([
-			#include <AvailabilityMacros.h>
+		#if MAC_OS_X_VERSION_MAX_ALLOWED < 101100
+		# error "too old"
+		#endif
+	]])], [use_avfoundation=yes], [])
+	AC_MSG_RESULT([$use_avfoundation])
 
-			#if MAC_OS_X_VERSION_MAX_ALLOWED < 101100
-			# error "too old"
-			#endif
-		], [use_avfoundation=yes], [])
-		AC_MSG_RESULT([$use_avfoundation])
-
-		use_macosx=yes
-		posix_fseek=yes
-		AC_DEFINE([SCHISM_MACOSX], [1], [Mac OS X])
-		;;
-	macos*)
-		# Retro68 toolchain
-		AC_MSG_RESULT([found Classic Mac OS host])
+	use_macosx=yes
+	posix_fseek=yes
+	AC_DEFINE([SCHISM_MACOSX], [1], [Mac OS X])
+],
+[macos*], [
+	dnl Retro68 toolchain
+	AC_MSG_RESULT([found Classic Mac OS host])
 
 	use_macos=yes
 	AC_DEFINE([SCHISM_MACOS], [1], [Classic Mac OS])
@@ -433,16 +437,16 @@ darwin*)
 	fi
 
 	posix_fseek=no
-	;;
-os2*)
+],
+[os2*], [
 	AC_MSG_RESULT([found OS/2 host])
 
 	have_loadso=yes
 	use_os2=yes
 
 	AC_DEFINE([SCHISM_OS2], [1], [OS/2])
-	;;
-cygwin*|mingw*)
+],
+[cygwin*|mingw*], [
 	AC_MSG_RESULT([found Windows host])
 	WIN32_LIBS="-lwinmm"
 
@@ -462,8 +466,8 @@ cygwin*|mingw*)
 	use_win32=yes
 	posix_fseek=yes
 	AC_DEFINE([SCHISM_WIN32], [1], [Windows])
-	;;
-xbox*)
+],
+[xbox*], [
 	AC_MSG_RESULT([found XBOX host])
 	dnl For all intents and purposes, the Xbox is a completely different
 	dnl operating system to Windows, with a similar (but not identical)
@@ -479,8 +483,8 @@ xbox*)
 	use_controller=yes
 	AC_DEFINE([SCHISM_XBOX], [1], [Original Xbox])
 	AC_DEFINE([SCHISM_CONTROLLER], [1], [Enable game controller support])
-	;;
-*)
+], [
+	dnl default case
 	AC_MSG_RESULT([nothing to do here])
 
 	dnl now check for other stuff
@@ -565,9 +569,7 @@ xbox*)
 		AC_DEFINE([USE_NETWORK], [1], [Networking])
 		use_network=yes
 	fi
-
-	;;
-esac
+])
 
 dnl Libs
 AC_SEARCH_LIBS([dlopen], [dl], [
@@ -623,6 +625,15 @@ AM_CONDITIONAL([USE_XBOX], [test "x$use_xbox" = "xyes"])
 
 dnl this ought to have something better
 AM_CONDITIONAL([USE_AVFOUNDATION], [test "x$use_avfoundation" = "xyes"])
+
+dnl ------------------------------------------------------------------------
+dnl test suite
+
+if test "x$TEST" = "xyes"; then
+	AC_DEFINE([SCHISM_TEST], [1], [Compile test suite])
+fi
+
+AM_CONDITIONAL([USE_TEST], [test "x$TEST" = "xyes"])
 
 dnl ------------------------------------------------------------------------
 

--- a/include/bshift.h
+++ b/include/bshift.h
@@ -93,4 +93,21 @@ SCHISM_SIGNED_RSHIFT_VARIANT(max)
 #undef SCHISM_SIGNED_RSHIFT_VARIANT
 #undef SCHISM_SIGNED_SHIFT_VARIANT
 
+#ifdef SCHISM_TEST
+
+static inline int test_bshift(void)
+{
+	int r = 0;
+
+#ifdef HAVE_ARITHMETIC_RSHIFT
+	r |= (rshift_signed(-0xFFFF, 8) != (-0xFFFF >> 8));
+#endif
+	r |= (rshift_signed(INT32_C(-0xFFFF), 8) != INT32_C(-0x100));
+	r |= (lshift_signed((int32_t)0xFF000000, 4) != (int32_t)0xF0000000);
+
+	return r;
+}
+
+#endif
+
 #endif /* SCHISM_BSHIFT_H_ */

--- a/include/bswap.h
+++ b/include/bswap.h
@@ -108,4 +108,32 @@ SCHISM_CONST SCHISM_ALWAYS_INLINE inline uint16_t bswap_16_schism_internal_(uint
 # define bswapLE64(x) (x)
 #endif
 
+#ifdef SCHISM_TEST
+
+static inline int test_bswap(void)
+{
+	int r = 0;
+
+#define BYTESWAP_TEST(BITS, TESTVAL, EXPECTEDLE, EXPECTEDBE) \
+	do { \
+		union { \
+			char x[BITS / 8]; \
+			uint##BITS##_t u; \
+		} x; \
+	\
+		memcpy(x.x, (TESTVAL), sizeof(x.x)); \
+	\
+		r |= (bswapLE##BITS(x.u) != (EXPECTEDLE)); \
+		r |= (bswapBE##BITS(x.u) != (EXPECTEDBE)); \
+	} while (0)
+
+	BYTESWAP_TEST(16, "\xAA\xBB", 0xBBAA, 0xAABB);
+	BYTESWAP_TEST(32, "\xAA\xBB\xCC\xDD", 0xDDCCBBAA, 0xAABBCCDD);
+	BYTESWAP_TEST(64, "\x11\x22\x33\x44\x55\x66\x77\x88", 0x8877665544332211, 0x1122334455667788);
+
+	return r;
+}
+
+#endif
+
 #endif /* SCHISM_BSWAP_H_ */

--- a/include/config-parser.h
+++ b/include/config-parser.h
@@ -88,4 +88,10 @@ void cfg_free(cfg_file_t *cfg);
 
 /* --------------------------------------------------------------------------------------------------------- */
 
+#ifdef SCHISM_TEST
+
+int cfg_test(void);
+
+#endif
+
 #endif /* SCHISM_CONFIG_PARSER_H_ */

--- a/schism/main.c
+++ b/schism/main.c
@@ -940,6 +940,7 @@ void schism_exit(int x)
 
 extern void vis_init(void);
 
+#ifndef SCHISM_TEST
 /* the real main function is called per-platform */
 int schism_main(int argc, char** argv)
 {
@@ -1128,6 +1129,34 @@ int schism_main(int argc, char** argv)
 
 	return 0; /* blah */
 }
+#else /* defined(SCHISM_TEST) */
+
+# include "bswap.h"
+# include "bshift.h"
+
+/* The main entry point for the test suite. */
+int schism_main(int argc, char **argv)
+{
+	static const struct {
+		const char *name;
+		int (*test)(void);
+	} tests[] = {
+		{"byteswap", test_bswap},
+		{"signed bitshift", test_bshift},
+		{"config", cfg_test},
+	};
+	size_t i;
+	int r;
+
+	for (i = 0; i < ARRAY_SIZE(tests); i++) {
+		int rr = tests[i].test();
+		printf("TESTS: %s test %s\n", tests[i].name, rr ? "FAILED" : "succeeded");
+		r |= rr;
+	}
+
+	return r;
+}
+#endif
 
 #if defined(SCHISM_MACOSX)
 // sys/macosx/macosx-sdlmain.m


### PR DESCRIPTION
This just plugs into `schism_main`. It's enabled by passing `--enable-test` to `configure`. Currently we only test the config functions, bit shift, and byteswap, but more is probably due to be implemented (for example, sample read/writing functions).