### PR TITLE
main: remove SDL_INIT_FLAGS

### DIFF
--- a/schism/main.c
+++ b/schism/main.c
@@ -83,8 +83,6 @@ static int did_classic = 0;
 
 /* --------------------------------------------------------------------- */
 
-#define SDL_INIT_FLAGS SDL_INIT_TIMER | SDL_INIT_VIDEO
-
 static void check_update(void);
 
 void toggle_display_fullscreen(void)


### PR DESCRIPTION
overlooked when SDL code was refactored into separate backends