### PR TITLE
Changed the paradigm for input processing: KEYSYM if it's textual input, SCANCODE otherwise

### DIFF
--- a/include/it.h
+++ b/include/it.h
@@ -150,7 +150,7 @@ struct tracker_status {
 	int flags;
 	enum tracker_time_display time_display;
 	enum tracker_vis_style vis_style;
-	schism_keysym_t last_keysym;
+	schism_scancode_t last_scancode;
 
 	schism_keymod_t keymod;
 

--- a/schism/itf.c
+++ b/schism/itf.c
@@ -850,18 +850,18 @@ static int fontedit_handle_key(struct key_event * k)
 	}
 
 	/* kp is special */
-	switch (k->sym) {
-	case SCHISM_KEYSYM_KP_0:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_KP_0:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		k->sym += 10;
 		/* fall through */
-	case SCHISM_KEYSYM_KP_1: case SCHISM_KEYSYM_KP_2: case SCHISM_KEYSYM_KP_3:
-	case SCHISM_KEYSYM_KP_4: case SCHISM_KEYSYM_KP_5: case SCHISM_KEYSYM_KP_6:
-	case SCHISM_KEYSYM_KP_7: case SCHISM_KEYSYM_KP_8: case SCHISM_KEYSYM_KP_9:
+	case SCHISM_SCANCODE_KP_1: case SCHISM_SCANCODE_KP_2: case SCHISM_SCANCODE_KP_3:
+	case SCHISM_SCANCODE_KP_4: case SCHISM_SCANCODE_KP_5: case SCHISM_SCANCODE_KP_6:
+	case SCHISM_SCANCODE_KP_7: case SCHISM_SCANCODE_KP_8: case SCHISM_SCANCODE_KP_9:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		n = k->sym - SCHISM_KEYSYM_KP_1;
+		n = k->scancode - SCHISM_SCANCODE_KP_1;
 		if (k->mod & SCHISM_KEYMOD_SHIFT)
 			n += 10;
 		palette_load_preset(n);
@@ -872,43 +872,48 @@ static int fontedit_handle_key(struct key_event * k)
 		break;
 	};
 
-	switch (k->sym) {
-	case '0':
-		if (k->state == KEY_RELEASE)
+	if ((k->sym >= '0') && (k->sym <= '9')) {
+		switch (k->sym) {
+		case '0':
+			if (k->state == KEY_RELEASE)
+				return 1;
+			k->sym += 10;
+			/* fall through */
+		case '1': case '2': case '3':
+		case '4': case '5': case '6':
+		case '7': case '8': case '9':
+			if (k->state == KEY_RELEASE)
+				return 1;
+			n = k->sym - '1';
+			if (k->mod & SCHISM_KEYMOD_SHIFT)
+				n += 10;
+			palette_load_preset(n);
+			palette_apply();
+			status.flags |= NEED_UPDATE;
 			return 1;
-		k->sym += 10;
-		/* fall through */
-	case '1': case '2': case '3':
-	case '4': case '5': case '6':
-	case '7': case '8': case '9':
-		if (k->state == KEY_RELEASE)
-			return 1;
-		n = k->sym - '1';
-		if (k->mod & SCHISM_KEYMOD_SHIFT)
-			n += 10;
-		palette_load_preset(n);
-		palette_apply();
-		status.flags |= NEED_UPDATE;
-		return 1;
-	case SCHISM_KEYSYM_F2:
+		}
+	}
+
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_F2:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selected_item = EDITBOX;
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_F3:
+	case SCHISM_SCANCODE_F3:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selected_item = CHARMAP;
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_F4:
+	case SCHISM_SCANCODE_F4:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selected_item = ITFMAP;
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
@@ -921,7 +926,7 @@ static int fontedit_handle_key(struct key_event * k)
 		}
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_c:
+	case SCHISM_SCANCODE_C:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -929,7 +934,7 @@ static int fontedit_handle_key(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_p:
+	case SCHISM_SCANCODE_P:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -938,7 +943,7 @@ static int fontedit_handle_key(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_m:
+	case SCHISM_SCANCODE_M:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -951,7 +956,7 @@ static int fontedit_handle_key(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_z:
+	case SCHISM_SCANCODE_Z:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -960,7 +965,7 @@ static int fontedit_handle_key(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_h:
+	case SCHISM_SCANCODE_H:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -975,7 +980,7 @@ static int fontedit_handle_key(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_v:
+	case SCHISM_SCANCODE_V:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -988,7 +993,7 @@ static int fontedit_handle_key(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_i:
+	case SCHISM_SCANCODE_I:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -1001,13 +1006,13 @@ static int fontedit_handle_key(struct key_event * k)
 
 		/* ----------------------------------------------------- */
 
-	case SCHISM_KEYSYM_l:
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_L:
+	case SCHISM_SCANCODE_R:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (!(k->mod & SCHISM_KEYMOD_CTRL)) break;
 		/* fall through */
-	case SCHISM_KEYSYM_F9:
+	case SCHISM_SCANCODE_F9:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		load_fontlist();
@@ -1015,12 +1020,12 @@ static int fontedit_handle_key(struct key_event * k)
 		selected_item = FONTLIST;
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_s:
+	case SCHISM_SCANCODE_S:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (!(k->mod & SCHISM_KEYMOD_CTRL)) break;
 		/* fall through */
-	case SCHISM_KEYSYM_F10:
+	case SCHISM_SCANCODE_F10:
 		/* a bit weird, but this ensures that font.cfg
 		 * is always the default font to save to, but
 		 * without the annoyance of moving the cursor
@@ -1033,7 +1038,7 @@ static int fontedit_handle_key(struct key_event * k)
 		selected_item = FONTLIST;
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -1045,9 +1050,9 @@ static int fontedit_handle_key(struct key_event * k)
 		}
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		return 0;
-	case SCHISM_KEYSYM_q:
+	case SCHISM_SCANCODE_Q:
 		if (k->mod & SCHISM_KEYMOD_CTRL)
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -1083,17 +1088,17 @@ static struct widget fontedit_widget_hack[1];
 
 static int fontedit_key_hack(struct key_event *k)
 {
-	switch (k->sym) {
-	case SCHISM_KEYSYM_r: case SCHISM_KEYSYM_l: case SCHISM_KEYSYM_s:
-	case SCHISM_KEYSYM_c: case SCHISM_KEYSYM_p: case SCHISM_KEYSYM_m:
-	case SCHISM_KEYSYM_z: case SCHISM_KEYSYM_v: case SCHISM_KEYSYM_h:
-	case SCHISM_KEYSYM_i: case SCHISM_KEYSYM_q: case SCHISM_KEYSYM_w:
-	case SCHISM_KEYSYM_F1: case SCHISM_KEYSYM_F2: case SCHISM_KEYSYM_F3:
-	case SCHISM_KEYSYM_F4: case SCHISM_KEYSYM_F5: case SCHISM_KEYSYM_F6:
-	case SCHISM_KEYSYM_F7: case SCHISM_KEYSYM_F8: case SCHISM_KEYSYM_F9:
-	case SCHISM_KEYSYM_F10: case SCHISM_KEYSYM_F11: case SCHISM_KEYSYM_F12:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_R: case SCHISM_SCANCODE_L: case SCHISM_SCANCODE_S:
+	case SCHISM_SCANCODE_C: case SCHISM_SCANCODE_P: case SCHISM_SCANCODE_M:
+	case SCHISM_SCANCODE_Z: case SCHISM_SCANCODE_V: case SCHISM_SCANCODE_H:
+	case SCHISM_SCANCODE_I: case SCHISM_SCANCODE_Q: case SCHISM_SCANCODE_W:
+	case SCHISM_SCANCODE_F1: case SCHISM_SCANCODE_F2: case SCHISM_SCANCODE_F3:
+	case SCHISM_SCANCODE_F4: case SCHISM_SCANCODE_F5: case SCHISM_SCANCODE_F6:
+	case SCHISM_SCANCODE_F7: case SCHISM_SCANCODE_F8: case SCHISM_SCANCODE_F9:
+	case SCHISM_SCANCODE_F10: case SCHISM_SCANCODE_F11: case SCHISM_SCANCODE_F12:
 		return fontedit_handle_key(k);
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (status.dialog_type & (DIALOG_MENU|DIALOG_BOX)) return 0;
 		if (selected_item == FONTLIST) {
 			handle_key_fontlist(k);

--- a/schism/keyboard.c
+++ b/schism/keyboard.c
@@ -136,28 +136,22 @@ int get_effect_number(char effect)
 int kbd_get_effect_number(struct key_event *k)
 {
 	if (!NO_CAM_MODS(k->mod)) return -1;
-	switch (k->sym) {
-#define QZA(n) case SCHISM_KEYSYM_ ## n : return get_effect_number(#n [0])
-QZA(a);QZA(b);QZA(c);QZA(d);QZA(e);QZA(f);QZA(g);QZA(h);QZA(i);QZA(j);QZA(k);
-QZA(l);QZA(m);QZA(n);QZA(o);QZA(p);QZA(q);QZA(r);QZA(s);QZA(t);QZA(u);QZA(v);
-QZA(w);QZA(x);QZA(y);QZA(z);
+	switch (k->scancode) {
+#define QZA(n) case SCHISM_SCANCODE_ ## n : return get_effect_number(#n [0])
+QZA(A);QZA(B);QZA(C);QZA(D);QZA(E);QZA(F);QZA(G);QZA(H);QZA(I);QZA(J);QZA(K);
+QZA(L);QZA(M);QZA(N);QZA(O);QZA(P);QZA(Q);QZA(R);QZA(S);QZA(T);QZA(U);QZA(V);
+QZA(W);QZA(X);QZA(Y);QZA(Z);
 #undef QZA
-	case SCHISM_KEYSYM_PERIOD: case SCHISM_KEYSYM_KP_PERIOD:
+	case SCHISM_SCANCODE_PERIOD: case SCHISM_SCANCODE_KP_PERIOD:
 		return get_effect_number('.');
-	case SCHISM_KEYSYM_1:
+	case SCHISM_SCANCODE_1:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT)) return -1;
-		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_EXCLAIM:
 		return get_effect_number('!');
-	case SCHISM_KEYSYM_4:
+	case SCHISM_SCANCODE_4:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT)) return -1;
-		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_DOLLAR:
 		return get_effect_number('$');
-	case SCHISM_KEYSYM_7:
+	case SCHISM_SCANCODE_7:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT)) return -1;
-		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_AMPERSAND:
 		return get_effect_number('&');
 
 	default:
@@ -179,14 +173,22 @@ void kbd_key_translate(struct key_event *k)
 		/* TODO: k->text should be Unicode, not CP437. */
 		switch (*k->text) {
 		/* there are likely more cases than this...*/
-		case '<': k->sym = SCHISM_KEYSYM_LESS; break;
-		case '>': k->sym = SCHISM_KEYSYM_GREATER; break;
-		case '$': k->sym = SCHISM_KEYSYM_DOLLAR; break;
+		case '<':
+			k->sym = SCHISM_KEYSYM_LESS;
+			break;
+		case '>':
+			k->sym = SCHISM_KEYSYM_GREATER;
+			break;
+		case '$':
+			k->sym = SCHISM_KEYSYM_DOLLAR;
+			break;
 
 		case '+': k->sym = SCHISM_KEYSYM_PLUS; break;
 		case ':': k->sym = SCHISM_KEYSYM_COLON; break;
 
-		case '*': k->sym = SCHISM_KEYSYM_ASTERISK; break;
+		case '*':
+			k->sym = SCHISM_KEYSYM_ASTERISK;
+			break;
 
 		default: break;
 		}
@@ -202,48 +204,48 @@ void kbd_key_translate(struct key_event *k)
 	}
 	if (k->mod & SCHISM_KEYMOD_NUM) {
 		switch (k->sym) {
-		case SCHISM_KEYSYM_KP_0: k->sym = SCHISM_KEYSYM_0; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_1: k->sym = SCHISM_KEYSYM_1; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_2: k->sym = SCHISM_KEYSYM_2; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_3: k->sym = SCHISM_KEYSYM_3; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_4: k->sym = SCHISM_KEYSYM_4; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_5: k->sym = SCHISM_KEYSYM_5; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_6: k->sym = SCHISM_KEYSYM_6; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_7: k->sym = SCHISM_KEYSYM_7; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_8: k->sym = SCHISM_KEYSYM_8; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_9: k->sym = SCHISM_KEYSYM_9; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_PERIOD: k->sym = SCHISM_KEYSYM_PERIOD; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_DIVIDE: k->sym = SCHISM_KEYSYM_SLASH; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_MULTIPLY: k->sym = SCHISM_KEYSYM_ASTERISK; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_MINUS: k->sym = SCHISM_KEYSYM_MINUS; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_PLUS: k->sym = SCHISM_KEYSYM_PLUS; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_ENTER: k->sym = SCHISM_KEYSYM_RETURN; k->mod &= ~SCHISM_KEYMOD_NUM; break;
-		case SCHISM_KEYSYM_KP_EQUALS: k->sym = SCHISM_KEYSYM_EQUALS; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_0: k->sym = SCHISM_KEYSYM_0; k->scancode = SCHISM_SCANCODE_0; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_1: k->sym = SCHISM_KEYSYM_1; k->scancode = SCHISM_SCANCODE_1; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_2: k->sym = SCHISM_KEYSYM_2; k->scancode = SCHISM_SCANCODE_2; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_3: k->sym = SCHISM_KEYSYM_3; k->scancode = SCHISM_SCANCODE_3; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_4: k->sym = SCHISM_KEYSYM_4; k->scancode = SCHISM_SCANCODE_4; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_5: k->sym = SCHISM_KEYSYM_5; k->scancode = SCHISM_SCANCODE_5; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_6: k->sym = SCHISM_KEYSYM_6; k->scancode = SCHISM_SCANCODE_6; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_7: k->sym = SCHISM_KEYSYM_7; k->scancode = SCHISM_SCANCODE_7; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_8: k->sym = SCHISM_KEYSYM_8; k->scancode = SCHISM_SCANCODE_8; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_9: k->sym = SCHISM_KEYSYM_9; k->scancode = SCHISM_SCANCODE_9; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_PERIOD: k->sym = SCHISM_KEYSYM_PERIOD; k->scancode = SCHISM_SCANCODE_PERIOD; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_DIVIDE: k->sym = SCHISM_KEYSYM_SLASH; k->scancode = SCHISM_SCANCODE_SLASH; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_MULTIPLY: k->sym = SCHISM_KEYSYM_ASTERISK; k->scancode = SCHISM_SCANCODE_8; k->mod = (k->mod & ~SCHISM_KEYMOD_NUM) | SCHISM_KEYMOD_SHIFT; break;
+		case SCHISM_KEYSYM_KP_MINUS: k->sym = SCHISM_KEYSYM_MINUS; k->scancode = SCHISM_SCANCODE_MINUS; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_PLUS: k->sym = SCHISM_KEYSYM_PLUS; k->scancode = SCHISM_SCANCODE_EQUALS; k->mod = (k->mod & ~SCHISM_KEYMOD_NUM) | SCHISM_KEYMOD_SHIFT; break;
+		case SCHISM_KEYSYM_KP_ENTER: k->sym = SCHISM_KEYSYM_RETURN; k->scancode = SCHISM_SCANCODE_RETURN; k->mod &= ~SCHISM_KEYMOD_NUM; break;
+		case SCHISM_KEYSYM_KP_EQUALS: k->sym = SCHISM_KEYSYM_EQUALS; k->scancode = SCHISM_SCANCODE_EQUALS; k->mod &= ~SCHISM_KEYMOD_NUM & ~SCHISM_KEYMOD_SHIFT; break;
 		default:
 			break;
 		};
 	} else {
 		switch (k->sym) {
-		case SCHISM_KEYSYM_KP_0: k->sym = SCHISM_KEYSYM_INSERT; break;
-		case SCHISM_KEYSYM_KP_4: k->sym = SCHISM_KEYSYM_LEFT; break;
-		case SCHISM_KEYSYM_KP_6: k->sym = SCHISM_KEYSYM_RIGHT; break;
-		case SCHISM_KEYSYM_KP_2: k->sym = SCHISM_KEYSYM_DOWN; break;
-		case SCHISM_KEYSYM_KP_8: k->sym = SCHISM_KEYSYM_UP; break;
+		case SCHISM_KEYSYM_KP_0: k->sym = SCHISM_KEYSYM_INSERT; k->scancode = SCHISM_SCANCODE_INSERT; break;
+		case SCHISM_KEYSYM_KP_4: k->sym = SCHISM_KEYSYM_LEFT; k->scancode = SCHISM_SCANCODE_LEFT; break;
+		case SCHISM_KEYSYM_KP_6: k->sym = SCHISM_KEYSYM_RIGHT; k->scancode = SCHISM_SCANCODE_RIGHT; break;
+		case SCHISM_KEYSYM_KP_2: k->sym = SCHISM_KEYSYM_DOWN; k->scancode = SCHISM_SCANCODE_DOWN; break;
+		case SCHISM_KEYSYM_KP_8: k->sym = SCHISM_KEYSYM_UP; k->scancode = SCHISM_SCANCODE_UP; break;
 
-		case SCHISM_KEYSYM_KP_9: k->sym = SCHISM_KEYSYM_PAGEUP; break;
-		case SCHISM_KEYSYM_KP_3: k->sym = SCHISM_KEYSYM_PAGEDOWN; break;
+		case SCHISM_KEYSYM_KP_9: k->sym = SCHISM_KEYSYM_PAGEUP; k->scancode = SCHISM_SCANCODE_PAGEUP; break;
+		case SCHISM_KEYSYM_KP_3: k->sym = SCHISM_KEYSYM_PAGEDOWN; k->scancode = SCHISM_SCANCODE_PAGEDOWN; break;
 
-		case SCHISM_KEYSYM_KP_7: k->sym = SCHISM_KEYSYM_HOME; break;
-		case SCHISM_KEYSYM_KP_1: k->sym = SCHISM_KEYSYM_END; break;
+		case SCHISM_KEYSYM_KP_7: k->sym = SCHISM_KEYSYM_HOME; k->scancode = SCHISM_SCANCODE_HOME; break;
+		case SCHISM_KEYSYM_KP_1: k->sym = SCHISM_KEYSYM_END; k->scancode = SCHISM_SCANCODE_END; break;
 
-		case SCHISM_KEYSYM_KP_PERIOD: k->sym = SCHISM_KEYSYM_DELETE; break;
+		case SCHISM_KEYSYM_KP_PERIOD: k->sym = SCHISM_KEYSYM_DELETE; k->scancode = SCHISM_SCANCODE_DELETE; break;
 
-		case SCHISM_KEYSYM_KP_DIVIDE: k->sym = SCHISM_KEYSYM_SLASH; break;
-		case SCHISM_KEYSYM_KP_MULTIPLY: k->sym = SCHISM_KEYSYM_ASTERISK; break;
-		case SCHISM_KEYSYM_KP_MINUS: k->sym = SCHISM_KEYSYM_MINUS; break;
-		case SCHISM_KEYSYM_KP_PLUS: k->sym = SCHISM_KEYSYM_PLUS; break;
-		case SCHISM_KEYSYM_KP_ENTER: k->sym = SCHISM_KEYSYM_RETURN; break;
-		case SCHISM_KEYSYM_KP_EQUALS: k->sym = SCHISM_KEYSYM_EQUALS; break;
+		case SCHISM_KEYSYM_KP_DIVIDE: k->sym = SCHISM_KEYSYM_SLASH; k->scancode = SCHISM_SCANCODE_SLASH; break;
+		case SCHISM_KEYSYM_KP_MULTIPLY: k->sym = SCHISM_KEYSYM_ASTERISK; k->scancode = SCHISM_SCANCODE_8; k->mod |= SCHISM_KEYMOD_SHIFT; break;
+		case SCHISM_KEYSYM_KP_MINUS: k->sym = SCHISM_KEYSYM_MINUS; k->scancode = SCHISM_SCANCODE_MINUS; break;
+		case SCHISM_KEYSYM_KP_PLUS: k->sym = SCHISM_KEYSYM_PLUS; k->scancode = SCHISM_SCANCODE_EQUALS; k->mod |= SCHISM_KEYMOD_SHIFT; break;
+		case SCHISM_KEYSYM_KP_ENTER: k->sym = SCHISM_KEYSYM_RETURN; k->scancode = SCHISM_SCANCODE_RETURN; break;
+		case SCHISM_KEYSYM_KP_EQUALS: k->sym = SCHISM_KEYSYM_EQUALS; k->scancode = SCHISM_SCANCODE_EQUALS; k->mod &= ~SCHISM_KEYMOD_SHIFT; break;
 
 		default:
 			break;
@@ -490,7 +492,7 @@ int kbd_get_note(struct key_event *k)
 
 	if (!NO_CAM_MODS(k->mod)) return -1;
 
-	if (k->sym == SCHISM_KEYSYM_KP_1 || k->sym == SCHISM_KEYSYM_KP_PERIOD)
+	if (k->scancode == SCHISM_SCANCODE_KP_1 || k->scancode == SCHISM_SCANCODE_KP_PERIOD)
 		if (!(k->mod & SCHISM_KEYMOD_NUM)) return -1;
 
 	switch (k->scancode) {

--- a/schism/main.c
+++ b/schism/main.c
@@ -380,7 +380,7 @@ SCHISM_NORETURN static void event_loop(void)
 {
 	unsigned int lx = 0, ly = 0; /* last x and y position (character) */
 	timer_ticks_t last_mouse_down, ticker, last_audio_poll;
-	schism_keysym_t last_key = 0;
+	schism_scancode_t last_scancode = 0;
 	time_t startdown;
 	int downtrip;
 	int fix_numlock_key;
@@ -396,7 +396,7 @@ SCHISM_NORETURN static void event_loop(void)
 	last_mouse_down = 0;
 	last_audio_poll = timer_ticks();
 	startdown = 0;
-	status.last_keysym = 0;
+	status.last_scancode = 0;
 
 	status.keymod = events_get_keymod_state();
 	os_get_modkey(&status.keymod);
@@ -512,14 +512,14 @@ SCHISM_NORETURN static void event_loop(void)
 
 				if (se.type == SCHISM_KEYUP) {
 					/* only empty the key repeat if
-					 * the last keydown is the same sym */
-					if (last_key == kk.sym)
+					 * the last keydown is the same scancode */
+					if (last_scancode == kk.scancode)
 						kbd_empty_key_repeat();
 				} else {
 					kbd_cache_key_repeat(&kk);
 
-					status.last_keysym = last_key;
-					last_key = kk.sym;
+					status.last_scancode = last_scancode;
+					last_scancode = kk.scancode;
 				}
 				break;
 			case SCHISM_MOUSEMOTION:

--- a/schism/menu.c
+++ b/schism/menu.c
@@ -480,8 +480,8 @@ int menu_handle_key(struct key_event *k)
 		return 1;
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_ESCAPE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_ESCAPE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		current_menu[1] = NULL;
@@ -492,7 +492,7 @@ int menu_handle_key(struct key_event *k)
 			menu_hide();
 		}
 		break;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (menu->selected_item > 0) {
@@ -500,7 +500,7 @@ int menu_handle_key(struct key_event *k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (menu->selected_item < menu->num_items - 1) {
@@ -509,17 +509,17 @@ int menu_handle_key(struct key_event *k)
 		}
 		return 1;
 		/* home/end are new here :) */
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		menu->selected_item = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		menu->selected_item = menu->num_items - 1;
 		break;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_PRESS) {
 			menu->active_item = menu->selected_item;
 			status.flags |= NEED_UPDATE;

--- a/schism/page.c
+++ b/schism/page.c
@@ -490,8 +490,8 @@ static int handle_key_global(struct key_event * k)
 
 	/* first, check the truly global keys (the ones that still work if
 	 * a dialog's open) */
-	switch (k->sym) {
-	case SCHISM_KEYSYM_RETURN:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_RETURN:
 		if ((k->mod & SCHISM_KEYMOD_CTRL) && k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_PRESS)
 				return 1;
@@ -499,7 +499,7 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_m:
+	case SCHISM_SCANCODE_M:
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -508,7 +508,7 @@ static int handle_key_global(struct key_event * k)
 		}
 		break;
 
-	case SCHISM_KEYSYM_d:
+	case SCHISM_SCANCODE_D:
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			if (k->state == KEY_RELEASE)
 				return 1; /* argh */
@@ -521,7 +521,7 @@ static int handle_key_global(struct key_event * k)
 		}
 		break;
 
-	case SCHISM_KEYSYM_i:
+	case SCHISM_SCANCODE_I:
 		/* reset audio stuff? */
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			if (k->state == KEY_RELEASE)
@@ -530,7 +530,7 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_e:
+	case SCHISM_SCANCODE_E:
 		/* This should reset everything display-related. */
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			if (k->state == KEY_RELEASE)
@@ -540,14 +540,14 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) break;
 		if (status.flags & DISKWRITER_ACTIVE) break;
 		if (k->state == KEY_RELEASE)
 			return 0;
 		kbd_set_current_octave(kbd_get_current_octave() - 1);
 		return 1;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) break;
 		if (status.flags & DISKWRITER_ACTIVE) break;
 		if (k->state == KEY_RELEASE)
@@ -561,8 +561,8 @@ static int handle_key_global(struct key_event * k)
 	/* next, if there's no dialog, check the rest of the keys */
 	if (status.flags & DISKWRITER_ACTIVE) return 0;
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_q:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_Q:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -575,7 +575,7 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_n:
+	case SCHISM_SCANCODE_N:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -585,7 +585,7 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_g:
+	case SCHISM_SCANCODE_G:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -595,7 +595,7 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_p:
+	case SCHISM_SCANCODE_P:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -605,7 +605,7 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_F1:
+	case SCHISM_SCANCODE_F1:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -624,7 +624,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F2:
+	case SCHISM_SCANCODE_F2:
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			if (status.current_page == PAGE_PATTERN_EDITOR) {
 				_mp_finish(NULL);
@@ -658,7 +658,7 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_F3:
+	case SCHISM_SCANCODE_F3:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (NO_MODIFIER(k->mod)) {
@@ -671,7 +671,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F4:
+	case SCHISM_SCANCODE_F4:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (NO_MODIFIER(k->mod)) {
@@ -686,7 +686,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F5:
+	case SCHISM_SCANCODE_F5:
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			_mp_finish(NULL);
 			if (k->state == KEY_PRESS)
@@ -714,7 +714,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F6:
+	case SCHISM_SCANCODE_F6:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			_mp_finish(NULL);
 			if (k->state == KEY_PRESS)
@@ -727,7 +727,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F7:
+	case SCHISM_SCANCODE_F7:
 		if (NO_MODIFIER(k->mod)) {
 			_mp_finish(NULL);
 			if (k->state == KEY_PRESS)
@@ -736,7 +736,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F8:
+	case SCHISM_SCANCODE_F8:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			if (k->state == KEY_PRESS)
 				song_pause();
@@ -749,7 +749,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F9:
+	case SCHISM_SCANCODE_F9:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
@@ -764,8 +764,8 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_l:
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_L:
+	case SCHISM_SCANCODE_R:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -776,7 +776,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_s:
+	case SCHISM_SCANCODE_S:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -787,7 +787,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_w:
+	case SCHISM_SCANCODE_W:
 		/* Ctrl-W _IS_ in IT, and hands don't leave home row :) */
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
@@ -799,7 +799,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F10:
+	case SCHISM_SCANCODE_F10:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_ALT) break;
@@ -814,7 +814,7 @@ static int handle_key_global(struct key_event * k)
 				set_page(PAGE_SAVE_MODULE);
 		}
 		return 1;
-	case SCHISM_KEYSYM_F11:
+	case SCHISM_SCANCODE_F11:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if (NO_MODIFIER(k->mod)) {
@@ -845,7 +845,7 @@ static int handle_key_global(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_F12:
+	case SCHISM_SCANCODE_F12:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		if ((k->mod & SCHISM_KEYMOD_ALT) && status.current_page == PAGE_INFO) {
@@ -872,11 +872,11 @@ static int handle_key_global(struct key_event * k)
 		}
 		return 1;
 	/* hack alert */
-	case SCHISM_KEYSYM_f:
+	case SCHISM_SCANCODE_F:
 		if (!(k->mod & SCHISM_KEYMOD_CTRL))
 			return 0;
 		/* fall through */
-	case SCHISM_KEYSYM_SCROLLLOCK:
+	case SCHISM_SCANCODE_SCROLLLOCK:
 		if (status.dialog_type != DIALOG_NONE)
 			return 0;
 		_mp_finish(NULL);
@@ -900,7 +900,7 @@ static int handle_key_global(struct key_event * k)
 		}
 
 		return 1;
-	case SCHISM_KEYSYM_PAUSE:
+	case SCHISM_SCANCODE_PAUSE:
 		if ((k->mod & SCHISM_KEYMOD_LSHIFT) && (k->mod & SCHISM_KEYMOD_LALT) && (k->mod & SCHISM_KEYMOD_RALT) && (k->mod & SCHISM_KEYMOD_RCTRL)) {
 			_mp_finish(NULL);
 			if (k->state == KEY_PRESS)
@@ -909,7 +909,7 @@ static int handle_key_global(struct key_event * k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_t:
+	case SCHISM_SCANCODE_T:
 		if ((k->mod & SCHISM_KEYMOD_CTRL) && (k->mod & SCHISM_KEYMOD_ALT)) {
 			_mp_finish(NULL);
 			if (k->state == KEY_PRESS)
@@ -926,15 +926,15 @@ static int handle_key_global(struct key_event * k)
 
 	/* got a bit ugly here, sorry */
 	if (k->mod & SCHISM_KEYMOD_ALT) {
-		switch (k->sym) {
-		case SCHISM_KEYSYM_F1: i = 0; break;
-		case SCHISM_KEYSYM_F2: i = 1; break;
-		case SCHISM_KEYSYM_F3: i = 2; break;
-		case SCHISM_KEYSYM_F4: i = 3; break;
-		case SCHISM_KEYSYM_F5: i = 4; break;
-		case SCHISM_KEYSYM_F6: i = 5; break;
-		case SCHISM_KEYSYM_F7: i = 6; break;
-		case SCHISM_KEYSYM_F8: i = 7; break;
+		switch (k->scancode) {
+		case SCHISM_SCANCODE_F1: i = 0; break;
+		case SCHISM_SCANCODE_F2: i = 1; break;
+		case SCHISM_SCANCODE_F3: i = 2; break;
+		case SCHISM_SCANCODE_F4: i = 3; break;
+		case SCHISM_SCANCODE_F5: i = 4; break;
+		case SCHISM_SCANCODE_F6: i = 5; break;
+		case SCHISM_SCANCODE_F7: i = 6; break;
+		case SCHISM_SCANCODE_F8: i = 7; break;
 		default:
 			return 0;
 		};
@@ -965,13 +965,13 @@ static int _handle_ime(struct key_event *k)
 		if (digraph_n == -1 && k->state == KEY_RELEASE) {
 			digraph_n = 0;
 
-		} else if (!(status.flags & CLASSIC_MODE) && (k->sym == SCHISM_KEYSYM_LCTRL || k->sym == SCHISM_KEYSYM_RCTRL)) {
+		} else if (!(status.flags & CLASSIC_MODE) && (k->scancode == SCHISM_SCANCODE_LCTRL || k->scancode == SCHISM_SCANCODE_RCTRL)) {
 			if (k->state == KEY_RELEASE && digraph_n >= 0) {
 				digraph_n++;
 				if (digraph_n >= 2)
 					status_text_flash_bios("Enter digraph:");
 			}
-		} else if (k->sym == SCHISM_KEYSYM_LSHIFT || k->sym == SCHISM_KEYSYM_RSHIFT) {
+		} else if (k->scancode == SCHISM_SCANCODE_LSHIFT || k->scancode == SCHISM_SCANCODE_RSHIFT) {
 			/* do nothing */
 		} else if (!NO_MODIFIER((k->mod&~SCHISM_KEYMOD_SHIFT)) || (c=(k->text) ? ((uint8_t)*k->text) : k->sym) == 0 || digraph_n < 2) {
 			if (k->state == KEY_PRESS && k->mouse == MOUSE_NONE) {
@@ -1005,7 +1005,7 @@ static int _handle_ime(struct key_event *k)
 		}
 
 		/* ctrl+shift -> unicode character */
-		if (k->sym==SCHISM_KEYSYM_LCTRL || k->sym==SCHISM_KEYSYM_RCTRL || k->sym==SCHISM_KEYSYM_LSHIFT || k->sym==SCHISM_KEYSYM_RSHIFT) {
+		if (k->scancode==SCHISM_SCANCODE_LCTRL || k->scancode==SCHISM_SCANCODE_RCTRL || k->scancode==SCHISM_SCANCODE_LSHIFT || k->scancode==SCHISM_SCANCODE_RSHIFT) {
 			if (k->state == KEY_RELEASE) {
 				if (cs_unicode_c > 0) {
 					uint8_t unicode[2] = {0};
@@ -1045,15 +1045,15 @@ static int _handle_ime(struct key_event *k)
 				}
 			}
 		} else {
-			if (k->sym==SCHISM_KEYSYM_LCTRL || k->sym==SCHISM_KEYSYM_RCTRL || k->sym==SCHISM_KEYSYM_LSHIFT || k->sym==SCHISM_KEYSYM_RSHIFT) {
+			if (k->scancode==SCHISM_SCANCODE_LCTRL || k->scancode==SCHISM_SCANCODE_RCTRL || k->scancode==SCHISM_SCANCODE_LSHIFT || k->scancode==SCHISM_SCANCODE_RSHIFT) {
 				return 1;
 			}
 			cs_unicode = cs_unicode_c = 0;
 		}
 
 		/* alt+numpad -> char number */
-		if (k->sym == SCHISM_KEYSYM_LALT || k->sym == SCHISM_KEYSYM_RALT
-			|| k->sym == SCHISM_KEYSYM_LGUI || k->sym == SCHISM_KEYSYM_RGUI) {
+		if (k->scancode == SCHISM_SCANCODE_LALT || k->scancode == SCHISM_SCANCODE_RALT
+			|| k->scancode == SCHISM_SCANCODE_LGUI || k->scancode == SCHISM_SCANCODE_RGUI) {
 			if (k->state == KEY_RELEASE && alt_numpad_c > 0 && (alt_numpad & 255) > 0) {\
 				if (alt_numpad < 32)
 					return 0;
@@ -1114,8 +1114,8 @@ void handle_key(struct key_event *k)
 	if (widget_handle_key(k)) return;
 
 	/* now check a couple other keys. */
-	switch (k->sym) {
-	case SCHISM_KEYSYM_LEFT:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_LEFT:
 		if (k->state == KEY_RELEASE) return;
 		if (status.flags & DISKWRITER_ACTIVE) return;
 		if ((k->mod & SCHISM_KEYMOD_CTRL) && status.current_page != PAGE_PATTERN_EDITOR) {
@@ -1125,7 +1125,7 @@ void handle_key(struct key_event *k)
 			return;
 		}
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (k->state == KEY_RELEASE) return;
 		if (status.flags & DISKWRITER_ACTIVE) return;
 		if ((k->mod & SCHISM_KEYMOD_CTRL) && status.current_page != PAGE_PATTERN_EDITOR) {
@@ -1135,7 +1135,7 @@ void handle_key(struct key_event *k)
 			return;
 		}
 		break;
-	case SCHISM_KEYSYM_ESCAPE:
+	case SCHISM_SCANCODE_ESCAPE:
 		/* TODO | Page key handlers should return true/false depending on if the key was handled
 		   TODO | (same as with other handlers), and the escape key check should go *after* the
 		   TODO | page gets a chance to grab it. This way, the load sample page can switch back
@@ -1153,17 +1153,21 @@ void handle_key(struct key_event *k)
 			return;
 		}
 		break;
-	case SCHISM_KEYSYM_SLASH:
+	case SCHISM_SCANCODE_SLASH:
 		if (k->state == KEY_RELEASE) return;
 		if (status.flags & DISKWRITER_ACTIVE) return;
 		kbd_set_current_octave(kbd_get_current_octave() - 1);
 		break;
-	case SCHISM_KEYSYM_ASTERISK:
+	case SCHISM_SCANCODE_8:
+		if (!(k->mod & SCHISM_KEYMOD_SHIFT))
+			break;
+		SCHISM_FALLTHROUGH;
+	case SCHISM_SCANCODE_KP_MULTIPLY:
 		if (k->state == KEY_RELEASE) return;
 		if (status.flags & DISKWRITER_ACTIVE) return;
 		kbd_set_current_octave(kbd_get_current_octave() + 1);
 		break;
-	case SCHISM_KEYSYM_LEFTBRACKET:
+	case SCHISM_SCANCODE_LEFTBRACKET:
 		if (k->state == KEY_RELEASE) break;
 		if (status.flags & DISKWRITER_ACTIVE) return;
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
@@ -1186,7 +1190,7 @@ void handle_key(struct key_event *k)
 			}
 		}
 		return;
-	case SCHISM_KEYSYM_RIGHTBRACKET:
+	case SCHISM_SCANCODE_RIGHTBRACKET:
 		if (k->state == KEY_RELEASE) break;
 		if (status.flags & DISKWRITER_ACTIVE) return;
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
@@ -1772,13 +1776,13 @@ static int _tj_num1 = 0, _tj_num2 = 0;
 
 static int _timejump_keyh(struct key_event *k)
 {
-	if (k->sym == SCHISM_KEYSYM_BACKSPACE) {
+	if (k->scancode == SCHISM_SCANCODE_BACKSPACE) {
 		if (*selected_widget == 1 && _timejump_widgets[1].d.numentry.value == 0) {
 			if (k->state == KEY_RELEASE) widget_change_focus_to(0);
 			return 1;
 		}
 	}
-	if (k->sym == SCHISM_KEYSYM_COLON || k->sym == SCHISM_KEYSYM_SEMICOLON) {
+	if (k->scancode == SCHISM_SCANCODE_SEMICOLON) {
 		if (k->state == KEY_RELEASE) {
 			if (*selected_widget == 0) {
 				widget_change_focus_to(1);

--- a/schism/page_about.c
+++ b/schism/page_about.c
@@ -55,23 +55,23 @@ static struct vgamem_overlay logo_image = {
 static int _fixup_ignore_globals(struct key_event *k)
 {
 	if (k->mouse && k->y > 20) return 0;
-	switch (k->sym) {
-	case SCHISM_KEYSYM_LEFT:
-	case SCHISM_KEYSYM_RIGHT:
-	case SCHISM_KEYSYM_DOWN:
-	case SCHISM_KEYSYM_UP:
-	case SCHISM_KEYSYM_TAB:
-	case SCHISM_KEYSYM_RETURN:
-	case SCHISM_KEYSYM_ESCAPE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_LEFT:
+	case SCHISM_SCANCODE_RIGHT:
+	case SCHISM_SCANCODE_DOWN:
+	case SCHISM_SCANCODE_UP:
+	case SCHISM_SCANCODE_TAB:
+	case SCHISM_SCANCODE_RETURN:
+	case SCHISM_SCANCODE_ESCAPE:
 		/* use default handler */
 		return 0;
-	case SCHISM_KEYSYM_F2: case SCHISM_KEYSYM_F5: case SCHISM_KEYSYM_F9: case SCHISM_KEYSYM_F10:
+	case SCHISM_SCANCODE_F2: case SCHISM_SCANCODE_F5: case SCHISM_SCANCODE_F9: case SCHISM_SCANCODE_F10:
 		// Ctrl + these keys does not lead to a new screen
 		if (k->mod & SCHISM_KEYMOD_CTRL)
 			break;
 		// Fall through.
-	case SCHISM_KEYSYM_F1: case SCHISM_KEYSYM_F3: case SCHISM_KEYSYM_F4:
-	case SCHISM_KEYSYM_F11: case SCHISM_KEYSYM_F12:
+	case SCHISM_SCANCODE_F1: case SCHISM_SCANCODE_F3: case SCHISM_SCANCODE_F4:
+	case SCHISM_SCANCODE_F11: case SCHISM_SCANCODE_F12:
 		// Ignore Alt and so on.
 		if (k->mod & (SCHISM_KEYMOD_ALT | SCHISM_KEYMOD_SHIFT))
 			break;

--- a/schism/page_help.c
+++ b/schism/page_help.c
@@ -161,38 +161,38 @@ static int help_handle_key(struct key_event * k)
 	} else if (k->mouse != MOUSE_NONE) {
 		return 0;
 	}
-	switch (k->sym) {
-	case SCHISM_KEYSYM_ESCAPE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_ESCAPE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		set_page(status.previous_page);
 		return 1;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_line--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_line++;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_line -= 32;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_line += 32;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_line = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_line = num_lines - 32;

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -1049,14 +1049,14 @@ static int info_page_handle_key(struct key_event * k)
 	}
 
 	/* hack to render this useful :) */
-	if (k->sym == SCHISM_KEYSYM_KP_9) {
-		k->sym = SCHISM_KEYSYM_F9;
-	} else if (k->sym == SCHISM_KEYSYM_KP_0) {
-		k->sym = SCHISM_KEYSYM_F10;
+	if (k->scancode == SCHISM_SCANCODE_KP_9) {
+		k->scancode = SCHISM_SCANCODE_F9;
+	} else if (k->scancode == SCHISM_SCANCODE_KP_0) {
+		k->scancode = SCHISM_SCANCODE_F10;
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_g:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_G:
 		if (k->state == KEY_PRESS)
 			return 1;
 
@@ -1075,7 +1075,7 @@ static int info_page_handle_key(struct key_event * k)
 			set_page(PAGE_PATTERN_EDITOR);
 		}
 	       return 1;
-	case SCHISM_KEYSYM_v:
+	case SCHISM_SCANCODE_V:
 		if (k->state == KEY_RELEASE)
 			return 1;
 
@@ -1083,7 +1083,7 @@ static int info_page_handle_key(struct key_event * k)
 		status_text_flash("Using %s bars", (velocity_mode ? "velocity" : "volume"));
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_i:
+	case SCHISM_SCANCODE_I:
 		if (k->state == KEY_RELEASE)
 			return 1;
 
@@ -1091,7 +1091,7 @@ static int info_page_handle_key(struct key_event * k)
 		status_text_flash("Using %s names", (instrument_names ? "instrument" : "sample"));
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_R:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -1101,32 +1101,33 @@ static int info_page_handle_key(struct key_event * k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_EQUALS:
+	case SCHISM_SCANCODE_EQUALS:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT))
 			return 0;
 		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_PLUS:
+	case SCHISM_SCANCODE_KP_PLUS:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (song_get_mode() == MODE_PLAYING) {
 			song_set_current_order(song_get_current_order() + 1);
 		}
 		return 1;
-	case SCHISM_KEYSYM_MINUS:
+	case SCHISM_SCANCODE_MINUS:
+	case SCHISM_SCANCODE_KP_MINUS:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (song_get_mode() == MODE_PLAYING) {
 			song_set_current_order(song_get_current_order() - 1);
 		}
 		return 1;
-	case SCHISM_KEYSYM_q:
+	case SCHISM_SCANCODE_Q:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_toggle_channel_mute(selected_channel - 1);
 		orderpan_recheck_muted_channels();
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_s:
+	case SCHISM_SCANCODE_S:
 		if (k->state == KEY_RELEASE)
 			return 1;
 
@@ -1140,7 +1141,7 @@ static int info_page_handle_key(struct key_event * k)
 		}
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_SPACE:
+	case SCHISM_SCANCODE_SPACE:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 
@@ -1151,7 +1152,7 @@ static int info_page_handle_key(struct key_event * k)
 			selected_channel++;
 		orderpan_recheck_muted_channels();
 		break;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -1168,7 +1169,7 @@ static int info_page_handle_key(struct key_event * k)
 		if (selected_channel > 1)
 			selected_channel--;
 		break;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (!NO_MODIFIER(k->mod) && !(k->mod & SCHISM_KEYMOD_ALT))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -1176,7 +1177,7 @@ static int info_page_handle_key(struct key_event * k)
 		if (selected_channel > 1)
 			selected_channel--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -1196,7 +1197,7 @@ static int info_page_handle_key(struct key_event * k)
 		if (selected_channel < 64)
 			selected_channel++;
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod) && !(k->mod & SCHISM_KEYMOD_ALT))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -1204,21 +1205,21 @@ static int info_page_handle_key(struct key_event * k)
 		if (selected_channel < 64)
 			selected_channel++;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selected_channel = 1;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selected_channel = song_find_last_channel();
 		break;
-	case SCHISM_KEYSYM_INSERT:
+	case SCHISM_SCANCODE_INSERT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -1244,7 +1245,7 @@ static int info_page_handle_key(struct key_event * k)
 			windows[selected_window + 1].height++;
 		}
 		break;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -1267,7 +1268,7 @@ static int info_page_handle_key(struct key_event * k)
 		if (selected_window == num_windows)
 			selected_window--;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -1278,14 +1279,14 @@ static int info_page_handle_key(struct key_event * k)
 		n--;
 		windows[selected_window].type = n;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		windows[selected_window].type = (windows[selected_window].type + 1) % NUM_WINDOW_TYPES;
 		break;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
@@ -1297,7 +1298,7 @@ static int info_page_handle_key(struct key_event * k)
 		}
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_F9:
+	case SCHISM_SCANCODE_F9:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -1306,7 +1307,7 @@ static int info_page_handle_key(struct key_event * k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_F10:
+	case SCHISM_SCANCODE_F10:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_RELEASE)
 				return 1;

--- a/schism/page_instruments.c
+++ b/schism/page_instruments.c
@@ -469,8 +469,8 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 			return 1;
 		}
 	} else {
-		switch (k->sym) {
-		case SCHISM_KEYSYM_UP:
+		switch (k->scancode) {
+		case SCHISM_SCANCODE_UP:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -484,13 +484,13 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				new_ins--;
 			}
 			break;
-		case SCHISM_KEYSYM_DOWN:
+		case SCHISM_SCANCODE_DOWN:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_ALT) {
 				// restrict position to the "old" value of _last_vis_inst()
 				// (this is entirely for aesthetic reasons)
-				if (status.last_keysym != SCHISM_KEYSYM_DOWN && !k->is_repeat)
+				if (status.last_scancode != SCHISM_SCANCODE_DOWN && !k->is_repeat)
 					_altswap_lastvis = _last_vis_inst();
 				if (current_instrument < _altswap_lastvis) {
 					new_ins = current_instrument + 1;
@@ -502,7 +502,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				new_ins++;
 			}
 			break;
-		case SCHISM_KEYSYM_PAGEUP:
+		case SCHISM_SCANCODE_PAGEUP:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -510,7 +510,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 			else
 				new_ins -= 16;
 			break;
-		case SCHISM_KEYSYM_PAGEDOWN:
+		case SCHISM_SCANCODE_PAGEDOWN:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -518,7 +518,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 			else
 				new_ins += 16;
 			break;
-		case SCHISM_KEYSYM_HOME:
+		case SCHISM_SCANCODE_HOME:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
@@ -529,7 +529,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				status.flags |= NEED_UPDATE;
 			}
 			return 1;
-		case SCHISM_KEYSYM_END:
+		case SCHISM_SCANCODE_END:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
@@ -540,7 +540,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				status.flags |= NEED_UPDATE;
 			}
 			return 1;
-		case SCHISM_KEYSYM_LEFT:
+		case SCHISM_SCANCODE_LEFT:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
@@ -551,7 +551,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				status.flags |= NEED_UPDATE;
 			}
 			return 1;
-		case SCHISM_KEYSYM_RIGHT:
+		case SCHISM_SCANCODE_RIGHT:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
@@ -565,7 +565,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				status.flags |= NEED_UPDATE;
 			}
 			return 1;
-		case SCHISM_KEYSYM_RETURN:
+		case SCHISM_SCANCODE_RETURN:
 			if (k->state == KEY_PRESS)
 				return 0;
 			if (instrument_cursor_pos < 25) {
@@ -577,7 +577,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				set_page(PAGE_LOAD_INSTRUMENT);
 			}
 			return 1;
-		case SCHISM_KEYSYM_ESCAPE:
+		case SCHISM_SCANCODE_ESCAPE:
 			if ((k->mod & SCHISM_KEYMOD_SHIFT) || instrument_cursor_pos < 25) {
 				if (k->state == KEY_RELEASE)
 					return 1;
@@ -587,7 +587,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				return 1;
 			}
 			return 0;
-		case SCHISM_KEYSYM_BACKSPACE:
+		case SCHISM_SCANCODE_BACKSPACE:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (instrument_cursor_pos == 25)
@@ -597,7 +597,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 			else if (k->mod & SCHISM_KEYMOD_CTRL)
 				instrument_list_add_char(127);
 			return 1;
-		case SCHISM_KEYSYM_INSERT:
+		case SCHISM_SCANCODE_INSERT:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -606,7 +606,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				return 1;
 			}
 			return 0;
-		case SCHISM_KEYSYM_DELETE:
+		case SCHISM_SCANCODE_DELETE:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -625,7 +625,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				return 0;
 
 			if (k->mod & SCHISM_KEYMOD_ALT) {
-				if (k->sym == SCHISM_KEYSYM_c) {
+				if (k->scancode == SCHISM_SCANCODE_C) {
 					clear_instrument_text();
 					return 1;
 				}
@@ -633,7 +633,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 				if (instrument_cursor_pos < 25) {
 					if (k->text)
 						return instrument_list_handle_text_input_on_list(k->text);
-				} else if (k->sym == SCHISM_KEYSYM_SPACE) {
+				} else if (k->scancode == SCHISM_SCANCODE_SPACE) {
 					instrument_cursor_pos = 0;
 					get_page_widgets()->accept_text = 0;
 					status.flags |= NEED_UPDATE;
@@ -813,20 +813,20 @@ static int note_trans_handle_key(struct key_event * k)
 	} else if (k->mod & SCHISM_KEYMOD_ALT) {
 		if (k->state == KEY_RELEASE)
 			return 0;
-		switch (k->sym) {
-		case SCHISM_KEYSYM_UP:
+		switch (k->scancode) {
+		case SCHISM_SCANCODE_UP:
 			instrument_note_trans_transpose(ins, 1);
 			break;
-		case SCHISM_KEYSYM_DOWN:
+		case SCHISM_SCANCODE_DOWN:
 			instrument_note_trans_transpose(ins, -1);
 			break;
-		case SCHISM_KEYSYM_INSERT:
+		case SCHISM_SCANCODE_INSERT:
 			instrument_note_trans_insert(ins, note_trans_sel_line);
 			break;
-		case SCHISM_KEYSYM_DELETE:
+		case SCHISM_SCANCODE_DELETE:
 			instrument_note_trans_delete(ins, note_trans_sel_line);
 			break;
-		case SCHISM_KEYSYM_n:
+		case SCHISM_SCANCODE_N:
 			n = note_trans_sel_line - 1; // the line to copy *from*
 			if (n < 0 || ins->note_map[n] == NOTE_LAST)
 				break;
@@ -834,7 +834,7 @@ static int note_trans_handle_key(struct key_event * k)
 			ins->sample_map[note_trans_sel_line] = ins->sample_map[n];
 			new_line++;
 			break;
-		case SCHISM_KEYSYM_p:
+		case SCHISM_SCANCODE_P:
 			n = note_trans_sel_line + 1; // the line to copy *from*
 			if (n > (NOTE_LAST - NOTE_FIRST) || ins->note_map[n] == NOTE_FIRST)
 				break;
@@ -842,7 +842,7 @@ static int note_trans_handle_key(struct key_event * k)
 			ins->sample_map[note_trans_sel_line] = ins->sample_map[n];
 			new_line--;
 			break;
-		case SCHISM_KEYSYM_a:
+		case SCHISM_SCANCODE_A:
 			c = sample_get_current();
 			for (n = 0; n < (NOTE_LAST - NOTE_FIRST + 1); n++)
 				ins->sample_map[n] = c;
@@ -855,8 +855,8 @@ static int note_trans_handle_key(struct key_event * k)
 			return 0;
 		}
 	} else {
-		switch (k->sym) {
-		case SCHISM_KEYSYM_UP:
+		switch (k->scancode) {
+		case SCHISM_SCANCODE_UP:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -868,7 +868,7 @@ static int note_trans_handle_key(struct key_event * k)
 				return 1;
 			}
 			break;
-		case SCHISM_KEYSYM_DOWN:
+		case SCHISM_SCANCODE_DOWN:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -877,7 +877,7 @@ static int note_trans_handle_key(struct key_event * k)
 				return 0;
 			new_line++;
 			break;
-		case SCHISM_KEYSYM_PAGEUP:
+		case SCHISM_SCANCODE_PAGEUP:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -886,7 +886,7 @@ static int note_trans_handle_key(struct key_event * k)
 			}
 			new_line -= 16;
 			break;
-		case SCHISM_KEYSYM_PAGEDOWN:
+		case SCHISM_SCANCODE_PAGEDOWN:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -895,35 +895,35 @@ static int note_trans_handle_key(struct key_event * k)
 			}
 			new_line += 16;
 			break;
-		case SCHISM_KEYSYM_HOME:
+		case SCHISM_SCANCODE_HOME:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
 				return 0;
 			new_line = 0;
 			break;
-		case SCHISM_KEYSYM_END:
+		case SCHISM_SCANCODE_END:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
 				return 0;
 			new_line = 119;
 			break;
-		case SCHISM_KEYSYM_LEFT:
+		case SCHISM_SCANCODE_LEFT:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
 				return 0;
 			new_pos--;
 			break;
-		case SCHISM_KEYSYM_RIGHT:
+		case SCHISM_SCANCODE_RIGHT:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
 				return 0;
 			new_pos++;
 			break;
-		case SCHISM_KEYSYM_RETURN:
+		case SCHISM_SCANCODE_RETURN:
 			if (k->state == KEY_PRESS)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
@@ -931,16 +931,20 @@ static int note_trans_handle_key(struct key_event * k)
 			sample_set(ins->sample_map[note_trans_sel_line]);
 			get_page_widgets()->accept_text = (instrument_cursor_pos == 25 ? 0 : 1);
 			return 1;
-		case SCHISM_KEYSYM_LESS:
-		case SCHISM_KEYSYM_SEMICOLON:
-		case SCHISM_KEYSYM_COLON:
+		case SCHISM_SCANCODE_COMMA:
+			if (!NO_MODIFIER(k->mod))
+				break;
+			SCHISM_FALLTHROUGH;
+		case SCHISM_SCANCODE_SEMICOLON:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			sample_set(sample_get_current() - 1);
 			return 1;
-		case SCHISM_KEYSYM_GREATER:
-		case SCHISM_KEYSYM_QUOTE:
-		case SCHISM_KEYSYM_QUOTEDBL:
+		case SCHISM_SCANCODE_PERIOD:
+			if (!NO_MODIFIER(k->mod))
+				break;
+			SCHISM_FALLTHROUGH;
+		case SCHISM_SCANCODE_APOSTROPHE:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			sample_set(sample_get_current() + 1);
@@ -973,19 +977,19 @@ static int note_trans_handle_key(struct key_event * k)
 
 			case 2:        /* instrument, first digit */
 			case 3:        /* instrument, second digit */
-				if (k->sym == SCHISM_KEYSYM_SPACE) {
+				if (k->scancode == SCHISM_SCANCODE_SPACE) {
 					ins->sample_map[note_trans_sel_line] =
 						sample_get_current();
 					new_line++;
 					break;
 				}
 
-				if ((k->sym == SCHISM_KEYSYM_PERIOD && NO_MODIFIER(k->mod)) || k->sym == SCHISM_KEYSYM_DELETE) {
+				if ((k->scancode == SCHISM_SCANCODE_PERIOD && NO_MODIFIER(k->mod)) || k->scancode == SCHISM_SCANCODE_DELETE) {
 					ins->sample_map[note_trans_sel_line] = 0;
-					new_line += (k->sym == SCHISM_KEYSYM_PERIOD) ? 1 : 0;
+					new_line += (k->scancode == SCHISM_SCANCODE_PERIOD) ? 1 : 0;
 					break;
 				}
-				if (k->sym == SCHISM_KEYSYM_COMMA && NO_MODIFIER(k->mod)) {
+				if (k->scancode == SCHISM_SCANCODE_COMMA && NO_MODIFIER(k->mod)) {
 					note_sample_mask = note_sample_mask ? 0 : 1;
 					break;
 				}
@@ -1408,32 +1412,32 @@ static int _env_handle_key_viewmode(struct key_event *k, song_envelope_t *env, i
 	int new_node = *current_node;
 	int n;
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		widget_change_focus_to(1);
 		return 1;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		widget_change_focus_to(6);
 		return 1;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_node--;
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_node++;
 		break;
-	case SCHISM_KEYSYM_INSERT:
+	case SCHISM_SCANCODE_INSERT:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
@@ -1441,7 +1445,7 @@ static int _env_handle_key_viewmode(struct key_event *k, song_envelope_t *env, i
 		*current_node = _env_node_add(env, *current_node, -1, -1);
 		status.flags |= NEED_UPDATE;
 		return 1 | 2;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
@@ -1449,7 +1453,7 @@ static int _env_handle_key_viewmode(struct key_event *k, song_envelope_t *env, i
 		*current_node = _env_node_remove(env, *current_node);
 		status.flags |= NEED_UPDATE;
 		return 1 | 2;
-	case SCHISM_KEYSYM_SPACE:
+	case SCHISM_SCANCODE_SPACE:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->is_repeat)
@@ -1464,7 +1468,7 @@ static int _env_handle_key_viewmode(struct key_event *k, song_envelope_t *env, i
 		}
 
 		return 0;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
@@ -1472,7 +1476,7 @@ static int _env_handle_key_viewmode(struct key_event *k, song_envelope_t *env, i
 		envelope_edit_mode = 1;
 		status.flags |= NEED_UPDATE;
 		return 1 | 2;
-	case SCHISM_KEYSYM_l:
+	case SCHISM_SCANCODE_L:
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) return 0;
@@ -1481,7 +1485,7 @@ static int _env_handle_key_viewmode(struct key_event *k, song_envelope_t *env, i
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_b:
+	case SCHISM_SCANCODE_B:
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) return 0;
@@ -1493,26 +1497,26 @@ static int _env_handle_key_viewmode(struct key_event *k, song_envelope_t *env, i
 
 	// F/G for key symmetry with pattern double/halve block
 	// E for symmetry with sample resize
-	case SCHISM_KEYSYM_f:
+	case SCHISM_SCANCODE_F:
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) return 0;
 		env_resize(env, env->ticks[env->nodes - 1] * 2);
 		return 1;
-	case SCHISM_KEYSYM_g:
+	case SCHISM_SCANCODE_G:
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) return 0;
 		env_resize(env, env->ticks[env->nodes - 1] / 2);
 		return 1;
-	case SCHISM_KEYSYM_e:
+	case SCHISM_SCANCODE_E:
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) return 0;
 		env_resize_dialog(env);
 		return 1;
 
-	case SCHISM_KEYSYM_z:
+	case SCHISM_SCANCODE_Z:
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) return 0;
@@ -1689,8 +1693,8 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 
 	/* TODO: when does adding/removing a node alter loop points? */
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_ALT)
@@ -1698,7 +1702,7 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 		else
 			new_value++;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_ALT)
@@ -1706,21 +1710,21 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 		else
 			new_value--;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_value += 16;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_value -= 16;
 		break;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -1730,7 +1734,7 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 		else
 			new_tick--;
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -1740,7 +1744,7 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 		else
 			new_tick++;
 		break;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_SHIFT)
@@ -1748,21 +1752,21 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 		else
 			new_tick += 16;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_tick = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_tick = 10000;
 		break;
-	case SCHISM_KEYSYM_INSERT:
+	case SCHISM_SCANCODE_INSERT:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
@@ -1770,7 +1774,7 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 		*current_node = _env_node_add(env, *current_node, -1, -1);
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
@@ -1778,7 +1782,7 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 		*current_node = _env_node_remove(env, *current_node);
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_SPACE:
+	case SCHISM_SCANCODE_SPACE:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
@@ -1786,7 +1790,7 @@ static int _env_handle_key_editmode(struct key_event *k, song_envelope_t *env, i
 		song_keyup(KEYJAZZ_NOINST, current_instrument, last_note);
 		song_keydown(KEYJAZZ_NOINST, current_instrument, last_note, 64, KEYJAZZ_CHAN_CURRENT);
 		return 1;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_PRESS)
 			return 0;
 		if (!NO_MODIFIER(k->mod))
@@ -1945,13 +1949,13 @@ static int pitch_pan_center_handle_key(struct key_event *k)
 
 	if (k->state == KEY_RELEASE)
 		return 0;
-	switch (k->sym) {
-	case SCHISM_KEYSYM_LEFT:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_LEFT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		ppc--;
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		ppc++;
@@ -2082,37 +2086,37 @@ static int export_instrument_list_handle_key(struct key_event * k)
 
 	if (k->state == KEY_RELEASE)
 		return 0;
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_format--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_format++;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_PAGEUP:
+	case SCHISM_SCANCODE_HOME:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_format = 0;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_PAGEDOWN:
+	case SCHISM_SCANCODE_END:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_format = num_save_formats - 1;
 		break;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			widget_change_focus_to(0);
 			return 1;
 		}
 		/* fall through */
-	case SCHISM_KEYSYM_LEFT:
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_LEFT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		widget_change_focus_to(0); /* should focus 0/1/2 depending on what's closest */
@@ -2177,30 +2181,30 @@ static void instrument_list_handle_alt_key(struct key_event *k)
 
 	if (k->state == KEY_RELEASE)
 		return;
-	switch (k->sym) {
-	case SCHISM_KEYSYM_n:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_N:
 		song_toggle_multichannel_mode();
 		return;
-	case SCHISM_KEYSYM_o:
+	case SCHISM_SCANCODE_O:
 		instrument_save(NULL, "ITI");
 		return;
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_R:
 		smpprompt_create("Replace instrument with:", "Instrument", do_replace_instrument);
 		return;
-	case SCHISM_KEYSYM_s:
+	case SCHISM_SCANCODE_S:
 		// extra space to align the text like IT
 		smpprompt_create("Swap instrument with: ", "Instrument", do_swap_instrument);
 		return;
-	case SCHISM_KEYSYM_x:
+	case SCHISM_SCANCODE_X:
 		smpprompt_create("Exchange instrument with:", "Instrument", do_exchange_instrument);
 		return;
-	case SCHISM_KEYSYM_p:
+	case SCHISM_SCANCODE_P:
 		smpprompt_create("Copy instrument:", "Instrument", do_copy_instrument);
 		return;
-	case SCHISM_KEYSYM_w:
+	case SCHISM_SCANCODE_W:
 		song_wipe_instrument(current_instrument);
 		break;
-	case SCHISM_KEYSYM_d:
+	case SCHISM_SCANCODE_D:
         if (k->mod & SCHISM_KEYMOD_SHIFT) {
             dialog_create(DIALOG_OK_CANCEL,
                 "Delete Instrument? (preserve shared samples)",
@@ -2211,7 +2215,7 @@ static void instrument_list_handle_alt_key(struct key_event *k)
                 do_delete_inst, NULL, 1, NULL);
         }
 		return;
-	case SCHISM_KEYSYM_t:
+	case SCHISM_SCANCODE_T:
 		export_instrument_dialog();
 		break;
 	default:
@@ -2224,7 +2228,7 @@ static void instrument_list_handle_alt_key(struct key_event *k)
 static int instrument_list_pre_handle_key(struct key_event * k)
 {
 	// Only handle plain F4 key when no dialog is active.
-	if (status.dialog_type != DIALOG_NONE || k->sym != SCHISM_KEYSYM_F4 || (k->mod & (SCHISM_KEYMOD_CTRL | SCHISM_KEYMOD_ALT)))
+	if (status.dialog_type != DIALOG_NONE || k->scancode != SCHISM_SCANCODE_F4 || (k->mod & (SCHISM_KEYMOD_CTRL | SCHISM_KEYMOD_ALT)))
 		return 0;
 	if (k->state == KEY_RELEASE)
 		return 1;
@@ -2259,40 +2263,36 @@ static int instrument_list_pre_handle_key(struct key_event * k)
 }
 static void instrument_list_handle_key(struct key_event * k)
 {
-	switch (k->sym) {
-	case SCHISM_KEYSYM_COMMA:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_COMMA:
 		if (NO_MODIFIER(k->mod)) {
 			if (!(status.flags & CLASSIC_MODE)
 			&& ACTIVE_PAGE.selected_widget == 5) return;
 		}
-		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_LESS:
 		if (k->state == KEY_RELEASE)
 			return;
 		song_change_current_play_channel(-1, 0);
 		return;
-	case SCHISM_KEYSYM_PERIOD:
+	case SCHISM_SCANCODE_PERIOD:
 		if (NO_MODIFIER(k->mod)) {
 			if (!(status.flags & CLASSIC_MODE)
 			&& ACTIVE_PAGE.selected_widget == 5) return;
 		}
-		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_GREATER:
 		if (k->state == KEY_RELEASE)
 			return;
 		song_change_current_play_channel(1, 0);
 		return;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (k->state == KEY_RELEASE)
 			return;
 		instrument_set(current_instrument - 1);
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
 			return;
 		instrument_set(current_instrument + 1);
 		break;
-	case SCHISM_KEYSYM_ESCAPE:
+	case SCHISM_SCANCODE_ESCAPE:
 		if ((k->mod & SCHISM_KEYMOD_SHIFT) || instrument_cursor_pos < 25) {
 			if (k->state == KEY_RELEASE)
 				return;
@@ -2325,7 +2325,7 @@ static void instrument_list_handle_key(struct key_event * k)
 
 			if (k->state == KEY_RELEASE) {
 				song_keyup(KEYJAZZ_NOINST, current_instrument, n);
-				status.last_keysym = 0;
+				status.last_scancode = 0;
 			} else if (!k->is_repeat) {
 				song_keydown(KEYJAZZ_NOINST, current_instrument, n, v, KEYJAZZ_CHAN_AUTO);
 			}
@@ -2883,7 +2883,7 @@ static int _fixup_mouse_instpage_volume(struct key_event *k)
 			return 1;
 		}
 	}
-	if ((k->sym == SCHISM_KEYSYM_l || k->sym == SCHISM_KEYSYM_b) && (k->mod & SCHISM_KEYMOD_ALT)) {
+	if ((k->scancode == SCHISM_SCANCODE_L || k->scancode == SCHISM_SCANCODE_B) && (k->mod & SCHISM_KEYMOD_ALT)) {
 		return _env_handle_key_viewmode(k, &ins->vol_env, &current_node_vol, ENV_VOLUME);
 	}
 	return instrument_list_pre_handle_key(k);
@@ -2950,7 +2950,7 @@ static int _fixup_mouse_instpage_panning(struct key_event *k)
 			return 1;
 		}
 	}
-	if ((k->sym == SCHISM_KEYSYM_l || k->sym == SCHISM_KEYSYM_b) && (k->mod & SCHISM_KEYMOD_ALT)) {
+	if ((k->scancode == SCHISM_SCANCODE_L || k->scancode == SCHISM_SCANCODE_B) && (k->mod & SCHISM_KEYMOD_ALT)) {
 		return _env_handle_key_viewmode(k, &ins->pan_env, &current_node_pan, ENV_PANNING);
 	}
 	return instrument_list_pre_handle_key(k);
@@ -3025,7 +3025,7 @@ static int _fixup_mouse_instpage_pitch(struct key_event *k)
 			return 1;
 		}
 	}
-	if ((k->sym == SCHISM_KEYSYM_l || k->sym == SCHISM_KEYSYM_b) && (k->mod & SCHISM_KEYMOD_ALT)) {
+	if ((k->scancode == SCHISM_SCANCODE_L || k->scancode == SCHISM_SCANCODE_B) && (k->mod & SCHISM_KEYMOD_ALT)) {
 		return _env_handle_key_viewmode(k, &ins->pitch_env, &current_node_pitch, ENV_PITCH);
 	}
 	return instrument_list_pre_handle_key(k);

--- a/schism/page_loadinst.c
+++ b/schism/page_loadinst.c
@@ -399,21 +399,21 @@ static int file_list_handle_key(struct key_event * k)
 			}
 		}
 	}
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:           new_file--; slash_search_mode = -1; break;
-	case SCHISM_KEYSYM_DOWN:         new_file++; slash_search_mode = -1; break;
-	case SCHISM_KEYSYM_PAGEUP:       new_file -= 35; slash_search_mode = -1; break;
-	case SCHISM_KEYSYM_PAGEDOWN:     new_file += 35; slash_search_mode = -1; break;
-	case SCHISM_KEYSYM_HOME:         new_file = 0; slash_search_mode = -1; break;
-	case SCHISM_KEYSYM_END:          new_file = flist.num_files - 1; slash_search_mode = -1; break;
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:           new_file--; slash_search_mode = -1; break;
+	case SCHISM_SCANCODE_DOWN:         new_file++; slash_search_mode = -1; break;
+	case SCHISM_SCANCODE_PAGEUP:       new_file -= 35; slash_search_mode = -1; break;
+	case SCHISM_SCANCODE_PAGEDOWN:     new_file += 35; slash_search_mode = -1; break;
+	case SCHISM_SCANCODE_HOME:         new_file = 0; slash_search_mode = -1; break;
+	case SCHISM_SCANCODE_END:          new_file = flist.num_files - 1; slash_search_mode = -1; break;
 
-	case SCHISM_KEYSYM_ESCAPE:
+	case SCHISM_SCANCODE_ESCAPE:
 		if (slash_search_mode < 0) {
 			if (k->state == KEY_RELEASE && NO_MODIFIER(k->mod))
 				set_page(PAGE_SAMPLE_LIST);
 			return 1;
 		} /* else fall through */
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (slash_search_mode < 0) {
 			if (k->state == KEY_PRESS)
 				return 0;
@@ -427,14 +427,14 @@ static int file_list_handle_key(struct key_event * k)
 			return 1;
 		}
 		return 1;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		slash_search_mode = -1;
 		if (flist.num_files > 0)
 			dialog_create(DIALOG_OK_CANCEL, "Delete file?", do_delete_file, NULL, 1, NULL);
 		return 1;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (slash_search_mode > -1) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -444,13 +444,15 @@ static int file_list_handle_key(struct key_event * k)
 			return 1;
 		}
 		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_SLASH:
-		if (slash_search_mode < 0) {
-			if (k->state == KEY_PRESS)
-				return 0;
-			slash_search_mode = 0;
-			status.flags |= NEED_UPDATE;
-			return 1;
+	case SCHISM_SCANCODE_SLASH:
+		if (NO_MODIFIER(k->mod)) {
+			if (slash_search_mode < 0) {
+				if (k->state == KEY_PRESS)
+					return 0;
+				slash_search_mode = 0;
+				status.flags |= NEED_UPDATE;
+				return 1;
+			}
 		}
 		SCHISM_FALLTHROUGH;
 	default:
@@ -485,7 +487,7 @@ static void load_instrument_handle_key(struct key_event * k)
 {
 	if (k->state == KEY_RELEASE)
 		return;
-	if (k->sym == SCHISM_KEYSYM_ESCAPE && NO_MODIFIER(k->mod))
+	if (k->scancode == SCHISM_SCANCODE_ESCAPE && NO_MODIFIER(k->mod))
 		set_page(PAGE_INSTRUMENT_LIST);
 }
 

--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -694,26 +694,26 @@ static int file_list_handle_key(struct key_event * k)
 {
 	int new_file = current_file;
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		new_file--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		new_file++;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		new_file -= 31;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		new_file += 31;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		new_file = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		new_file = flist.num_files - 1;
 		break;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_PRESS)
 			return 1;
 		if (current_file < flist.num_files) {
@@ -723,13 +723,13 @@ static int file_list_handle_key(struct key_event * k)
 		search_text_clear();
 
 		return 1;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (k->state == KEY_RELEASE)
 		    return 1;
 		if (flist.num_files > 0)
 			dialog_create(DIALOG_OK_CANCEL, "Delete file?", do_delete_file, NULL, 1, NULL);
 		return 1;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -737,7 +737,7 @@ static int file_list_handle_key(struct key_event * k)
 		else
 			search_text_delete_char();
 		return 1;
-	case SCHISM_KEYSYM_p:
+	case SCHISM_SCANCODE_P:
 		if ((k->mod & SCHISM_KEYMOD_ALT) && k->state == KEY_PRESS) {
 			show_selected_song_length();
 			return 1;
@@ -886,26 +886,26 @@ static inline int dir_list_handle_key(struct key_event * k, unsigned int width)
 		}
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		new_dir--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		new_dir++;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		new_dir -= 21;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		new_dir += 21;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		new_dir = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		new_dir = dlist.num_dirs - 1;
 		break;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_PRESS)
 			return 0;
 		/* reset */
@@ -917,7 +917,7 @@ static inline int dir_list_handle_key(struct key_event * k, unsigned int width)
 			*selected_widget = 0;
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -925,9 +925,9 @@ static inline int dir_list_handle_key(struct key_event * k, unsigned int width)
 		else
 			search_text_delete_char();
 		return 1;
-	case SCHISM_KEYSYM_SLASH:
+	case SCHISM_SCANCODE_SLASH:
 #ifdef SCHISM_WIN32
-	case SCHISM_KEYSYM_BACKSLASH:
+	case SCHISM_SCANCODE_BACKSLASH:
 #endif
 		if (k->state == KEY_RELEASE)
 			return 0;

--- a/schism/page_loadsample.c
+++ b/schism/page_loadsample.c
@@ -489,22 +489,22 @@ static int stereo_cvt_hk(struct key_event *k)
 		return 0;
 
 	/* trap the default dialog keys - we don't want to escape this dialog without running something */
-	switch (k->sym) {
-	case SCHISM_KEYSYM_RETURN:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_RETURN:
 		printf("why am I here\n");
 		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_ESCAPE: case SCHISM_KEYSYM_o: case SCHISM_KEYSYM_c:
+	case SCHISM_SCANCODE_ESCAPE: case SCHISM_SCANCODE_O: case SCHISM_SCANCODE_C:
 		return 1;
-	case SCHISM_KEYSYM_l:
+	case SCHISM_SCANCODE_L:
 		if (k->state == KEY_RELEASE)
 			stereo_cvt_complete_left();
 		return 1;
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_R:
 		if (k->state == KEY_RELEASE)
 			stereo_cvt_complete_right();
 		return 1;
-	case SCHISM_KEYSYM_s:
-	case SCHISM_KEYSYM_b:
+	case SCHISM_SCANCODE_S:
+	case SCHISM_SCANCODE_B:
 		if (k->state == KEY_RELEASE)
 			stereo_cvt_complete_both();
 		return 1;
@@ -669,7 +669,7 @@ static int file_list_handle_key(struct key_event * k)
 
 	new_file = CLAMP(new_file, 0, flist.num_files - 1);
 
-	if (!(status.flags & CLASSIC_MODE) && k->sym == SCHISM_KEYSYM_n && (k->mod & SCHISM_KEYMOD_ALT)) {
+	if (!(status.flags & CLASSIC_MODE) && k->scancode == SCHISM_SCANCODE_N && (k->mod & SCHISM_KEYMOD_ALT)) {
 		if (k->state == KEY_RELEASE)
 			song_toggle_multichannel_mode();
 		return 1;
@@ -687,21 +687,21 @@ static int file_list_handle_key(struct key_event * k)
 			}
 		}
 	}
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:           new_file--; search_pos = -1; break;
-	case SCHISM_KEYSYM_DOWN:         new_file++; search_pos = -1; break;
-	case SCHISM_KEYSYM_PAGEUP:       new_file -= 35; search_pos = -1; break;
-	case SCHISM_KEYSYM_PAGEDOWN:     new_file += 35; search_pos = -1; break;
-	case SCHISM_KEYSYM_HOME:         new_file = 0; search_pos = -1; break;
-	case SCHISM_KEYSYM_END:          new_file = flist.num_files - 1; search_pos = -1; break;
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:           new_file--; search_pos = -1; break;
+	case SCHISM_SCANCODE_DOWN:         new_file++; search_pos = -1; break;
+	case SCHISM_SCANCODE_PAGEUP:       new_file -= 35; search_pos = -1; break;
+	case SCHISM_SCANCODE_PAGEDOWN:     new_file += 35; search_pos = -1; break;
+	case SCHISM_SCANCODE_HOME:         new_file = 0; search_pos = -1; break;
+	case SCHISM_SCANCODE_END:          new_file = flist.num_files - 1; search_pos = -1; break;
 
-	case SCHISM_KEYSYM_ESCAPE:
+	case SCHISM_SCANCODE_ESCAPE:
 		if (search_pos < 0) {
 			if (k->state == KEY_RELEASE && NO_MODIFIER(k->mod))
 				set_page(PAGE_SAMPLE_LIST);
 			return 1;
 		} /* else fall through */
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (search_pos < 0) {
 			if (k->state == KEY_PRESS)
 				return 0;
@@ -715,14 +715,14 @@ static int file_list_handle_key(struct key_event * k)
 			return 1;
 		}
 		return 1;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		search_pos = -1;
 		if (flist.num_files > 0)
 			dialog_create(DIALOG_OK_CANCEL, "Delete file?", do_delete_file, NULL, 1, NULL);
 		return 1;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (search_pos > -1) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -732,13 +732,15 @@ static int file_list_handle_key(struct key_event * k)
 			return 1;
 		}
 		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_SLASH:
-		if (search_pos < 0) {
-			if (k->state == KEY_PRESS)
-				return 0;
-			search_pos = 0;
-			status.flags |= NEED_UPDATE;
-			return 1;
+	case SCHISM_SCANCODE_SLASH:
+		if (NO_MODIFIER(k->mod)) {
+			if (search_pos < 0) {
+				if (k->state == KEY_PRESS)
+					return 0;
+				search_pos = 0;
+				status.flags |= NEED_UPDATE;
+				return 1;
+			}
 		}
 		SCHISM_FALLTHROUGH;
 	default:
@@ -788,7 +790,7 @@ static void load_sample_handle_key(struct key_event * k)
 {
 	int n, v;
 
-	if (k->state == KEY_PRESS && k->sym == SCHISM_KEYSYM_ESCAPE && NO_MODIFIER(k->mod)) {
+	if (k->state == KEY_PRESS && k->scancode == SCHISM_SCANCODE_ESCAPE && NO_MODIFIER(k->mod)) {
 		set_page(PAGE_SAMPLE_LIST);
 		return;
 	}

--- a/schism/page_log.c
+++ b/schism/page_log.c
@@ -66,33 +66,33 @@ static void log_draw_const(void)
 
 static int log_handle_key(struct key_event * k)
 {
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		top_line--;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		top_line -= 15;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		top_line++;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		top_line += 15;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		top_line = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		top_line = last_line;

--- a/schism/page_message.c
+++ b/schism/page_message.c
@@ -476,38 +476,38 @@ static int message_handle_key_viewmode(struct key_event * k)
 		}
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		top_line--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		top_line++;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		top_line -= 35;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		top_line += 35;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		top_line = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		top_line = str_get_num_lines(current_song->message) - 34;
 		break;
-	case SCHISM_KEYSYM_t:
+	case SCHISM_SCANCODE_T:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -515,7 +515,7 @@ static int message_handle_key_viewmode(struct key_event * k)
 			break;
 		}
 		return 1;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_PRESS)
 			return 0;
 		message_set_editmode();
@@ -603,50 +603,50 @@ static int message_handle_key_editmode(struct key_event * k)
 	line_len = get_nth_line(current_song->message, cursor_line, &ptr);
 
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_cursor_line--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_cursor_line++;
 		break;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_cursor_char--;
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_cursor_char++;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_cursor_line -= 35;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_cursor_line += 35;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_CTRL)
@@ -654,7 +654,7 @@ static int message_handle_key_editmode(struct key_event * k)
 		else
 			new_cursor_char = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -664,7 +664,7 @@ static int message_handle_key_editmode(struct key_event * k)
 			new_cursor_char = line_len;
 		}
 		break;
-	case SCHISM_KEYSYM_ESCAPE:
+	case SCHISM_SCANCODE_ESCAPE:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -672,7 +672,7 @@ static int message_handle_key_editmode(struct key_event * k)
 		message_set_viewmode();
 		memused_songchanged();
 		return 1;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -683,7 +683,7 @@ static int message_handle_key_editmode(struct key_event * k)
 			message_delete_char();
 		}
 		return 1;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -695,7 +695,7 @@ static int message_handle_key_editmode(struct key_event * k)
 			message_delete_next_char();
 
 		return 1;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (NO_MODIFIER(k->mod)) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -714,10 +714,10 @@ static int message_handle_key_editmode(struct key_event * k)
 			if (k->state == KEY_RELEASE)
 				return 1;
 
-			if (k->sym == SCHISM_KEYSYM_t) {
+			if (k->scancode == SCHISM_SCANCODE_T) {
 				message_extfont = !message_extfont;
 				break;
-			} else if (k->sym == SCHISM_KEYSYM_y) {
+			} else if (k->scancode == SCHISM_SCANCODE_Y) {
 				clippy_select(NULL, NULL, 0);
 				message_delete_line();
 				break;
@@ -726,7 +726,7 @@ static int message_handle_key_editmode(struct key_event * k)
 			if (k->state == KEY_RELEASE)
 				return 1;
 
-			if (k->sym == SCHISM_KEYSYM_c) {
+			if (k->scancode == SCHISM_SCANCODE_C) {
 				prompt_message_clear();
 				return 1;
 			}

--- a/schism/page_midi.c
+++ b/schism/page_midi.c
@@ -154,31 +154,31 @@ static int midi_page_handle_key(struct key_event * k)
 		}
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_SPACE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_SPACE:
 		if (k->state == KEY_PRESS)
 			return 1;
 		toggle_port();
 		return 1;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		new_port -= 13;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		new_port += 13;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		new_port = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		new_port = midi_engine_port_count() - 1;
 		break;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		new_port--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		new_port++;
 		break;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		widget_change_focus_to(1);

--- a/schism/page_midiout.c
+++ b/schism/page_midiout.c
@@ -104,7 +104,7 @@ static void zxx_setpos(int pos)
 
 static int pre_handle_key(struct key_event *k)
 {
-	if (*selected_widget == 25 && k->sym == SCHISM_KEYSYM_UP) {
+	if (*selected_widget == 25 && k->scancode == SCHISM_SCANCODE_UP) {
 		/* scroll up */
 		if (k->state == KEY_RELEASE)
 			return 1;
@@ -113,7 +113,7 @@ static int pre_handle_key(struct key_event *k)
 		zxx_setpos(zxx_top - 1);
 		return 1;
 	}
-	if (*selected_widget == 31 && k->sym == SCHISM_KEYSYM_DOWN) {
+	if (*selected_widget == 31 && k->scancode == SCHISM_SCANCODE_DOWN) {
 		/* scroll down */
 		if (k->state == KEY_RELEASE)
 			return 1;
@@ -121,13 +121,13 @@ static int pre_handle_key(struct key_event *k)
 		return 1;
 	}
 	if ((*selected_widget) >= 25) {
-		switch (k->sym) {
-		case SCHISM_KEYSYM_PAGEUP:
+		switch (k->scancode) {
+		case SCHISM_SCANCODE_PAGEUP:
 			if (k->state == KEY_RELEASE)
 				return 1;
 			zxx_setpos(zxx_top - 7);
 			return 1;
-		case SCHISM_KEYSYM_PAGEDOWN:
+		case SCHISM_SCANCODE_PAGEDOWN:
 			if (k->state == KEY_RELEASE)
 				return 1;
 			zxx_setpos(zxx_top + 7);

--- a/schism/page_orderpan.c
+++ b/schism/page_orderpan.c
@@ -434,8 +434,8 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		}
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_BACKSPACE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (status.flags & CLASSIC_MODE) return 0;
 		if (!(k->mod & SCHISM_KEYMOD_ALT)) return 0;
 		if (k->state == KEY_PRESS)
@@ -445,8 +445,8 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		orderlist_restore();
 		return 1;
 
-	case SCHISM_KEYSYM_RETURN:
-	case SCHISM_KEYSYM_KP_ENTER:
+	case SCHISM_SCANCODE_RETURN:
+	case SCHISM_SCANCODE_KP_ENTER:
 		if (status.flags & CLASSIC_MODE) return 0;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_PRESS)
@@ -457,7 +457,7 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		}
 		// else fall through
 
-	case SCHISM_KEYSYM_g:
+	case SCHISM_SCANCODE_G:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_PRESS)
@@ -471,7 +471,7 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		}
 		return 1;
 
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -483,28 +483,28 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 			widget_change_focus_to(1);
 		}
 		return 1;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_cursor_pos--;
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_cursor_pos++;
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_order = 0;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -513,7 +513,7 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		if (current_song->orderlist[new_order] != ORDER_LAST)
 			new_order++;
 		break;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			if (status.flags & CLASSIC_MODE) return 0;
 			if (k->state == KEY_RELEASE)
@@ -528,7 +528,7 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 			return 1;
 		new_order--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			if (status.flags & CLASSIC_MODE) return 0;
 			if (k->state == KEY_RELEASE)
@@ -543,44 +543,44 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 			return 1;
 		new_order++;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_order -= 16;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		new_order += 16;
 		break;
-	case SCHISM_KEYSYM_INSERT:
+	case SCHISM_SCANCODE_INSERT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		orderlist_insert_pos();
 		return 1;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		orderlist_delete_pos();
 		return 1;
-	case SCHISM_KEYSYM_F7:
+	case SCHISM_SCANCODE_F7:
 		if (!(k->mod & SCHISM_KEYMOD_CTRL)) return 0;
 		/* fall through */
-	case SCHISM_KEYSYM_SPACE:
+	case SCHISM_SCANCODE_SPACE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_set_next_order(current_order);
 		status_text_flash("Playing order %d next", current_order);
 		return 1;
-	case SCHISM_KEYSYM_F6:
+	case SCHISM_SCANCODE_F6:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -589,7 +589,7 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		}
 		return 0;
 
-	case SCHISM_KEYSYM_n:
+	case SCHISM_SCANCODE_N:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			if (k->state == KEY_PRESS)
 				return 1;
@@ -602,7 +602,7 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 			return 1;
 		orderlist_insert_next();
 		return 1;
-	case SCHISM_KEYSYM_c:
+	case SCHISM_SCANCODE_C:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (status.flags & CLASSIC_MODE) return 0;
@@ -629,7 +629,7 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		}
 		break;
 
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_R:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_PRESS)
 				return 1;
@@ -637,7 +637,7 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_u:
+	case SCHISM_SCANCODE_U:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -646,31 +646,27 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		}
 		return 0;
 
-	case SCHISM_KEYSYM_b:
+	case SCHISM_SCANCODE_B:
 		if (k->mod & SCHISM_KEYMOD_SHIFT)
 			return 0;
 		/* fall through */
-	case SCHISM_KEYSYM_o:
+	case SCHISM_SCANCODE_O:
 		if (!(k->mod & SCHISM_KEYMOD_CTRL))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_pattern_to_sample(current_song->orderlist[current_order],
-				!!(k->mod & SCHISM_KEYMOD_SHIFT), !!(k->sym == SCHISM_KEYSYM_b));
+				!!(k->mod & SCHISM_KEYMOD_SHIFT), !!(k->scancode == SCHISM_SCANCODE_B));
 		return 1;
 
-	case SCHISM_KEYSYM_LESS:
-	case SCHISM_KEYSYM_SEMICOLON:
-	case SCHISM_KEYSYM_COLON:
+	case SCHISM_SCANCODE_SEMICOLON:
 		if (!NO_MODIFIER(k->mod)) return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		sample_set(sample_get_current()-1);
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_GREATER:
-	case SCHISM_KEYSYM_QUOTE:
-	case SCHISM_KEYSYM_QUOTEDBL:
+	case SCHISM_SCANCODE_APOSTROPHE:
 		if (!NO_MODIFIER(k->mod)) return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
@@ -845,11 +841,11 @@ static void order_pan_vol_handle_key(struct key_event * k)
 	if (!NO_MODIFIER(k->mod))
 		return;
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_PAGEDOWN:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_PAGEDOWN:
 		n += 8;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		n -= 8;
 		break;
 	default:
@@ -870,7 +866,7 @@ static int order_pre_key(struct key_event *k)
 			= ACTIVE_PAGE.selected_widget;
 	}
 
-	if (k->sym == SCHISM_KEYSYM_F7) {
+	if (k->scancode == SCHISM_SCANCODE_F7) {
 		if (!NO_MODIFIER(k->mod)) return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;

--- a/schism/page_palette.c
+++ b/schism/page_palette.c
@@ -186,8 +186,8 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 			new_palette += MOUSE_SCROLL_LINES;
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (--new_palette < 0) {
@@ -195,7 +195,7 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		// new_palette++;
@@ -204,12 +204,12 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_palette = 0;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (new_palette == 0) {
@@ -218,17 +218,17 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 		}
 		new_palette -= 16;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_palette = NUM_PALETTES - 1;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_palette += 16;
 		break;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		// if (selected_palette == -1) return 1;
@@ -237,8 +237,8 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 		update_thumbbars();
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_RIGHT:
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_RIGHT:
+	case SCHISM_SCANCODE_TAB:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			widget_change_focus_to(focus_offsets[selected_palette+1] + 29);
 			return 1;
@@ -247,12 +247,12 @@ static int palette_list_handle_key_on_list(struct key_event * k)
 			return 0;
 		widget_change_focus_to(focus_offsets[selected_palette+1] + 8);
 		return 1;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		widget_change_focus_to(focus_offsets[selected_palette+1] + 29);
 		return 1;
-	case SCHISM_KEYSYM_c:
+	case SCHISM_SCANCODE_C:
 		/* pasting is handled by the page */
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			palette_copy_palette_to_clipboard(selected_palette);
@@ -290,22 +290,22 @@ static void palette_list_handle_key(struct key_event * k)
 	if (k->state == KEY_RELEASE)
 		return;
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_PAGEUP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_PAGEUP:
 		if (!NO_MODIFIER(k->mod))
 			n -= 3;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
 			n += 3;
 		break;
-	case SCHISM_KEYSYM_c:
+	case SCHISM_SCANCODE_C:
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			palette_copy_current_to_clipboard();
 			return;
 		}
 		break;
-	case SCHISM_KEYSYM_v:
+	case SCHISM_SCANCODE_V:
 		if (k->mod & SCHISM_KEYMOD_CTRL) {
 			palette_paste_from_clipboard();
 			return;

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -454,7 +454,7 @@ static void multichannel_close(SCHISM_UNUSED void *data)
 }
 static int multichannel_handle_key(struct key_event *k)
 {
-	if (k->sym == SCHISM_KEYSYM_n) {
+	if (k->scancode == SCHISM_SCANCODE_N) {
 		if ((k->mod & SCHISM_KEYMOD_ALT) && k->state == KEY_PRESS)
 			dialog_yes(NULL);
 		else if (NO_MODIFIER(k->mod) && k->state == KEY_RELEASE)
@@ -959,28 +959,28 @@ static int history_handle_key(struct key_event *k)
 {
 	int i,j;
 	if (! NO_MODIFIER(k->mod)) return 0;
-	switch (k->sym) {
-	case SCHISM_KEYSYM_ESCAPE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_ESCAPE:
 		if (k->state == KEY_PRESS)
 			return 0;
 		dialog_cancel(NULL);
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		undo_selection--;
 		if (undo_selection < 0) undo_selection = 0;
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		undo_selection++;
 		if (undo_selection > 9) undo_selection = 9;
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		j = undo_history_top;
@@ -1094,7 +1094,7 @@ static void volume_amplify_ok(SCHISM_UNUSED void *data)
 
 static int volume_amplify_jj(struct key_event *k)
 {
-	if (k->state == KEY_PRESS && (k->mod & SCHISM_KEYMOD_ALT) && (k->sym == SCHISM_KEYSYM_j)) {
+	if (k->state == KEY_PRESS && (k->mod & SCHISM_KEYMOD_ALT) && (k->scancode == SCHISM_SCANCODE_J)) {
 		dialog_yes(NULL);
 		return 1;
 	}
@@ -2928,39 +2928,39 @@ static int handle_volume(song_note_t * note, struct key_event *k, int pos)
 		if (q >= 0 && q <= 9) {
 			vol = q * 10 + vol % 10;
 			fx = vp;
-		} else if (k->sym == SCHISM_KEYSYM_a) {
+		} else if (k->scancode == SCHISM_SCANCODE_A) {
 			fx = VOLFX_FINEVOLUP;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_b) {
+		} else if (k->scancode == SCHISM_SCANCODE_B) {
 			fx = VOLFX_FINEVOLDOWN;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_c) {
+		} else if (k->scancode == SCHISM_SCANCODE_C) {
 			fx = VOLFX_VOLSLIDEUP;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_d) {
+		} else if (k->scancode == SCHISM_SCANCODE_D) {
 			fx = VOLFX_VOLSLIDEDOWN;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_e) {
+		} else if (k->scancode == SCHISM_SCANCODE_E) {
 			fx = VOLFX_PORTADOWN;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_f) {
+		} else if (k->scancode == SCHISM_SCANCODE_F) {
 			fx = VOLFX_PORTAUP;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_g) {
+		} else if (k->scancode == SCHISM_SCANCODE_G) {
 			fx = VOLFX_TONEPORTAMENTO;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_h) {
+		} else if (k->scancode == SCHISM_SCANCODE_H) {
 			fx = VOLFX_VIBRATODEPTH;
 			vol %= 10;
 		} else if (status.flags & CLASSIC_MODE) {
 			return 0;
-		} else if (k->sym == SCHISM_KEYSYM_DOLLAR) {
+		} else if ((k->scancode == SCHISM_SCANCODE_4) && (k->mod & SCHISM_KEYMOD_SHIFT)) {
 			fx = VOLFX_VIBRATOSPEED;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_LESS) {
+		} else if ((k->scancode == SCHISM_SCANCODE_COMMA) && (k->mod & SCHISM_KEYMOD_SHIFT)) {
 			fx = VOLFX_PANSLIDELEFT;
 			vol %= 10;
-		} else if (k->sym == SCHISM_KEYSYM_GREATER) {
+		} else if ((k->scancode == SCHISM_SCANCODE_PERIOD) && (k->mod & SCHISM_KEYMOD_SHIFT)) {
 			fx = VOLFX_PANSLIDERIGHT;
 			vol %= 10;
 		} else {
@@ -3281,7 +3281,7 @@ static int pattern_editor_insert(struct key_event *k)
 			ins = KEYJAZZ_NOINST;
 		}
 
-		if (k->sym == SCHISM_KEYSYM_4) {
+		if (k->scancode == SCHISM_SCANCODE_4) {
 			if (k->state == KEY_RELEASE)
 				return 0;
 
@@ -3294,7 +3294,7 @@ static int pattern_editor_insert(struct key_event *k)
 				vol, current_channel, cur_note->effect, cur_note->param);
 			advance_cursor(!(k->mod & SCHISM_KEYMOD_SHIFT), 1);
 			return 1;
-		} else if (k->sym == SCHISM_KEYSYM_8) {
+		} else if (k->scancode == SCHISM_SCANCODE_8) {
 			/* note: Impulse Tracker doesn't skip multichannels when pressing "8"  -delt. */
 			if (k->state == KEY_RELEASE)
 				return 0;
@@ -3312,7 +3312,7 @@ static int pattern_editor_insert(struct key_event *k)
 		}
 
 
-		if (k->sym == SCHISM_KEYSYM_SPACE) {
+		if (k->scancode == SCHISM_SCANCODE_SPACE) {
 			/* copy mask to note */
 			n = mask_note.note;
 
@@ -3379,7 +3379,7 @@ static int pattern_editor_insert(struct key_event *k)
 
 		/* Never copy the instrument etc. from the mask when inserting control notes or when
 		erasing a note -- but DO write it when inserting a blank note with the space key. */
-		if (!(NOTE_IS_CONTROL(n) || (k->sym != SCHISM_KEYSYM_SPACE && n == NOTE_NONE)) && !template_mode) {
+		if (!(NOTE_IS_CONTROL(n) || (k->scancode != SCHISM_SCANCODE_SPACE && n == NOTE_NONE)) && !template_mode) {
 			if (edit_copy_mask & MASK_INSTRUMENT) {
 				if (song_is_instrument_mode())
 					cur_note->instrument = instrument_get_current();
@@ -3434,7 +3434,7 @@ static int pattern_editor_insert(struct key_event *k)
 		break;
 	case 2:                 /* instrument, first digit */
 	case 3:                 /* instrument, second digit */
-		if (k->sym == SCHISM_KEYSYM_SPACE) {
+		if (k->scancode == SCHISM_SCANCODE_SPACE) {
 			if (song_is_instrument_mode())
 				n = instrument_get_current();
 			else
@@ -3500,7 +3500,7 @@ static int pattern_editor_insert(struct key_event *k)
 		break;
 	case 4:
 	case 5:                 /* volume */
-		if (k->sym == SCHISM_KEYSYM_SPACE) {
+		if (k->scancode == SCHISM_SCANCODE_SPACE) {
 			cur_note->volparam = mask_note.volparam;
 			cur_note->voleffect = mask_note.voleffect;
 			advance_cursor(1, 0);
@@ -3533,7 +3533,7 @@ static int pattern_editor_insert(struct key_event *k)
 		pattern_selection_system_copyout();
 		break;
 	case 6:                 /* effect */
-		if (k->sym == SCHISM_KEYSYM_SPACE) {
+		if (k->scancode == SCHISM_SCANCODE_SPACE) {
 			cur_note->effect = mask_note.effect;
 		} else {
 			n = kbd_get_effect_number(k);
@@ -3550,7 +3550,7 @@ static int pattern_editor_insert(struct key_event *k)
 		break;
 	case 7:                 /* param, high nibble */
 	case 8:                 /* param, low nibble */
-		if (k->sym == SCHISM_KEYSYM_SPACE) {
+		if (k->scancode == SCHISM_SCANCODE_SPACE) {
 			cur_note->param = mask_note.param;
 			current_position = link_effect_column ? 6 : 7;
 			advance_cursor(1, 0);
@@ -3601,10 +3601,10 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	int total_rows = song_get_rows_in_pattern(current_pattern);
 
 	/* hack to render this useful :) */
-	if (k->sym == SCHISM_KEYSYM_KP_9) {
-		k->sym = SCHISM_KEYSYM_F9;
-	} else if (k->sym == SCHISM_KEYSYM_KP_0) {
-		k->sym = SCHISM_KEYSYM_F10;
+	if (k->scancode == SCHISM_SCANCODE_KP_9) {
+		k->scancode = SCHISM_SCANCODE_F9;
+	} else if (k->scancode == SCHISM_SCANCODE_KP_0) {
+		k->scancode = SCHISM_SCANCODE_F10;
 	}
 
 	n = numeric_key_event(k, 0);
@@ -3616,21 +3616,21 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		return 1;
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_RETURN:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_PRESS)
 			return 1;
 		fast_save_update();
 		return 1;
 
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (k->state == KEY_PRESS)
 			return 1;
 		pated_save("Undo revert pattern data (Alt-BkSpace)");
 		snap_paste(&fast_save, 0, 0, 0);
 		return 1;
 
-	case SCHISM_KEYSYM_b:
+	case SCHISM_SCANCODE_B:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (!SELECTION_EXISTS) {
@@ -3641,7 +3641,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		selection.first_row = current_row;
 		normalise_block_selection();
 		break;
-	case SCHISM_KEYSYM_e:
+	case SCHISM_SCANCODE_E:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (!SELECTION_EXISTS) {
@@ -3652,10 +3652,10 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		selection.last_row = current_row;
 		normalise_block_selection();
 		break;
-	case SCHISM_KEYSYM_d:
+	case SCHISM_SCANCODE_D:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_d) {
+		if (status.last_scancode == SCHISM_SCANCODE_D) {
 			if (total_rows - (current_row - 1) > block_double_size)
 				block_double_size <<= 1;
 		} else {
@@ -3669,10 +3669,10 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		n = block_double_size + current_row - 1;
 		selection.last_row = MIN(n, total_rows);
 		break;
-	case SCHISM_KEYSYM_l:
+	case SCHISM_SCANCODE_L:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_l) {
+		if (status.last_scancode == SCHISM_SCANCODE_L) {
 			/* 3x alt-l re-selects the current channel */
 			if (selection.first_channel == selection.last_channel) {
 				selection.first_channel = 1;
@@ -3687,18 +3687,18 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		}
 		pattern_selection_system_copyout();
 		break;
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_R:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		draw_divisions = 1;
 		set_view_scheme(0);
 		break;
-	case SCHISM_KEYSYM_s:
+	case SCHISM_SCANCODE_S:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selection_set_sample();
 		break;
-	case SCHISM_KEYSYM_u:
+	case SCHISM_SCANCODE_U:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (SELECTION_EXISTS) {
@@ -3712,48 +3712,48 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 			dialog_create(DIALOG_OK, "No data in clipboard", NULL, NULL, 0, NULL);
 		}
 		break;
-	case SCHISM_KEYSYM_c:
+	case SCHISM_SCANCODE_C:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		clipboard_copy(0);
 		break;
-	case SCHISM_KEYSYM_o:
+	case SCHISM_SCANCODE_O:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_o) {
+		if (status.last_scancode == SCHISM_SCANCODE_O) {
 			pattern_copyin_behavior = PATTERN_COPYIN_OVERWRITE_GROW;
 		} else {
 			pattern_copyin_behavior = PATTERN_COPYIN_OVERWRITE;
 		}
 		status.flags |= CLIPPY_PASTE_BUFFER;
 		break;
-	case SCHISM_KEYSYM_p:
+	case SCHISM_SCANCODE_P:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		pattern_copyin_behavior = PATTERN_COPYIN_INSERT;
 		status.flags |= CLIPPY_PASTE_BUFFER;
 		break;
-	case SCHISM_KEYSYM_m:
+	case SCHISM_SCANCODE_M:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_m) {
+		if (status.last_scancode == SCHISM_SCANCODE_M) {
 			pattern_copyin_behavior = PATTERN_COPYIN_MIX_FIELDS;
 		} else {
 			pattern_copyin_behavior = PATTERN_COPYIN_MIX_NOTES;
 		}
 		status.flags |= CLIPPY_PASTE_BUFFER;
 		break;
-	case SCHISM_KEYSYM_f:
+	case SCHISM_SCANCODE_F:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		block_length_double();
 		break;
-	case SCHISM_KEYSYM_g:
+	case SCHISM_SCANCODE_G:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		block_length_halve();
 		break;
-	case SCHISM_KEYSYM_n:
+	case SCHISM_SCANCODE_N:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		channel_multi[current_channel - 1] ^= 1;
@@ -3769,57 +3769,57 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 			}
 		}
 
-		if (status.last_keysym == SCHISM_KEYSYM_n) {
+		if (status.last_scancode == SCHISM_SCANCODE_N) {
 			pattern_editor_display_multichannel();
 		}
 		break;
-	case SCHISM_KEYSYM_z:
+	case SCHISM_SCANCODE_Z:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		clipboard_copy(0);
 		selection_erase();
 		break;
-	case SCHISM_KEYSYM_y:
+	case SCHISM_SCANCODE_Y:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selection_swap();
 		break;
-	case SCHISM_KEYSYM_v:
+	case SCHISM_SCANCODE_V:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selection_set_volume();
 		break;
-	case SCHISM_KEYSYM_w:
+	case SCHISM_SCANCODE_W:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selection_wipe_volume(0);
 		break;
-	case SCHISM_KEYSYM_k:
+	case SCHISM_SCANCODE_K:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_k) {
+		if (status.last_scancode == SCHISM_SCANCODE_K) {
 			selection_wipe_volume(1);
 		} else {
 			selection_slide_volume();
 		}
 		break;
-	case SCHISM_KEYSYM_x:
+	case SCHISM_SCANCODE_X:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_x) {
+		if (status.last_scancode == SCHISM_SCANCODE_X) {
 			selection_wipe_effect();
 		} else {
 			selection_slide_effect();
 		}
 		break;
-	case SCHISM_KEYSYM_h:
+	case SCHISM_SCANCODE_H:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		draw_divisions = !draw_divisions;
 		recalculate_visible_area();
 		pattern_editor_reposition();
 		break;
-	case SCHISM_KEYSYM_q:
+	case SCHISM_SCANCODE_Q:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_SHIFT)
@@ -3827,7 +3827,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		else
 			transpose_notes(1);
 		break;
-	case SCHISM_KEYSYM_a:
+	case SCHISM_SCANCODE_A:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_SHIFT)
@@ -3835,7 +3835,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		else
 			transpose_notes(-1);
 		break;
-	case SCHISM_KEYSYM_i:
+	case SCHISM_SCANCODE_I:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (k->mod & SCHISM_KEYMOD_SHIFT)
@@ -3845,7 +3845,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		else
 			template_mode = (template_mode + 1) % TEMPLATE_MODE_MAX; /* cycle */
 		break;
-	case SCHISM_KEYSYM_j:
+	case SCHISM_SCANCODE_J:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (fast_volume_mode)
@@ -3853,7 +3853,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		else
 			volume_amplify();
 		break;
-	case SCHISM_KEYSYM_t:
+	case SCHISM_SCANCODE_T:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		n = current_channel - top_display_channel;
@@ -3861,7 +3861,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 		recalculate_visible_area();
 		pattern_editor_reposition();
 		break;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (top_display_row > 0) {
@@ -3871,7 +3871,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 			return -1;
 		}
 		return 1;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (top_display_row + 31 < total_rows) {
@@ -3881,34 +3881,34 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 			return -1;
 		}
 		return 1;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		current_channel--;
 		return -1;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		current_channel++;
 		return -1;
-	case SCHISM_KEYSYM_INSERT:
+	case SCHISM_SCANCODE_INSERT:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		pated_save("Remove inserted row(s)    (Alt-Insert)");
 		pattern_insert_rows(current_row, 1, 1, 64);
 		break;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		pated_save("Replace deleted row(s)    (Alt-Delete)");
 		pattern_delete_rows(current_row, 1, 1, 64);
 		break;
-	case SCHISM_KEYSYM_F9:
+	case SCHISM_SCANCODE_F9:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_toggle_channel_mute(current_channel - 1);
 		break;
-	case SCHISM_KEYSYM_F10:
+	case SCHISM_SCANCODE_F10:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_handle_channel_solo(current_channel - 1);
@@ -3948,110 +3948,111 @@ static int pattern_editor_handle_ctrl_key(struct key_event * k)
 	}
 
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_LEFT:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_LEFT:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (current_channel > top_display_channel)
 			current_channel--;
 		return -1;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (current_channel < top_display_channel + visible_channels - 1)
 			current_channel++;
 		return -1;
-	case SCHISM_KEYSYM_F6:
+	case SCHISM_SCANCODE_F6:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_loop_pattern(current_pattern, current_row);
 		return 1;
-	case SCHISM_KEYSYM_F7:
+	case SCHISM_SCANCODE_F7:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		set_playback_mark();
 		return -1;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		set_previous_instrument();
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		set_next_instrument();
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		current_row = 0;
 		return -1;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		current_row = total_rows;
 		return -1;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		current_row--;
 		return -1;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		current_row++;
 		return -1;
-	case SCHISM_KEYSYM_INSERT:
+	case SCHISM_SCANCODE_INSERT:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selection_roll(ROLL_DOWN);
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		selection_roll(ROLL_UP);
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_MINUS:
+	case SCHISM_SCANCODE_MINUS:
+	case SCHISM_SCANCODE_KP_MINUS:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (song_get_mode() & (MODE_PLAYING|MODE_PATTERN_LOOP) && playback_tracing)
 			return 1;
 		prev_order_pattern();
 		return 1;
-	case SCHISM_KEYSYM_EQUALS:
+	case SCHISM_SCANCODE_EQUALS:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT))
 			return 0;
 		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_PLUS:
+	case SCHISM_SCANCODE_KP_PLUS:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (song_get_mode() & (MODE_PLAYING|MODE_PATTERN_LOOP) && playback_tracing)
 			return 1;
 		next_order_pattern();
 		return 1;
-	case SCHISM_KEYSYM_c:
+	case SCHISM_SCANCODE_C:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		centralise_cursor = !centralise_cursor;
 		status_text_flash("Centralise cursor %s", (centralise_cursor ? "enabled" : "disabled"));
 		return -1;
-	case SCHISM_KEYSYM_h:
+	case SCHISM_SCANCODE_H:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		highlight_current_row = !highlight_current_row;
 		status_text_flash("Row hilight %s", (highlight_current_row ? "enabled" : "disabled"));
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_j:
+	case SCHISM_SCANCODE_J:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		fast_volume_toggle();
 		return 1;
-	case SCHISM_KEYSYM_u:
+	case SCHISM_SCANCODE_U:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (fast_volume_mode)
@@ -4060,7 +4061,7 @@ static int pattern_editor_handle_ctrl_key(struct key_event * k)
 			vary_command(FX_CHANNELVOLUME);
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_y:
+	case SCHISM_SCANCODE_Y:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (fast_volume_mode)
@@ -4069,7 +4070,7 @@ static int pattern_editor_handle_ctrl_key(struct key_event * k)
 			vary_command(FX_PANBRELLO);
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_k:
+	case SCHISM_SCANCODE_K:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (fast_volume_mode)
@@ -4079,24 +4080,24 @@ static int pattern_editor_handle_ctrl_key(struct key_event * k)
 		status.flags |= NEED_UPDATE;
 		return 1;
 
-	case SCHISM_KEYSYM_b:
+	case SCHISM_SCANCODE_B:
 		if (k->mod & SCHISM_KEYMOD_SHIFT)
 			return 0;
 		/* fall through */
-	case SCHISM_KEYSYM_o:
+	case SCHISM_SCANCODE_O:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		song_pattern_to_sample(current_pattern, !!(k->mod & SCHISM_KEYMOD_SHIFT), !!(k->sym == SCHISM_KEYSYM_b));
+		song_pattern_to_sample(current_pattern, !!(k->mod & SCHISM_KEYMOD_SHIFT), !!(k->scancode == SCHISM_SCANCODE_B));
 		return 1;
 
-	case SCHISM_KEYSYM_v:
+	case SCHISM_SCANCODE_V:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		show_default_volumes = !show_default_volumes;
 		status_text_flash("Default volumes %s", (show_default_volumes ? "enabled" : "disabled"));
 		return 1;
-	case SCHISM_KEYSYM_x:
-	case SCHISM_KEYSYM_z:
+	case SCHISM_SCANCODE_X:
+	case SCHISM_SCANCODE_Z:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		midi_start_record++;
@@ -4113,7 +4114,7 @@ static int pattern_editor_handle_ctrl_key(struct key_event * k)
 			break;
 		};
 		return 1;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		pattern_editor_display_history();
@@ -4132,7 +4133,7 @@ static int pattern_editor_handle_key_default(struct key_event * k)
 
 	/* stupid hack; if we have a note, that's definitely more important than this stuff */
 	if (n < 0 || current_position > 0) {
-		if (k->sym == SCHISM_KEYSYM_LESS || k->sym == SCHISM_KEYSYM_COLON || k->sym == SCHISM_KEYSYM_SEMICOLON) {
+		if ((k->scancode == SCHISM_SCANCODE_COMMA && (k->mod & SCHISM_KEYMOD_SHIFT)) || k->scancode == SCHISM_SCANCODE_SEMICOLON) {
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if ((status.flags & CLASSIC_MODE) || current_position != 4) {
@@ -4140,7 +4141,7 @@ static int pattern_editor_handle_key_default(struct key_event * k)
 				status.flags |= NEED_UPDATE;
 				return 1;
 			}
-		} else if (k->sym == SCHISM_KEYSYM_GREATER || k->sym == SCHISM_KEYSYM_QUOTE || k->sym == SCHISM_KEYSYM_QUOTEDBL) {
+		} else if ((k->scancode == SCHISM_SCANCODE_PERIOD && (k->mod & SCHISM_KEYMOD_SHIFT)) || k->scancode == SCHISM_SCANCODE_APOSTROPHE) {
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if ((status.flags & CLASSIC_MODE) || current_position != 4) {
@@ -4148,7 +4149,7 @@ static int pattern_editor_handle_key_default(struct key_event * k)
 				status.flags |= NEED_UPDATE;
 				return 1;
 			}
-		} else if (k->sym == SCHISM_KEYSYM_COMMA) {
+		} else if (k->scancode == SCHISM_SCANCODE_COMMA) {
 			if (k->state == KEY_RELEASE)
 				return 0;
 			switch (current_position) {
@@ -4334,8 +4335,8 @@ static int pattern_editor_handle_key(struct key_event * k)
 		return pattern_editor_insert_midi(k);
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (skip_value) {
@@ -4345,7 +4346,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			current_row--;
 		}
 		return -1;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (skip_value) {
@@ -4355,7 +4356,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			current_row++;
 		}
 		return -1;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
@@ -4367,7 +4368,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			current_position--;
 		}
 		return -1;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
@@ -4378,7 +4379,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			current_position++;
 		}
 		return -1;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if ((k->mod & SCHISM_KEYMOD_SHIFT) == 0)
@@ -4392,7 +4393,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 		shift_selection_end();
 
 		return -1;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		{
@@ -4403,12 +4404,12 @@ static int pattern_editor_handle_key(struct key_event * k)
 				current_row -= rh;
 		}
 		return -1;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		current_row += current_song->row_highlight_major ? current_song->row_highlight_major : 16;
 		return -1;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (current_position == 0) {
@@ -4421,7 +4422,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			current_position = 0;
 		}
 		return -1;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		n = song_find_last_channel();
@@ -4435,7 +4436,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			current_position = 8;
 		}
 		return -1;
-	case SCHISM_KEYSYM_INSERT:
+	case SCHISM_SCANCODE_INSERT:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (template_mode && clipboard.rows == 1) {
@@ -4448,7 +4449,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			pattern_insert_rows(current_row, 1, current_channel, 1);
 		}
 		break;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		if (template_mode && clipboard.rows == 1) {
@@ -4461,7 +4462,8 @@ static int pattern_editor_handle_key(struct key_event * k)
 			pattern_delete_rows(current_row, 1, current_channel, 1);
 		}
 		break;
-	case SCHISM_KEYSYM_MINUS:
+	case SCHISM_SCANCODE_MINUS:
+	case SCHISM_SCANCODE_KP_MINUS:
 		if (k->state == KEY_RELEASE)
 			return 0;
 
@@ -4482,11 +4484,11 @@ static int pattern_editor_handle_key(struct key_event * k)
 		else
 			set_current_pattern(current_pattern - 1);
 		return 1;
-	case SCHISM_KEYSYM_EQUALS:
+	case SCHISM_SCANCODE_EQUALS:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT))
 			return 0;
 		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_PLUS:
+	case SCHISM_SCANCODE_KP_PLUS:
 		if (k->state == KEY_RELEASE)
 			return 0;
 
@@ -4502,12 +4504,12 @@ static int pattern_editor_handle_key(struct key_event * k)
 			};
 		}
 
-		if ((k->mod & SCHISM_KEYMOD_SHIFT) && k->sym == SCHISM_KEYSYM_KP_PLUS)
+		if ((k->mod & SCHISM_KEYMOD_SHIFT) && k->scancode == SCHISM_SCANCODE_KP_PLUS)
 			set_current_pattern(current_pattern + 4);
 		else
 			set_current_pattern(current_pattern + 1);
 		return 1;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		current_channel = multichannel_get_previous (current_channel);
@@ -4516,14 +4518,14 @@ static int pattern_editor_handle_key(struct key_event * k)
 		else
 			current_row--;
 		return -1;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (k->state == KEY_RELEASE)
 			return 0;
 		copy_note_to_mask();
 		if (template_mode != TEMPLATE_NOTES_ONLY)
 			template_mode = TEMPLATE_OFF;
 		return 1;
-	case SCHISM_KEYSYM_l:
+	case SCHISM_SCANCODE_L:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			if (status.flags & CLASSIC_MODE) return 0;
 			if (k->state == KEY_RELEASE)
@@ -4532,7 +4534,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			break;
 		}
 		return pattern_editor_handle_key_default(k);
-	case SCHISM_KEYSYM_a:
+	case SCHISM_SCANCODE_A:
 		if (k->mod & SCHISM_KEYMOD_SHIFT && !(status.flags & CLASSIC_MODE)) {
 			if (k->state == KEY_RELEASE) {
 				return 0;
@@ -4546,7 +4548,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 			return -1;
 		}
 		return pattern_editor_handle_key_default(k);
-	case SCHISM_KEYSYM_f:
+	case SCHISM_SCANCODE_F:
 		if (k->mod & SCHISM_KEYMOD_SHIFT && !(status.flags & CLASSIC_MODE)) {
 			if (k->state == KEY_RELEASE) {
 				return 0;
@@ -4561,8 +4563,8 @@ static int pattern_editor_handle_key(struct key_event * k)
 		}
 		return pattern_editor_handle_key_default(k);
 
-	case SCHISM_KEYSYM_LSHIFT:
-	case SCHISM_KEYSYM_RSHIFT:
+	case SCHISM_SCANCODE_LSHIFT:
+	case SCHISM_SCANCODE_RSHIFT:
 		if (k->state == KEY_PRESS) {
 			if (shift_selection.in_progress)
 				shift_selection_end();
@@ -4594,15 +4596,15 @@ static int pattern_editor_handle_key_cb(struct key_event * k)
 	int total_rows = song_get_rows_in_pattern(current_pattern);
 
 	if (k->mod & SCHISM_KEYMOD_SHIFT) {
-		switch (k->sym) {
-		case SCHISM_KEYSYM_LEFT:
-		case SCHISM_KEYSYM_RIGHT:
-		case SCHISM_KEYSYM_UP:
-		case SCHISM_KEYSYM_DOWN:
-		case SCHISM_KEYSYM_HOME:
-		case SCHISM_KEYSYM_END:
-		case SCHISM_KEYSYM_PAGEUP:
-		case SCHISM_KEYSYM_PAGEDOWN:
+		switch (k->scancode) {
+		case SCHISM_SCANCODE_LEFT:
+		case SCHISM_SCANCODE_RIGHT:
+		case SCHISM_SCANCODE_UP:
+		case SCHISM_SCANCODE_DOWN:
+		case SCHISM_SCANCODE_HOME:
+		case SCHISM_SCANCODE_END:
+		case SCHISM_SCANCODE_PAGEUP:
+		case SCHISM_SCANCODE_PAGEDOWN:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!shift_selection.in_progress)
@@ -4689,7 +4691,7 @@ static void pated_song_changed(void)
 
 static int _fix_f7(struct key_event *k)
 {
-	if (k->sym == SCHISM_KEYSYM_F7) {
+	if (k->scancode == SCHISM_SCANCODE_F7) {
 		if (!NO_MODIFIER(k->mod)) return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;

--- a/schism/page_preferences.c
+++ b/schism/page_preferences.c
@@ -258,8 +258,8 @@ static int audio_device_list_handle_key_on_list(struct key_event * k)
 			return 0;
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (--new_device < 0) {
@@ -267,7 +267,7 @@ static int audio_device_list_handle_key_on_list(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (++new_device >= (int)audio_device_list_size + 1) {
@@ -275,12 +275,12 @@ static int audio_device_list_handle_key_on_list(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_device = 0;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 
@@ -289,28 +289,28 @@ static int audio_device_list_handle_key_on_list(struct key_event * k)
 
 		new_device -= 16;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_device = audio_device_list_size;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_device += 16;
 		break;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		load_selected_device = 1;
 		break;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT || NO_MODIFIER(k->mod)))
 			return 0;
 
 		widget_change_focus_to(focus_offsets[selected_audio_device]);
 		return 1;
-	case SCHISM_KEYSYM_LEFT: case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_LEFT: case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 
@@ -407,8 +407,8 @@ static int audio_driver_list_handle_key_on_list(struct key_event * k)
 			return 0;
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (--new_driver < 0) {
@@ -416,7 +416,7 @@ static int audio_driver_list_handle_key_on_list(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (++new_driver >= num_drivers + 1) {
@@ -424,12 +424,12 @@ static int audio_driver_list_handle_key_on_list(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_driver = 0;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 
@@ -438,28 +438,28 @@ static int audio_driver_list_handle_key_on_list(struct key_event * k)
 
 		new_driver -= 16;
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_driver = num_drivers;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_driver += 16;
 		break;
-	case SCHISM_KEYSYM_RETURN:
+	case SCHISM_SCANCODE_RETURN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		load_selected_driver = 1;
 		break;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT || NO_MODIFIER(k->mod)))
 			return 0;
 
 		widget_change_focus_to(focus_offsets[selected_audio_driver]);
 		return 1;
-	case SCHISM_KEYSYM_LEFT: case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_LEFT: case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 

--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -440,36 +440,36 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 			}
 		}
 	} else {
-		switch (k->sym) {
-		case SCHISM_KEYSYM_LEFT:
+		switch (k->scancode) {
+		case SCHISM_SCANCODE_LEFT:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
 				return 0;
 			new_cursor_pos--;
 			break;
-		case SCHISM_KEYSYM_RIGHT:
+		case SCHISM_SCANCODE_RIGHT:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
 				return 0;
 			new_cursor_pos++;
 			break;
-		case SCHISM_KEYSYM_HOME:
+		case SCHISM_SCANCODE_HOME:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
 				return 0;
 			new_cursor_pos = 0;
 			break;
-		case SCHISM_KEYSYM_END:
+		case SCHISM_SCANCODE_END:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (!NO_MODIFIER(k->mod))
 				return 0;
 			new_cursor_pos = 25;
 			break;
-		case SCHISM_KEYSYM_UP:
+		case SCHISM_SCANCODE_UP:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -483,13 +483,13 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 				new_sample--;
 			}
 			break;
-		case SCHISM_KEYSYM_DOWN:
+		case SCHISM_SCANCODE_DOWN:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_ALT) {
 				// restrict position to the "old" value of _last_vis_sample()
 				// (this is entirely for aesthetic reasons)
-				if (status.last_keysym != SCHISM_KEYSYM_DOWN && !k->is_repeat)
+				if (status.last_scancode != SCHISM_SCANCODE_DOWN && !k->is_repeat)
 					_altswap_lastvis = _last_vis_sample();
 				if (current_sample < _altswap_lastvis) {
 					new_sample = current_sample + 1;
@@ -501,7 +501,7 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 				new_sample++;
 			}
 			break;
-		case SCHISM_KEYSYM_PAGEUP:
+		case SCHISM_SCANCODE_PAGEUP:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -510,7 +510,7 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 				new_sample -= 16;
 			}
 			break;
-		case SCHISM_KEYSYM_PAGEDOWN:
+		case SCHISM_SCANCODE_PAGEDOWN:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if (k->mod & SCHISM_KEYMOD_CTRL) {
@@ -519,12 +519,12 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 				new_sample += 16;
 			}
 			break;
-		case SCHISM_KEYSYM_RETURN:
+		case SCHISM_SCANCODE_RETURN:
 			if (k->state == KEY_PRESS)
 				return 0;
 			set_page(PAGE_LOAD_SAMPLE);
 			break;
-		case SCHISM_KEYSYM_BACKSPACE:
+		case SCHISM_SCANCODE_BACKSPACE:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if ((k->mod & (SCHISM_KEYMOD_CTRL | SCHISM_KEYMOD_ALT)) == 0) {
@@ -541,7 +541,7 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 				return 1;
 			}
 			return 0;
-		case SCHISM_KEYSYM_DELETE:
+		case SCHISM_SCANCODE_DELETE:
 			if (k->state == KEY_RELEASE)
 				return 0;
 			if ((k->mod & (SCHISM_KEYMOD_CTRL | SCHISM_KEYMOD_ALT)) == 0) {
@@ -551,7 +551,7 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 				return 1;
 			}
 			return 0;
-		case SCHISM_KEYSYM_ESCAPE:
+		case SCHISM_SCANCODE_ESCAPE:
 			if (k->mod & SCHISM_KEYMOD_SHIFT) {
 				if (k->state == KEY_RELEASE)
 					return 1;
@@ -561,7 +561,7 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 			return 0;
 		default:
 			if (k->mod & SCHISM_KEYMOD_ALT) {
-				if (k->sym == SCHISM_KEYSYM_c) {
+				if (k->scancode == SCHISM_SCANCODE_C) {
 					clear_sample_text();
 					return 1;
 				}
@@ -935,7 +935,7 @@ static void sample_adlibconfig_draw_const(void)
 
 static int do_adlib_handlekey(struct key_event *kk)
 {
-	if (kk->sym == SCHISM_KEYSYM_F1) {
+	if (kk->scancode == SCHISM_SCANCODE_F1) {
 		if (kk->state == KEY_PRESS)
 			return 1;
 		status.current_help_index = HELP_ADLIB_SAMPLE;
@@ -1160,37 +1160,37 @@ static int export_sample_list_handle_key(struct key_event * k)
 
 	if (k->state == KEY_RELEASE)
 		return 0;
-	switch (k->sym) {
-	case SCHISM_KEYSYM_UP:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_UP:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_format--;
 		break;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_format++;
 		break;
-	case SCHISM_KEYSYM_PAGEUP:
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_PAGEUP:
+	case SCHISM_SCANCODE_HOME:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_format = 0;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_PAGEDOWN:
+	case SCHISM_SCANCODE_END:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		new_format = num_save_formats - 1;
 		break;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			widget_change_focus_to(0);
 			return 1;
 		}
 		/* fall through */
-	case SCHISM_KEYSYM_LEFT:
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_LEFT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		widget_change_focus_to(0); /* should focus 0/1/2 depending on what's closest */
@@ -1451,18 +1451,18 @@ static void sample_list_handle_alt_key(struct key_event * k)
 	if (k->state == KEY_RELEASE)
 		return;
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_a:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_A:
 		if (canmod)
 			dialog_create(DIALOG_OK_CANCEL, "Convert sample?", do_sign_convert, NULL, 0, NULL);
 		return;
-	case SCHISM_KEYSYM_b:
+	case SCHISM_SCANCODE_B:
 		if (canmod && (sample->loop_start > 0
 			       || ((sample->flags & CHN_SUSTAINLOOP) && sample->sustain_start > 0))) {
 			dialog_create(DIALOG_OK_CANCEL, "Cut sample?", do_pre_loop_cut, NULL, 1, NULL);
 		}
 		return;
-	case SCHISM_KEYSYM_d:
+	case SCHISM_SCANCODE_D:
 		if ((k->mod & SCHISM_KEYMOD_SHIFT) && !(status.flags & CLASSIC_MODE)) {
 			if (canmod && sample->flags & CHN_STEREO) {
 				dialog_create(DIALOG_OK_CANCEL, "Downmix sample to mono?",
@@ -1473,7 +1473,7 @@ static void sample_list_handle_alt_key(struct key_event * k)
 				NULL, 1, NULL);
 		}
 		return;
-	case SCHISM_KEYSYM_e:
+	case SCHISM_SCANCODE_E:
 		if (canmod) {
 			if ((k->mod & SCHISM_KEYMOD_SHIFT) && !(status.flags & CLASSIC_MODE))
 				resample_sample_dialog(1);
@@ -1481,7 +1481,7 @@ static void sample_list_handle_alt_key(struct key_event * k)
 				resize_sample_dialog(1);
 		}
 		break;
-	case SCHISM_KEYSYM_f:
+	case SCHISM_SCANCODE_F:
 		if (canmod) {
 			if ((k->mod & SCHISM_KEYMOD_SHIFT) && !(status.flags & CLASSIC_MODE))
 				resample_sample_dialog(0);
@@ -1489,53 +1489,53 @@ static void sample_list_handle_alt_key(struct key_event * k)
 				resize_sample_dialog(0);
 		}
 		break;
-	case SCHISM_KEYSYM_g:
+	case SCHISM_SCANCODE_G:
 		if (canmod)
 			sample_reverse(sample);
 		break;
-	case SCHISM_KEYSYM_h:
+	case SCHISM_SCANCODE_H:
 		if (canmod)
 			dialog_create(DIALOG_YES_NO, "Centralise sample?", do_centralise, NULL, 0, NULL);
 		return;
-	case SCHISM_KEYSYM_i:
+	case SCHISM_SCANCODE_I:
 		if (canmod)
 			sample_invert(sample);
 		break;
-	case SCHISM_KEYSYM_l:
+	case SCHISM_SCANCODE_L:
 		if (canmod && (sample->loop_end > 0
 			       || ((sample->flags & CHN_SUSTAINLOOP) && sample->sustain_end > 0))) {
 			dialog_create(DIALOG_OK_CANCEL, "Cut sample?", do_post_loop_cut, NULL, 1, NULL);
 		}
 		return;
-	case SCHISM_KEYSYM_m:
+	case SCHISM_SCANCODE_M:
 		if (canmod)
 			sample_amplify_dialog();
 		return;
-	case SCHISM_KEYSYM_n:
+	case SCHISM_SCANCODE_N:
 		song_toggle_multichannel_mode();
 		return;
-	case SCHISM_KEYSYM_o:
+	case SCHISM_SCANCODE_O:
 		sample_save(NULL, "ITS");
 		return;
-	case SCHISM_KEYSYM_p:
+	case SCHISM_SCANCODE_P:
 		smpprompt_create("Copy sample:", "Sample", do_copy_sample);
 		return;
-	case SCHISM_KEYSYM_q:
+	case SCHISM_SCANCODE_Q:
 		if (canmod) {
 			dialog_create(DIALOG_YES_NO, "Convert sample?",
 			      do_quality_convert, do_quality_toggle, 0, NULL);
 		}
 		return;
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_R:
 		smpprompt_create("Replace sample with:", "Sample", do_replace_sample);
 		return;
-	case SCHISM_KEYSYM_s:
+	case SCHISM_SCANCODE_S:
 		smpprompt_create("Swap sample with:", "Sample", do_swap_sample);
 		return;
-	case SCHISM_KEYSYM_t:
+	case SCHISM_SCANCODE_T:
 		export_sample_dialog();
 		return;
-	case SCHISM_KEYSYM_v:
+	case SCHISM_SCANCODE_V:
 		if (!canmod || (status.flags & CLASSIC_MODE))
 			return;
 
@@ -1551,17 +1551,17 @@ static void sample_list_handle_alt_key(struct key_event * k)
 
 		crossfade_sample_dialog();
 		return;
-	case SCHISM_KEYSYM_w:
+	case SCHISM_SCANCODE_W:
 		sample_save(NULL, "RAW");
 		return;
-	case SCHISM_KEYSYM_x:
+	case SCHISM_SCANCODE_X:
 		smpprompt_create("Exchange sample with:", "Sample", do_exchange_sample);
 		return;
-	case SCHISM_KEYSYM_y:
+	case SCHISM_SCANCODE_Y:
 		/* hi virt */
 		txtsynth_dialog();
 		return;
-	case SCHISM_KEYSYM_z:
+	case SCHISM_SCANCODE_Z:
 		{ // uguu~
 			void (*dlg)(void *) = (k->mod & SCHISM_KEYMOD_SHIFT)
 				? sample_adlibpatch_dialog
@@ -1574,16 +1574,16 @@ static void sample_list_handle_alt_key(struct key_event * k)
 			}
 		}
 		return;
-	case SCHISM_KEYSYM_INSERT:
+	case SCHISM_SCANCODE_INSERT:
 		song_insert_sample_slot(current_sample);
 		break;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		song_remove_sample_slot(current_sample);
 		break;
-	case SCHISM_KEYSYM_F9:
+	case SCHISM_SCANCODE_F9:
 		sample_toggle_mute(current_sample);
 		break;
-	case SCHISM_KEYSYM_F10:
+	case SCHISM_SCANCODE_F10:
 		sample_toggle_solo(current_sample);
 		break;
 	default:
@@ -1598,19 +1598,19 @@ static void sample_list_handle_key(struct key_event * k)
 	int new_sample = current_sample;
 	song_sample_t *sample = song_get_sample(current_sample);
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_SPACE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_SPACE:
 		if (k->state == KEY_RELEASE)
 			return;
 		if (selected_widget && *selected_widget == 0) {
 			status.flags |= NEED_UPDATE;
 		}
 		return;
-	case SCHISM_KEYSYM_EQUALS:
+	case SCHISM_SCANCODE_EQUALS:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT))
 			return;
 		SCHISM_FALLTHROUGH;
-	case SCHISM_KEYSYM_PLUS:
+	case SCHISM_SCANCODE_KP_PLUS:
 		if (k->state == KEY_RELEASE)
 			return;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -1622,7 +1622,8 @@ static void sample_list_handle_key(struct key_event * k)
 		}
 		status.flags |= NEED_UPDATE;
 		return;
-	case SCHISM_KEYSYM_MINUS:
+	case SCHISM_SCANCODE_MINUS:
+	case SCHISM_SCANCODE_KP_MINUS:
 		if (k->state == KEY_RELEASE)
 			return;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -1635,29 +1636,27 @@ static void sample_list_handle_key(struct key_event * k)
 		status.flags |= NEED_UPDATE;
 		return;
 
-	case SCHISM_KEYSYM_COMMA:
-	case SCHISM_KEYSYM_LESS:
+	case SCHISM_SCANCODE_COMMA:
 		if (k->state == KEY_RELEASE)
 			return;
 		song_change_current_play_channel(-1, 0);
 		return;
-	case SCHISM_KEYSYM_PERIOD:
-	case SCHISM_KEYSYM_GREATER:
+	case SCHISM_SCANCODE_PERIOD:
 		if (k->state == KEY_RELEASE)
 			return;
 		song_change_current_play_channel(1, 0);
 		return;
-	case SCHISM_KEYSYM_PAGEUP:
+	case SCHISM_SCANCODE_PAGEUP:
 		if (k->state == KEY_RELEASE)
 			return;
 		new_sample--;
 		break;
-	case SCHISM_KEYSYM_PAGEDOWN:
+	case SCHISM_SCANCODE_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
 			return;
 		new_sample++;
 		break;
-	case SCHISM_KEYSYM_ESCAPE:
+	case SCHISM_SCANCODE_ESCAPE:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			if (k->state == KEY_RELEASE)
 				return;
@@ -1683,7 +1682,7 @@ static void sample_list_handle_key(struct key_event * k)
 					v = KEYJAZZ_DEFAULTVOL;
 				}
 			} else {
-				n = (k->sym == SCHISM_KEYSYM_SPACE)
+				n = (k->scancode == SCHISM_SCANCODE_SPACE)
 					? last_note
 					: kbd_get_note(k);
 				if (n <= 0 || n > 120)

--- a/schism/page_timeinfo.c
+++ b/schism/page_timeinfo.c
@@ -53,8 +53,8 @@ static void timeinfo_draw_const(void)
 
 static int timeinfo_handle_key(struct key_event * k)
 {
-	switch (k->sym) {
-	case SCHISM_KEYSYM_BACKQUOTE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_GRAVE:
 		if (k->state != KEY_RELEASE)
 			return 0;
 
@@ -64,7 +64,7 @@ static int timeinfo_handle_key(struct key_event * k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_s:
+	case SCHISM_SCANCODE_S:
 		if (k->state != KEY_RELEASE)
 			return 0;
 
@@ -79,33 +79,33 @@ static int timeinfo_handle_key(struct key_event * k)
 	}
 
 	if (display_session) {
-		switch (k->sym) {
-		case SCHISM_KEYSYM_UP:
+		switch (k->scancode) {
+		case SCHISM_SCANCODE_UP:
 			if (k->state == KEY_RELEASE)
 				return 1;
 			top_line--;
 			break;
-		case SCHISM_KEYSYM_PAGEUP:
+		case SCHISM_SCANCODE_PAGEUP:
 			if (k->state == KEY_RELEASE)
 				return 1;
 			top_line -= 15;
 			break;
-		case SCHISM_KEYSYM_DOWN:
+		case SCHISM_SCANCODE_DOWN:
 			if (k->state == KEY_RELEASE)
 				return 1;
 			top_line++;
 			break;
-		case SCHISM_KEYSYM_PAGEDOWN:
+		case SCHISM_SCANCODE_PAGEDOWN:
 			if (k->state == KEY_RELEASE)
 				return 1;
 			top_line += 15;
 			break;
-		case SCHISM_KEYSYM_HOME:
+		case SCHISM_SCANCODE_HOME:
 			if (k->state == KEY_RELEASE)
 				return 1;
 			top_line = 0;
 			break;
-		case SCHISM_KEYSYM_END:
+		case SCHISM_SCANCODE_END:
 			if (k->state == KEY_RELEASE)
 				return 1;
 			top_line = current_song->histlen;

--- a/schism/page_waterfall.c
+++ b/schism/page_waterfall.c
@@ -354,7 +354,7 @@ static int waterfall_handle_key(struct key_event *k)
 			}
 			if (k->state == KEY_RELEASE) {
 				song_keyup(KEYJAZZ_NOINST, ii, n);
-				status.last_keysym = 0;
+				status.last_scancode = 0;
 			} else if (!k->is_repeat) {
 				song_keydown(KEYJAZZ_NOINST, ii, n, v, KEYJAZZ_CHAN_CURRENT);
 			}
@@ -362,8 +362,8 @@ static int waterfall_handle_key(struct key_event *k)
 		}
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_s:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_S:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -373,7 +373,7 @@ static int waterfall_handle_key(struct key_event *k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_m:
+	case SCHISM_SCANCODE_M:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -381,21 +381,21 @@ static int waterfall_handle_key(struct key_event *k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		noisefloor-=4;
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
 		noisefloor+=4;
 		break;
-	case SCHISM_KEYSYM_g:
+	case SCHISM_SCANCODE_G:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_PRESS)
 				return 1;
@@ -415,7 +415,7 @@ static int waterfall_handle_key(struct key_event *k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_R:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_RELEASE)
 				return 1;
@@ -424,7 +424,7 @@ static int waterfall_handle_key(struct key_event *k)
 			return 1;
 		}
 		return 0;
-	case SCHISM_KEYSYM_PLUS:
+	case SCHISM_SCANCODE_KP_PLUS:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -433,7 +433,7 @@ static int waterfall_handle_key(struct key_event *k)
 			song_set_current_order(song_get_current_order() + 1);
 		}
 		return 1;
-	case SCHISM_KEYSYM_MINUS:
+	case SCHISM_SCANCODE_KP_MINUS:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
@@ -442,8 +442,7 @@ static int waterfall_handle_key(struct key_event *k)
 			song_set_current_order(song_get_current_order() - 1);
 		}
 		return 1;
-	case SCHISM_KEYSYM_SEMICOLON:
-	case SCHISM_KEYSYM_COLON:
+	case SCHISM_SCANCODE_SEMICOLON:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (song_is_instrument_mode()) {
@@ -452,8 +451,7 @@ static int waterfall_handle_key(struct key_event *k)
 			sample_set(sample_get_current() - 1);
 		}
 		return 1;
-	case SCHISM_KEYSYM_QUOTE:
-	case SCHISM_KEYSYM_QUOTEDBL:
+	case SCHISM_SCANCODE_APOSTROPHE:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		if (song_is_instrument_mode()) {
@@ -462,14 +460,12 @@ static int waterfall_handle_key(struct key_event *k)
 			sample_set(sample_get_current() + 1);
 		}
 		return 1;
-	case SCHISM_KEYSYM_COMMA:
-	case SCHISM_KEYSYM_LESS:
+	case SCHISM_SCANCODE_COMMA:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_change_current_play_channel(-1, 0);
 		return 1;
-	case SCHISM_KEYSYM_PERIOD:
-	case SCHISM_KEYSYM_GREATER:
+	case SCHISM_SCANCODE_PERIOD:
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_change_current_play_channel(1, 0);

--- a/schism/widget-keyhandler.c
+++ b/schism/widget-keyhandler.c
@@ -284,9 +284,11 @@ int widget_handle_key(struct key_event * k)
 		case WIDGET_NUMENTRY:
 			if (k->mouse_button == MOUSE_BUTTON_LEFT) {
 				k->sym = SCHISM_KEYSYM_MINUS;
+				k->scancode = SCHISM_SCANCODE_KP_MINUS;
 				k->mouse = MOUSE_NONE;
 			} else if (k->mouse_button == MOUSE_BUTTON_RIGHT) {
 				k->sym = SCHISM_KEYSYM_PLUS;
+				k->scancode = SCHISM_SCANCODE_KP_PLUS;
 				k->mouse = MOUSE_NONE;
 			}
 			break;
@@ -333,7 +335,7 @@ int widget_handle_key(struct key_event * k)
 	}
 
 	if (k->mouse == MOUSE_CLICK
-	    || (k->mouse == MOUSE_NONE && k->sym == SCHISM_KEYSYM_RETURN)) {
+	    || (k->mouse == MOUSE_NONE && k->scancode == SCHISM_SCANCODE_RETURN)) {
 #if 0
 		if (k->mouse && k->mouse_button == MOUSE_BUTTON_MIDDLE) {
 			if (status.flags & DISKWRITER_ACTIVE) return 0;
@@ -496,28 +498,30 @@ int widget_handle_key(struct key_event * k)
 
 	if (k->mouse == MOUSE_SCROLL_UP && current_type == WIDGET_NUMENTRY) {
 		k->sym = SCHISM_KEYSYM_MINUS;
+		k->scancode = SCHISM_SCANCODE_KP_MINUS;
 	} else if (k->mouse == MOUSE_SCROLL_DOWN && current_type == WIDGET_NUMENTRY) {
 		k->sym = SCHISM_KEYSYM_PLUS;
+		k->scancode = SCHISM_SCANCODE_KP_PLUS;
 	}
 
-	switch (k->sym) {
-	case SCHISM_KEYSYM_ESCAPE:
+	switch (k->scancode) {
+	case SCHISM_SCANCODE_ESCAPE:
 		/* this is to keep the text entries from taking the key hostage and inserting '<-'
 		characters instead of showing the menu */
 		return 0;
-	case SCHISM_KEYSYM_UP:
+	case SCHISM_SCANCODE_UP:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		widget_change_focus_to(widget->next.up);
 		return 1;
-	case SCHISM_KEYSYM_DOWN:
+	case SCHISM_SCANCODE_DOWN:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		widget_change_focus_to(widget->next.down);
 		return 1;
-	case SCHISM_KEYSYM_TAB:
+	case SCHISM_SCANCODE_TAB:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			_backtab();
@@ -527,7 +531,7 @@ int widget_handle_key(struct key_event * k)
 			return 0;
 		widget_change_focus_to(widget->next.tab);
 		return 1;
-	case SCHISM_KEYSYM_LEFT:
+	case SCHISM_SCANCODE_LEFT:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		switch (current_type) {
 		case WIDGET_BITSET:
@@ -570,7 +574,7 @@ int widget_handle_key(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_RIGHT:
+	case SCHISM_SCANCODE_RIGHT:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		/* pretty much the same as left, but with a few small
 		 * changes here and there... */
@@ -613,7 +617,7 @@ int widget_handle_key(struct key_event * k)
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_HOME:
+	case SCHISM_SCANCODE_HOME:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		/* Impulse Tracker only does home/end for the thumbbars.
 		 * This stuff is all extra. */
@@ -642,7 +646,7 @@ int widget_handle_key(struct key_event * k)
 			break;
 		}
 		break;
-	case SCHISM_KEYSYM_END:
+	case SCHISM_SCANCODE_END:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		switch (current_type) {
 		case WIDGET_NUMENTRY:
@@ -669,7 +673,7 @@ int widget_handle_key(struct key_event * k)
 			break;
 		}
 		break;
-	case SCHISM_KEYSYM_SPACE:
+	case SCHISM_SCANCODE_SPACE:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		switch (current_type) {
 		case WIDGET_BITSET:
@@ -706,7 +710,7 @@ int widget_handle_key(struct key_event * k)
 			break;
 		}
 		break;
-	case SCHISM_KEYSYM_BACKSPACE:
+	case SCHISM_SCANCODE_BACKSPACE:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_NUMENTRY) {
 			if (widget->d.numentry.reverse) {
@@ -744,7 +748,7 @@ int widget_handle_key(struct key_event * k)
 		if (widget->changed) widget->changed();
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_DELETE:
+	case SCHISM_SCANCODE_DELETE:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type != WIDGET_TEXTENTRY)
 			break;
@@ -757,21 +761,26 @@ int widget_handle_key(struct key_event * k)
 		if (widget->changed) widget->changed();
 		status.flags |= NEED_UPDATE;
 		return 1;
-	case SCHISM_KEYSYM_PLUS:
+	case SCHISM_SCANCODE_EQUALS:
+		if (!(k->mod & SCHISM_KEYMOD_SHIFT))
+			break;
+		SCHISM_FALLTHROUGH;
+	case SCHISM_SCANCODE_KP_PLUS:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_NUMENTRY) {
 			widget_numentry_change_value(widget, widget->d.numentry.value + 1);
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_MINUS:
+	case SCHISM_SCANCODE_MINUS:
+	case SCHISM_SCANCODE_KP_MINUS:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_NUMENTRY && NO_MODIFIER(k->mod)) {
 			widget_numentry_change_value(widget, widget->d.numentry.value - 1);
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_l:
+	case SCHISM_SCANCODE_L:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_PANBAR) {
 			if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -785,7 +794,7 @@ int widget_handle_key(struct key_event * k)
 			}
 		}
 		break;
-	case SCHISM_KEYSYM_m:
+	case SCHISM_SCANCODE_M:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_PANBAR) {
 			if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -799,7 +808,7 @@ int widget_handle_key(struct key_event * k)
 			}
 		}
 		break;
-	case SCHISM_KEYSYM_r:
+	case SCHISM_SCANCODE_R:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_PANBAR) {
 			if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -813,7 +822,7 @@ int widget_handle_key(struct key_event * k)
 			}
 		}
 		break;
-	case SCHISM_KEYSYM_s:
+	case SCHISM_SCANCODE_S:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_PANBAR) {
 			if (k->mod & SCHISM_KEYMOD_ALT) {
@@ -828,7 +837,7 @@ int widget_handle_key(struct key_event * k)
 			}
 		}
 		break;
-	case SCHISM_KEYSYM_a:
+	case SCHISM_SCANCODE_A:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_PANBAR && (k->mod & SCHISM_KEYMOD_ALT)) {
 			song_set_pan_scheme(PANS_AMIGA);
@@ -836,7 +845,7 @@ int widget_handle_key(struct key_event * k)
 		}
 		break;
 #if 0
-	case SCHISM_KEYSYM_x:
+	case SCHISM_SCANCODE_X:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_PANBAR && (k->mod & SCHISM_KEYMOD_ALT)) {
 			song_set_pan_scheme(PANS_CROSS);
@@ -844,15 +853,15 @@ int widget_handle_key(struct key_event * k)
 		}
 		break;
 #endif
-	case SCHISM_KEYSYM_SLASH:
-	case SCHISM_KEYSYM_KP_DIVIDE:
+	case SCHISM_SCANCODE_SLASH:
+	case SCHISM_SCANCODE_KP_DIVIDE:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_PANBAR && (k->mod & SCHISM_KEYMOD_ALT)) {
 			song_set_pan_scheme(PANS_SLASH);
 			return 1;
 		}
 		break;
-	case SCHISM_KEYSYM_BACKSLASH:
+	case SCHISM_SCANCODE_BACKSLASH:
 		if (status.flags & DISKWRITER_ACTIVE) return 0;
 		if (current_type == WIDGET_PANBAR && (k->mod & SCHISM_KEYMOD_ALT)) {
 			song_set_pan_scheme(PANS_BACKSLASH);

--- a/sys/macosx/osdefs.c
+++ b/sys/macosx/osdefs.c
@@ -360,6 +360,7 @@ int macosx_event(schism_event_t *event)
 			 *
 			 *   - paper */
 			event->key.sym = SCHISM_KEYSYM_INSERT;
+			event->key.scancode = SCHISM_SCANCODE_INSERT;
 			break;
 		default:
 			break;

--- a/sys/sdl12/events.c
+++ b/sys/sdl12/events.c
@@ -640,7 +640,7 @@ static void sdl12_pump_events(void)
 			 * arrow keys are translated to some odd unicode char. */
 			if (!(schism_event.key.sym & SCHISM_KEYSYM_SCANCODE_MASK)
 				&& !(schism_event.key.mod & SCHISM_KEYMOD_CTRL)
-				&& schism_event.key.sym != SCHISM_KEYSYM_ESCAPE) {
+				&& schism_event.key.scancode != SCHISM_SCANCODE_ESCAPE) {
 				/* convert UCS-2 to UTF-8 */
 				if (e.key.keysym.unicode < 0x80) {
 					schism_event.key.text[0] = e.key.keysym.unicode;

--- a/sys/win32/osdefs.c
+++ b/sys/win32/osdefs.c
@@ -897,8 +897,9 @@ int win32_event(schism_event_t *event)
 		// We get bogus keydowns for Ctrl-Pause.
 		// As a workaround, we can check what Windows thinks, but only for Right Ctrl.
 		// Left Ctrl just gets completely ignored and there's nothing we can do about it.
-		if (event->key.sym == SCHISM_KEYSYM_SCROLLLOCK && (event->key.mod & SCHISM_KEYMOD_RCTRL) && !(GetKeyState(VK_SCROLL) & 0x80))
+		if (event->key.scancode == SCHISM_SCANCODE_SCROLLLOCK && (event->key.mod & SCHISM_KEYMOD_RCTRL) && !(GetKeyState(VK_SCROLL) & 0x80))
 			event->key.sym = SCHISM_KEYSYM_PAUSE;
+			event->key.scancode = SCHISM_SCANCODE_PAUSE;
 
 		return 1;
 	}


### PR DESCRIPTION
This PR replaces all locations that inspect `key_event`'s `sym` member for a purpose that is not text input to instead inspect the `scancode` member, switching the values from `SCHISM_KEYSYM_*` to `SCHISM_SCANCODE_*` accordingly.

One point in particular, the method `fontedit_handle_key` splits out the handling of digits from the main `switch` block so as to not have to worry about keypad digits having different scan codes.

With these changes, I have not tested every possible key input in every dialog, but with my Dvorak-layout keyboard:
- In the pattern editor, the letter keys on the keyboard act like a piano again.
- In the effect data column, because `kbd_char_to_hex` has not been switched to scan codes (being for textual input), the letters A to F are where they are with the Dvorak layout.
- In every text input field I could find (song name, sample name/filename, instrument name/filename, file/dir list quick search, filename entry, etc.), text input is natural for the keyboard layout and uses the Dvorak keys.
- All accelerator key combos are forced to the QWERTY layout.

(For instance: selecting the entire column/pattern is Alt and the last key on the home row, even though with Dvorak, L is the last key on the top row instead, marked P on QWERTY keyboards. Pressing Alt and the last key on the top row gives me Alt-P even though that's the letter L with Dvorak.)

The net result of these changes is that except for text input, the current keyboard layout being imposed at the system level is irrelevant. When you _are_ entering text, though, you just type naturally.