### PR TITLE
itf: highlight all matching characters

### DIFF
--- a/schism/itf.c
+++ b/schism/itf.c
@@ -300,6 +300,7 @@ static inline void draw_itfmap(void)
 {
 	int n, fg, bg;
 	uint8_t *ptr;
+	uint8_t highlight_char = 0xFF;
 
 	if (itfmap_pos < 0 || itfmap_chars[itfmap_pos] != current_char) {
 		ptr = (unsigned char *) memchr((char *) itfmap_chars, current_char, sizeof(itfmap_chars));
@@ -309,10 +310,13 @@ static inline void draw_itfmap(void)
 			itfmap_pos = ptr - itfmap_chars;
 	}
 
+	if ((itfmap_pos >= 0) && (itfmap_pos < sizeof(itfmap_chars)) && (selected_item != ITFMAP))
+		highlight_char = current_char;
+
 	for (n = 0; n < 240; n++) {
 		fg = 1;
 		bg = 0;
-		if (n == itfmap_pos) {
+		if ((n == itfmap_pos) || (itfmap_chars[n] == highlight_char)) {
 			if (selected_item == ITFMAP) {
 				fg = 0;
 				bg = 3;


### PR DESCRIPTION
In the font editor, if you select a character that appears more than once in the map, only the first match is highlighted. This PR updates `draw_itfmap` to highlight all matching characters so that the user can see that their edit is going to affect multiple places simultaneously. This is only done when the `selected_item` is not `ITFMAP`; it would be confusing if characters other than the cursor were highlighted when interact with the map directly.