### PR TITLE
Proposed solution to the problem of short patterns

### DIFF
--- a/include/dialog.h
+++ b/include/dialog.h
@@ -43,7 +43,8 @@ struct dialog {
 
 	/* maybe these should get the data pointer as well? */
 	void (*draw_const) (void);
-	int (*handle_key) (struct key_event * k);
+	int (*handle_key) (struct key_event * k, void *data);
+	void (*focus_changed) (int selected_widget, void *data);
 
 	/* there's no action_ok, as yes and ok are fundamentally the same */
 	void (*action_yes) (void *data);
@@ -70,6 +71,8 @@ void dialog_draw(void);
 
 struct dialog *dialog_create(int type, const char *text, void (*action_yes) (void *data),
 		   void (*action_no) (void *data), int default_widget, void *data);
+
+void dialog_notify_selected_widget_changed(void);
 
 void dialog_destroy(void);
 void dialog_destroy_all(void);

--- a/include/events.h
+++ b/include/events.h
@@ -138,6 +138,7 @@ typedef struct {
 	/* X and Y coordinates relative to the window */
 	int32_t x;
 	int32_t y;
+	enum mouse_button buttons;
 } schism_mouse_motion_event_t;
 
 typedef struct {

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -536,9 +536,9 @@ enum mouse_state {
 };
 
 enum mouse_button {
-	MOUSE_BUTTON_LEFT = 0,
-	MOUSE_BUTTON_MIDDLE,
-	MOUSE_BUTTON_RIGHT,
+	MOUSE_BUTTON_LEFT = 1,
+	MOUSE_BUTTON_MIDDLE = 2,
+	MOUSE_BUTTON_RIGHT = 4,
 };
 
 struct key_event {

--- a/schism/main.c
+++ b/schism/main.c
@@ -523,6 +523,7 @@ SCHISM_NORETURN static void event_loop(void)
 				case SCHISM_MOUSEMOTION:
 					kk.state = KEY_DRAG;
 					video_translate(se.motion.x, se.motion.y, &kk.fx, &kk.fy);
+					button = se.motion.buttons;
 					break;
 				case SCHISM_MOUSEBUTTONDOWN:
 					video_translate(se.button.x, se.button.y, &kk.fx, &kk.fy);

--- a/schism/page.c
+++ b/schism/page.c
@@ -1785,6 +1785,11 @@ static int _timejump_keyh(struct key_event *k)
 	return 0;
 }
 
+int _timejump_keyh_dialog(struct key_event *k, void *data)
+{
+	return _timejump_keyh(k);
+}
+
 static void _timejump_draw(void)
 {
 	draw_text("Jump to time:", 30, 26, 0, 2);
@@ -1826,7 +1831,7 @@ void show_song_timejump(void)
 	widget_create_button(_timejump_widgets+2, 30, 29, 8, 0, 2, 2, 3, 3, _timejump_ok, "OK", 4);
 	widget_create_button(_timejump_widgets+3, 42, 29, 8, 1, 3, 3, 3, 0, dialog_cancel_NULL, "Cancel", 2);
 	d = dialog_create_custom(26, 24, 30, 8, _timejump_widgets, 4, 0, _timejump_draw, NULL);
-	d->handle_key = _timejump_keyh;
+	d->handle_key = _timejump_keyh_dialog;
 	d->action_yes = _timejump_ok_ptr;
 }
 

--- a/schism/page_loadsample.c
+++ b/schism/page_loadsample.c
@@ -485,7 +485,7 @@ static void stereo_cvt_dialog(void)
 	draw_text("Loading Stereo Sample", 30, 27, 0, 2);
 }
 
-static int stereo_cvt_hk(struct key_event *k)
+static int stereo_cvt_hk(struct key_event *k, void *data)
 {
 	if (!NO_MODIFIER(k->mod))
 		return 0;

--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -953,7 +953,7 @@ static void sample_adlibconfig_draw_const(void)
 		draw_text(labels[a].label, labels[a].x, labels[a].y + 30, a ? 0 : 3, 2);
 }
 
-static int do_adlib_handlekey(struct key_event *kk)
+static int do_adlib_handlekey(struct key_event *kk, void *data)
 {
 	if (kk->sym == SCHISM_KEYSYM_F1) {
 		if (kk->state == KEY_PRESS)

--- a/schism/widget.c
+++ b/schism/widget.c
@@ -27,6 +27,7 @@
 #include "it.h"
 #include "page.h"
 #include "widget.h"
+#include "dialog.h"
 #include "vgamem.h"
 #include "str.h"
 
@@ -669,6 +670,8 @@ void widget_change_focus_to(int new_widget_index)
 	if (ACTIVE_WIDGET.depressed) ACTIVE_WIDGET.depressed = 0;
 
 	*selected_widget = new_widget_index;
+
+	dialog_notify_selected_widget_changed();
 
 	ACTIVE_WIDGET.depressed = 0;
 

--- a/sys/sdl12/events.c
+++ b/sys/sdl12/events.c
@@ -26,6 +26,7 @@
 #include "backend/events.h"
 #include "util.h"
 #include "video.h"
+#include "keyboard.h"
 
 #include "init.h"
 
@@ -568,6 +569,20 @@ static schism_scancode_t sdl12_scancode_trans(uint8_t sc)
 	}
 }
 
+static enum mouse_button sdl12_mouse_buttons_trans(Uint32 sdl_mouse_button_state)
+{
+	enum mouse_button ret = 0;
+
+	if (sdl_mouse_button_state & SDL_BUTTON(SDL_BUTTON_LEFT))
+		ret |= MOUSE_BUTTON_LEFT;
+	if (sdl_mouse_button_state & SDL_BUTTON(SDL_BUTTON_MIDDLE))
+		ret |= MOUSE_BUTTON_MIDDLE;
+	if (sdl_mouse_button_state & SDL_BUTTON(SDL_BUTTON_RIGHT))
+		ret |= MOUSE_BUTTON_RIGHT;
+
+	return ret;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 static SDLMod (SDLCALL *sdl12_GetModState)(void);
@@ -723,6 +738,7 @@ static void sdl12_pump_events(void)
 			schism_event.type = SCHISM_MOUSEMOTION;
 			schism_event.motion.x = e.motion.x;
 			schism_event.motion.y = e.motion.y;
+			schism_event.motion.buttons = sdl12_mouse_buttons_trans(e.motion.state);
 			events_push_event(&schism_event);
 			break;
 		case SDL_MOUSEBUTTONDOWN:

--- a/sys/sdl2/events.c
+++ b/sys/sdl2/events.c
@@ -365,6 +365,24 @@ static schism_keymod_t sdl2_event_mod_state(void)
 	return sdl2_modkey_trans(sdl2_GetModState());
 }
 
+static enum mouse_button sdl2_mouse_buttons_trans(Uint32 sdl_mouse_button_state)
+{
+	printf("SDL mouse button state: %d\n", sdl_mouse_button_state);
+
+	enum mouse_button ret = 0;
+
+	if (sdl_mouse_button_state & SDL_BUTTON(SDL_BUTTON_LEFT))
+		ret |= MOUSE_BUTTON_LEFT;
+	if (sdl_mouse_button_state & SDL_BUTTON(SDL_BUTTON_MIDDLE))
+		ret |= MOUSE_BUTTON_MIDDLE;
+	if (sdl_mouse_button_state & SDL_BUTTON(SDL_BUTTON_RIGHT))
+		ret |= MOUSE_BUTTON_RIGHT;
+
+	printf("translated button state: %d\n", ret);
+
+	return ret;
+}
+
 /* These are here for linking text input to keyboard inputs.
  * If no keyboard input can be found, then the text will
  * be sent as a SCHISM_TEXTINPUT event.
@@ -507,6 +525,7 @@ static void sdl2_pump_events(void)
 			schism_event.type = SCHISM_MOUSEMOTION;
 			schism_event.motion.x = e.motion.x;
 			schism_event.motion.y = e.motion.y;
+			schism_event.motion.buttons = sdl2_mouse_buttons_trans(e.motion.state);
 			events_push_event(&schism_event);
 			break;
 		case SDL_MOUSEBUTTONDOWN:

--- a/sys/sdl3/events.c
+++ b/sys/sdl3/events.c
@@ -97,6 +97,20 @@ static schism_keymod_t sdl3_event_mod_state(void)
 	return sdl3_modkey_trans(sdl3_GetModState());
 }
 
+static mouse_button sdl2_mouse_buttons_trans(Uint32 sdl_mouse_button_state)
+{
+	enum mouse_button ret = 0;
+
+	if (sdl12_mouse_button_state & SDL_BUTTON(SDL_BUTTON_LEFT))
+		ret |= MOUSE_BUTTON_LEFT;
+	if (sdl12_mouse_button_state & SDL_BUTTON(SDL_BUTTON_MIDDLE))
+		ret |= MOUSE_BUTTON_MIDDLE;
+	if (sdl12_mouse_button_state & SDL_BUTTON(SDL_BUTTON_RIGHT))
+		ret |= MOUSE_BUTTON_RIGHT;
+
+	return ret;
+}
+
 /* These are here for linking text input to keyboard inputs.
  * If no keyboard input can be found, then the text will
  * be sent as a SCHISM_TEXTINPUT event.
@@ -292,6 +306,7 @@ static void sdl3_pump_events(void)
 			schism_event.type = SCHISM_MOUSEMOTION;
 			schism_event.motion.x = e.motion.x;
 			schism_event.motion.y = e.motion.y;
+			schism_event.motion.buttons = sdl3_mouse_buttons_trans(e.motion.state);
 			events_push_event(&schism_event);
 			break;
 		case SDL_EVENT_MOUSE_BUTTON_DOWN:


### PR DESCRIPTION
A comment in the source code describes a problem to do with pattern lengths: The editor handles short patterns with fewer than 32 rows just fine, but the user experience in the Options dialog in the Pattern Editor is poor when the thumb bar's minimum is set to 1. In particular, Storlek found that pressing the Home key and getting a pattern length of 1 was in most cases an unuseful and unexpected behaviour.

This PR proposes a solution to this problem. With the changes here, the Options dialog still has a minimum pattern length of 32, unless the user holds down the Ctrl key while on that widget. This behaviour is described with hint text that is displayed only when the pattern length widget has focus. The code attempts to revert to the lower bound of 32 when Ctrl is released, but keeps the new lower bound of 1 when the value has been moved into the extended range.

In order to make this change, it was necessary to create infrastructure to notify interested parties when a dialog's `selected_widget` changes. It also seemed appropriate to thread the user-defined `data` value into the `handle_key` callback. Finally, it was important to have accurate information about mouse button states when handling the events related to Ctrl key press/release, and to that end, I've reworked `enum mouse_button` to be usable as flags and updated the SDL back-ends to include the mouse button state information that SDL provides as part of `SDL_EVENT_MOUSE_MOTION` events in the event data that percolates through the input handling infrastructure.

The only thing I encountered in testing this that was perhaps not entirely perfect is that while adjusting the pattern length with Ctrl held down, this also triggers the behaviour of increasing the step size to 2. However, Ctrl-Home does set the length to 1, and if Ctrl is released while the value is less than 32, it can then be adjusted to arbitrary values below 32 with no step.