### PR TITLE
Fixed range check in log_redraw

### DIFF
--- a/schism/page_log.c
+++ b/schism/page_log.c
@@ -121,7 +121,7 @@ static void log_redraw(void)
 	int n, i;
 
 	i = top_line;
-	for (n = 0; n <= last_line && n < 33; n++, i++) {
+	for (n = 0; i <= last_line && n < 33; n++, i++) {
 		if (!lines[i].text) continue;
 		if (lines[i].bios_font) {
 			draw_text_bios_len(lines[i].text,


### PR DESCRIPTION
In `log_redraw`, there is a loop that loops over logical lines `n` from 0 .. 32 and physical lines `i` from `top_line` on down. `i` is used to index the `lines` array, which is only populated up to index `last_line`. The loop condition compares `n` to `last_line`, but it should be comparing `i` to `last_line`.