### PR TITLE
Refactor widget infrastructure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -144,6 +144,7 @@ noinst_HEADERS = \
 	include/version.h		\
 	include/vgamem.h      \
 	include/video.h			\
+	include/widget_context.h     \
 	include/widget.h        \
 	include/player/cmixer.h		\
 	include/player/fmopl.h			\
@@ -629,6 +630,7 @@ schismtracker_SOURCES = \
 	schism/video.c			\
 	schism/widget-keyhandler.c	\
 	schism/widget.c			\
+	schism/widget_context.c   \
 	schism/xpmdata.c		\
 	sys/posix/osdefs.c \
 	$(files_macosx)			\

--- a/include/dialog.h
+++ b/include/dialog.h
@@ -27,7 +27,23 @@
 struct key_event;
 struct widget;
 
+#include "widget_context.h"
+
+struct dialog;
+
+typedef void (*action_cb)(void *data);
+typedef void (*dialog_cb)(struct dialog *this);
+typedef int (*dialog_key_event_cb)(struct dialog *this, struct key_event *k);
+
 struct dialog {
+	/************************************/
+	/* must match struct widget_context */
+	enum widget_context_type context_type;
+	struct widget *widgets;     /* malloc'ed (type != DIALOG_CUSTOM) */
+	int selected_widget;
+	int total_widgets;
+	/************************************/
+
 	int type;
 	int x, y, w, h;
 
@@ -35,41 +51,36 @@ struct dialog {
 	char *text;     /* malloc'ed */
 	int text_x;
 
-	struct widget *widgets;     /* malloc'ed */
-	int selected_widget;
-	int total_widgets;
-
 	void *data; /* extra data pointer */
 
 	/* maybe these should get the data pointer as well? */
-	void (*draw_const) (void);
-	int (*handle_key) (struct key_event * k);
+	dialog_cb draw_const;
+	dialog_key_event_cb handle_key;
 
 	/* there's no action_ok, as yes and ok are fundamentally the same */
-	void (*action_yes) (void *data);
-	void (*action_no) (void *data); /* only useful for y/n dialogs? */
+	action_cb action_yes;
+	action_cb action_no; /* only useful for y/n dialogs? */
 	/* currently, this is only settable for custom dialogs.
 	 * it's only used in a couple of places (mostly on the pattern editor) */
-	void (*action_cancel) (void *data);
+	action_cb action_cancel;
 };
 
 /* dialog handlers
  * these are set by default for normal dialogs, and can be used with the custom dialogs.
  * they call the {yes, no, cancel} callback, destroy the dialog, and schedule a screen
  * update. (note: connect these to the BUTTONS, not the action_* callbacks!) */
-void dialog_yes(void *data);
-void dialog_no(void *data);
-void dialog_cancel(void *data);
-/* these are the same as dialog_yes(NULL) etc., and are used in button callbacks */
-void dialog_yes_NULL(void);
-void dialog_no_NULL(void);
-void dialog_cancel_NULL(void);
+void dialog_yes(struct widget_context *this);
+void dialog_no(struct widget_context *this);
+void dialog_cancel(struct widget_context *this);
+
+/* dialog handler that simply calls free() on this->data */
+void dialog_free_data(struct dialog *this);
 
 int dialog_handle_key(struct key_event * k);
 void dialog_draw(void);
 
-struct dialog *dialog_create(int type, const char *text, void (*action_yes) (void *data),
-		   void (*action_no) (void *data), int default_widget, void *data);
+struct dialog *dialog_create(int type, const char *text, action_cb action_yes,
+		   action_cb action_no, int default_widget, void *data);
 
 void dialog_destroy(void);
 void dialog_destroy_all(void);
@@ -79,6 +90,9 @@ void dialog_destroy_all(void);
  * the dialog has been displayed. */
 struct dialog *dialog_create_custom(int x, int y, int w, int h, struct widget *dialog_widgets,
 				    int dialog_total_widgets, int dialog_selected_widget,
-				    void (*draw_const) (void), void *data);
+				    dialog_cb draw_const, void *data);
+
+/* dynamic cast to struct dialog * */
+struct dialog *widget_context_as_dialog(struct widget_context *this);
 
 #endif /* SCHISM_DIALOG_H_ */

--- a/include/page.h
+++ b/include/page.h
@@ -347,9 +347,7 @@ extern struct page pages[];
 
 /* these are updated to point to the relevant data in the selected page
  * (or the dialog, if one is active) */
-extern struct widget *widgets;
-extern int *selected_widget;
-extern int *total_widgets;
+extern struct widget_context *widget_context;
 
 /* to make it easier to deal with either the page's widgets or the
  * current dialog's:
@@ -358,7 +356,7 @@ extern int *total_widgets;
  * ACTIVE_PAGE_WIDGET references the *page's* idea of what's active.
  *     (these are different if there's a dialog) */
 #define ACTIVE_PAGE        (pages[status.current_page])
-#define ACTIVE_WIDGET      (widgets[*selected_widget])
+#define ACTIVE_WIDGET      (widget_context->widgets[widget_context->selected_widget])
 #define ACTIVE_PAGE_WIDGET (ACTIVE_PAGE.widgets[ACTIVE_PAGE.selected_widget])
 
 /* dynamic cast to struct page * */

--- a/include/page.h
+++ b/include/page.h
@@ -28,6 +28,8 @@
 #ifndef SCHISM_PAGE_H_
 #define SCHISM_PAGE_H_
 
+#include "widget_context.h"
+
 /* How much to scroll. */
 #define MOUSE_SCROLL_LINES       3
 
@@ -129,8 +131,8 @@ struct widget_numentry {
 	int32_t min;
 	int32_t max;
 	int32_t value;
-	int *cursor_pos; /* XXX why is this a pointer */
-	int (*handle_unknown_key)(struct key_event *k);
+	int *cursor_pos; /* this is a pointer to allow a column of numentries to share a common cursor_pos */
+	widget_key_cb handle_unknown_key;
 	int reverse; /* boolean */
 };
 
@@ -188,20 +190,21 @@ struct widget_panbar {
  * through function pointers. :) */
 struct widget_listbox {
 	/* get the size of the listbox */
-	uint32_t (*size)(void);
+	widget_cb_uint32 size;
 
 	/* get the name of an item */
-	const char *(*name)(uint32_t i);
+	widget_uint32_cb_str name;
 
 	/* get whether an item is toggled or not.
 	 * in the scope of the UI, this decides whether
 	 * the item is prefixed with a "*" or not.
 	 * in most cases there should only be ONE of
 	 * these at a time. */
-	int (*toggled)(uint32_t i);
+	widget_uint32_cb_int toggled;
 
 	/* custom key handler, for extra keybinds. :) */
-	int (*handle_key)(struct key_event *k);
+
+	widget_key_cb handle_key;
 
 	struct {
 		/* left & backtab */
@@ -224,13 +227,13 @@ struct widget_other {
 	 * pretty much stuck)
 	 * this MUST be set to a valid function.
 	 * return value is 1 if the key was handled, 0 if not. */
-	int (*handle_key) (struct key_event * k);
-	int (*handle_text_input) (const char *text_input);
+	widget_key_cb handle_key;
+	widget_text_cb handle_text_input;
 
 	/* also the widget drawing function can't possibly know how to
 	 * draw a custom widget, so it calls this instead.
 	 * this MUST be set to a valid function. */
-	void (*redraw) (void);
+	widget_cb redraw;
 };
 
 /* --------------------------------------------------------------------- */
@@ -267,14 +270,17 @@ struct widget {
 	} next;
 
 	/* called whenever the value is changed... duh ;) */
-	void (*changed) (void);
+	void (*changed) (struct widget_context *this);
 
 	/* called when the enter key is pressed */
-	void (*activate) (void);
+	void (*activate) (struct widget_context *this);
+
+	/* the context this widget is participating in (page, dialog) */
+	struct widget_context *this;
 
 	/* called by the clipboard manager; really, only "other" widgets
 	should "override" this... */
-	int (*clipboard_paste)(int cb, const void *cptr);
+	int (*clipboard_paste)(struct widget_context *, int cb, const void *cptr);
 
 	/* true if the widget accepts "text"- used for digraphs and unicode
 	and alt+kp entry... */
@@ -289,6 +295,14 @@ struct widget {
  * everything in this struct MUST be set for each page.
  * functions that aren't implemented should be set to NULL. */
 struct page {
+	/************************************/
+	/* must match struct widget_context */
+	enum widget_context_type context_type;
+	struct widget *widgets;
+	int selected_widget;
+	int total_widgets;
+	/************************************/
+
 	/* the title of the page, eg "Sample List (F3)" */
 	const char *title;
 
@@ -308,11 +322,11 @@ struct page {
 	 * (this is called *very* frequently) */
 	void (*playback_update) (void);
 	/* this gets first shot at keys (to do unnatural overrides) */
-	int (*pre_handle_key) (struct key_event * k);
+	int (*pre_handle_key) (struct widget_context *this, struct key_event * k);
 	/* this catches any keys that the main handler doesn't deal with */
-	void (*handle_key) (struct key_event * k);
+	int (*handle_key) (struct widget_context *this, struct key_event * k);
 	/* handle any text input events from SDL */
-	void (*handle_text_input) (const char* text_input);
+	void (*handle_text_input) (struct widget_context *this, const char* text_input);
 	/* called when the page is set. this is for reloading the
 	 * directory in the file browsers. */
 	void (*set_page) (void);
@@ -321,11 +335,7 @@ struct page {
 	void (*song_mode_changed_cb) (void);
 
 	/* called by the clipboard manager */
-	int (*clipboard_paste)(int cb, const void *cptr);
-
-	struct widget *widgets;
-	int selected_widget;
-	int total_widgets;
+	int (*clipboard_paste)(struct widget_context *this, int cb, const void *cptr);
 
 	/* 0 if no page-specific help */
 	int help_index;
@@ -350,6 +360,9 @@ extern int *total_widgets;
 #define ACTIVE_PAGE        (pages[status.current_page])
 #define ACTIVE_WIDGET      (widgets[*selected_widget])
 #define ACTIVE_PAGE_WIDGET (ACTIVE_PAGE.widgets[ACTIVE_PAGE.selected_widget])
+
+/* dynamic cast to struct page * */
+struct page *widget_context_as_page(struct widget_context *this);
 
 extern int instrument_list_subpage;
 #define PAGE_INSTRUMENT_LIST instrument_list_subpage

--- a/include/page.h
+++ b/include/page.h
@@ -203,7 +203,6 @@ struct widget_listbox {
 	widget_uint32_cb_int toggled;
 
 	/* custom key handler, for extra keybinds. :) */
-
 	widget_key_cb handle_key;
 
 	struct {
@@ -487,8 +486,13 @@ void message_reset_selection(void);
 /* --------------------------------------------------------------------- */
 /* Other UI prompt stuff. */
 
-/* Ask for a value, like the thumbbars. */
+/* XXX The code for these is in dialog.c, should these declarations be in dialog.h? */
+
+/* Ask for a value. */
 void numprompt_create(const char *prompt, void (*finish)(int n), char initvalue);
+
+/* Ask for a value, specifically for thumbbars. */
+void numprompt_create_for_thumbbar(const char *prompt, struct widget *thumbbar, void (*finish)(struct widget *thumbbar, int n), char initvalue);
 
 /* Ask for a sample / instrument number, like the "swap sample" dialog. */
 void smpprompt_create(const char *title, const char *prompt, void (*finish)(int n));

--- a/include/util.h
+++ b/include/util.h
@@ -133,4 +133,10 @@ int util_call_func_with_envvar(int (*cb)(void *p), void *p, const char *name,
 int msgboxv(int style, const char *title, const char *fmt, va_list ap);
 int msgbox(int style, const char *title, const char *fmt, ...);
 
+/* This function takes an int and copies it into a malloc()ed buffer, for
+ * use with lifetime models like dialog.final_data where the pointer is
+ * always free()d.
+ */
+void *malloc_int(int value);
+
 #endif /* SCHISM_UTIL_H_ */

--- a/include/widget.h
+++ b/include/widget.h
@@ -28,46 +28,46 @@
 
 void widget_create_toggle(struct widget *w, int x, int y, int next_up,
 		   int next_down, int next_left, int next_right,
-		   int next_tab, void (*changed) (void));
+		   int next_tab, widget_cb changed);
 void widget_create_menutoggle(struct widget *w, int x, int y, int next_up,
 		       int next_down, int next_left, int next_right,
-		       int next_tab, void (*changed) (void),
+		       int next_tab, widget_cb changed,
 		       const char *const *choices);
 void widget_create_button(struct widget *w, int x, int y, int width, int next_up,
 		   int next_down, int next_left, int next_right,
-		   int next_tab, void (*changed) (void), const char *text,
+		   int next_tab, widget_cb changed, const char *text,
 		   int padding);
 void widget_create_togglebutton(struct widget *w, int x, int y, int width,
 			 int next_up, int next_down, int next_left,
 			 int next_right, int next_tab,
-			 void (*changed) (void), const char *text,
+			 widget_cb changed, const char *text,
 			 int padding, const int *group);
 void widget_create_textentry(struct widget *w, int x, int y, int width, int next_up,
-		      int next_down, int next_tab, void (*changed) (void),
+		      int next_down, int next_tab, widget_cb changed,
 		      char *text, int max_length);
 void widget_create_numentry(struct widget *w, int x, int y, int width, int next_up,
-		     int next_down, int next_tab, void (*changed) (void),
+		     int next_down, int next_tab, widget_cb changed,
 		     int32_t min, int32_t max, int *cursor_pos);
 void widget_create_thumbbar(struct widget *w, int x, int y, int width, int next_up,
-		     int next_down, int next_tab, void (*changed) (void),
+		     int next_down, int next_tab, widget_cb changed,
 		     int min, int max);
 void widget_create_bitset(struct widget *w, int x, int y, int width, int next_up,
-		   int next_down, int next_tab, void (*changed) (void),
+		   int next_down, int next_tab, widget_cb changed,
 		   int nbits, const char* bits_on, const char* bits_off,
 		   int *cursor_pos);
 void widget_create_panbar(struct widget *w, int x, int y, int next_up,
-		   int next_down, int next_tab, void (*changed) (void),
+		   int next_down, int next_tab, widget_cb changed,
 		   int channel);
 void widget_create_listbox(struct widget *w,
-	uint32_t (*i_size) (void), int (*i_toggled) (uint32_t),
-	const char * (*i_name) (uint32_t), void (*i_changed) (void),
-	void (*i_activate)(void), int (*i_handle_key)(struct key_event *kk),
+	widget_cb_uint32 i_size, widget_uint32_cb_int i_toggled,
+	widget_uint32_cb_str i_name, widget_cb i_changed,
+	widget_cb i_activate, widget_key_cb i_handle_key,
 	const int *focus_offsets_left, const int *focus_offsets_right,
 	int next_up, int next_down);
 void widget_create_other(struct widget *w, int next_tab,
-		  int (*w_handle_key) (struct key_event * k),
-		  int (*w_handle_text_input) (const char* text),
-		  void (*w_redraw) (void));
+		  widget_key_cb w_handle_key,
+		  widget_text_cb w_handle_text_input,
+		  widget_cb w_redraw);
 
 /* --------------------------------------------------- */
 /* widget.c */
@@ -78,6 +78,8 @@ void widget_numentry_change_value(struct widget *widget, int32_t new_value);
 int widget_numentry_handle_text(struct widget *w, const char* text_input);
 
 int widget_find_xy(int x, int y);
+
+void widget_context_change_focus_to(struct widget_context *this, int new_widget_index);
 
 int widget_change_focus_to_xy(int x, int y);
 void widget_change_focus_to(int new_widget_index);

--- a/include/widget_context.h
+++ b/include/widget_context.h
@@ -1,0 +1,58 @@
+/*
+ * Schism Tracker - a cross-platform Impulse Tracker clone
+ * copyright (c) 2003-2005 Storlek <storlek@rigelseven.com>
+ * copyright (c) 2005-2008 Mrs. Brisby <mrs.brisby@nimh.org>
+ * copyright (c) 2009 Storlek & Mrs. Brisby
+ * copyright (c) 2010-2012 Storlek
+ * URL: http://schismtracker.org/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef SCHISM_WIDGET_CONTEXT_H_
+#define SCHISM_WIDGET_CONTEXT_H_
+
+#include "headers.h"
+
+struct widget;
+struct key_event;
+
+enum widget_context_type {
+	WIDGET_CONTEXT_INVALID,
+
+	WIDGET_CONTEXT_PAGE,
+	WIDGET_CONTEXT_DIALOG,
+};
+
+struct widget_context {
+	/* base class for struct page and struct dialog */
+	enum widget_context_type context_type;
+	struct widget *widgets;
+	int selected_widget;
+	int total_widgets;
+};
+
+typedef uint32_t (*widget_cb_uint32)(struct widget_context *this);
+typedef int (*widget_uint32_cb_int)(struct widget_context *this, uint32_t);
+typedef const char * (*widget_uint32_cb_str)(struct widget_context *this, uint32_t);
+typedef void (*widget_cb)(struct widget_context *this);
+typedef int (*widget_key_cb)(struct widget_context *this, struct key_event *kk);
+typedef int (*widget_text_cb)(struct widget_context *this, const char *text);
+
+void widget_set_context(struct widget_context *context);
+void widget_set_context_use_active_page(struct widget_context *context);
+struct widget_context *widget_get_context(struct widget *widget);
+
+#endif /* SCHISM_WIDGET_CONTEXT_H_ */

--- a/schism/audio_loadsave.c
+++ b/schism/audio_loadsave.c
@@ -765,7 +765,7 @@ int song_load_instrument(int n, const char* file)
 	return song_load_instrument_ex(n,file,NULL,-1);
 }
 
-static void do_enable_inst(SCHISM_UNUSED void* d)
+static void do_enable_inst(SCHISM_UNUSED void* d, SCHISM_UNUSED void* fd)
 {
 	song_set_instrument_mode(1);
 	main_song_changed_cb();
@@ -773,7 +773,7 @@ static void do_enable_inst(SCHISM_UNUSED void* d)
 	memused_songchanged();
 }
 
-static void dont_enable_inst(SCHISM_UNUSED void* d)
+static void dont_enable_inst(SCHISM_UNUSED void* d, SCHISM_UNUSED void* fd)
 {
 	set_page(PAGE_INSTRUMENT_LIST);
 }

--- a/schism/dialog.c
+++ b/schism/dialog.c
@@ -111,14 +111,10 @@ void dialog_destroy(void)
 	num_dialogs--;
 	if (num_dialogs) {
 		d--;
-		widgets = dialogs[d].widgets;
-		selected_widget = &(dialogs[d].selected_widget);
-		total_widgets = &(dialogs[d].total_widgets);
+		widget_context = (struct widget_context *)&dialogs[d];
 		status.dialog_type = dialogs[d].type;
 	} else {
-		widgets = ACTIVE_PAGE.widgets;
-		selected_widget = &(ACTIVE_PAGE.selected_widget);
-		total_widgets = &(ACTIVE_PAGE.total_widgets);
+		widget_context = (struct widget_context *)&ACTIVE_PAGE;
 		status.dialog_type = DIALOG_NONE;
 	}
 
@@ -418,9 +414,7 @@ struct dialog *dialog_create(int type, const char *text, action_cb action_yes,
 	widget_set_context((struct widget_context *)dialog);
 
 	dialog->type = type;
-	widgets = dialog->widgets;
-	selected_widget = &(dialog->selected_widget);
-	total_widgets = &(dialog->total_widgets);
+	widget_context = (struct widget_context *)dialog;
 
 	num_dialogs++;
 
@@ -467,9 +461,7 @@ struct dialog *dialog_create_custom(int x, int y, int w, int h, struct widget *d
 	widget_set_context((struct widget_context *)d);
 
 	status.dialog_type = DIALOG_CUSTOM;
-	widgets = d->widgets;
-	selected_widget = &(d->selected_widget);
-	total_widgets = &(d->total_widgets);
+	widget_context = (struct widget_context *)d;
 
 	status.flags |= NEED_UPDATE;
 

--- a/schism/dialog.c
+++ b/schism/dialog.c
@@ -513,7 +513,7 @@ struct dialog *dialog_create_custom(int x, int y, int w, int h, struct widget *d
 /* dynamic cast to struct dialog * */
 struct dialog *widget_context_as_dialog(struct widget_context *this)
 {
-	if (this->context_type == WIDGET_CONTEXT_DIALOG)
+	if (this && (this->context_type == WIDGET_CONTEXT_DIALOG))
 		return (struct dialog *)this;
 	else
 		return NULL;

--- a/schism/disko.c
+++ b/schism/disko.c
@@ -665,7 +665,7 @@ static int canceled = 0; /* this sucks, but so do I */
 
 static int disko_finish(void);
 
-static void diskodlg_draw(void)
+static void diskodlg_draw(SCHISM_UNUSED struct dialog *this)
 {
 	int sec, pos;
 	char buf[32];
@@ -953,10 +953,8 @@ struct pat2smp {
 	int pattern, sample, bind;
 };
 
-static void pat2smp_single(void *data)
+static void pat2smp_single(struct pat2smp *ps)
 {
-	struct pat2smp *ps = data;
-
 	if (disko_writeout_sample(ps->sample, ps->pattern, ps->bind) == DW_OK) {
 		set_page(PAGE_SAMPLE_LIST);
 	} else {
@@ -965,6 +963,12 @@ static void pat2smp_single(void *data)
 	}
 
 	free(ps);
+}
+
+static void pat2smp_single_dialog(void *data)
+{
+	struct pat2smp *ps = data;
+	pat2smp_single(ps);
 }
 
 static void pat2smp_multi(void *data)
@@ -1020,7 +1024,7 @@ void song_pattern_to_sample(int pattern, int split, int bind)
 			pat2smp_single(ps);
 		} else {
 			dialog_create(DIALOG_OK_CANCEL, "This will replace the current sample.",
-				pat2smp_single, free, 1, ps);
+				pat2smp_single_dialog, free, 1, ps);
 		}
 	}
 }

--- a/schism/disko.c
+++ b/schism/disko.c
@@ -687,7 +687,7 @@ static void diskodlg_draw(SCHISM_UNUSED struct dialog *this)
 	draw_box(23, 29, 56, 31, BOX_THIN | BOX_INNER | BOX_INSET);
 }
 
-static void diskodlg_cancel(SCHISM_UNUSED void *ignored)
+static void diskodlg_cancel(SCHISM_UNUSED void *ignored, SCHISM_UNUSED void *final_data)
 {
 	canceled = 1;
 	export_dwsong.flags |= SONG_ENDREACHED;
@@ -708,14 +708,14 @@ static void diskodlg_cancel(SCHISM_UNUSED void *ignored)
 static void disko_dialog_setup(size_t len);
 
 // this needs to be done to work around stupid inconsistent key-up code
-static void diskodlg_reset(SCHISM_UNUSED void *ignored)
+static void diskodlg_reset(SCHISM_UNUSED void *ignored, SCHISM_UNUSED void *final_data)
 {
 	disko_dialog_setup(est_len);
 }
 
 static void disko_dialog_setup(size_t len)
 {
-	struct dialog *d = dialog_create_custom(22, 25, 36, 8, diskodlg_widgets, 0, 0, diskodlg_draw, NULL);
+	struct dialog *d = dialog_create_custom(22, 25, 36, 8, diskodlg_widgets, 0, 0, diskodlg_draw, NULL, NULL);
 	d->action_yes = diskodlg_reset;
 	d->action_no = diskodlg_reset;
 	d->action_cancel = diskodlg_cancel;
@@ -965,7 +965,7 @@ static void pat2smp_single(struct pat2smp *ps)
 	free(ps);
 }
 
-static void pat2smp_single_dialog(void *data)
+static void pat2smp_single_dialog(void *data, SCHISM_UNUSED void *final_data)
 {
 	struct pat2smp *ps = data;
 	pat2smp_single(ps);
@@ -1024,7 +1024,7 @@ void song_pattern_to_sample(int pattern, int split, int bind)
 			pat2smp_single(ps);
 		} else {
 			dialog_create(DIALOG_OK_CANCEL, "This will replace the current sample.",
-				pat2smp_single_dialog, free, 1, ps);
+				pat2smp_single_dialog, dialog_free_data, 1, ps);
 		}
 	}
 }

--- a/schism/itf.c
+++ b/schism/itf.c
@@ -838,7 +838,7 @@ static void handle_mouse(struct key_event * k)
 	status.flags |= NEED_UPDATE;
 }
 
-static int fontedit_handle_key(struct key_event * k)
+static int fontedit_handle_key(struct widget_context *this, struct key_event * k)
 {
 	int n, ci = current_char << 3;
 	uint8_t *ptr = font_data + ci;
@@ -1085,7 +1085,7 @@ static int fontedit_handle_key(struct key_event * k)
 
 static struct widget fontedit_widget_hack[1];
 
-static int fontedit_key_hack(struct key_event *k)
+static int fontedit_key_hack(struct widget_context *this, struct key_event *k)
 {
 	switch (k->sym) {
 	case SCHISM_KEYSYM_r: case SCHISM_KEYSYM_l: case SCHISM_KEYSYM_s:
@@ -1096,7 +1096,7 @@ static int fontedit_key_hack(struct key_event *k)
 	case SCHISM_KEYSYM_F4: case SCHISM_KEYSYM_F5: case SCHISM_KEYSYM_F6:
 	case SCHISM_KEYSYM_F7: case SCHISM_KEYSYM_F8: case SCHISM_KEYSYM_F9:
 	case SCHISM_KEYSYM_F10: case SCHISM_KEYSYM_F11: case SCHISM_KEYSYM_F12:
-		return fontedit_handle_key(k);
+		return fontedit_handle_key(this, k);
 	case SCHISM_KEYSYM_RETURN:
 		if (status.dialog_type & (DIALOG_MENU|DIALOG_BOX)) return 0;
 		if (selected_item == FONTLIST) {
@@ -1109,7 +1109,7 @@ static int fontedit_key_hack(struct key_event *k)
 	return 0;
 }
 
-static void do_nil(void) {}
+static void do_nil(SCHISM_UNUSED struct widget_context *this) {}
 void fontedit_load_page(struct page *page)
 {
 	page->title = "";

--- a/schism/itf.c
+++ b/schism/itf.c
@@ -645,7 +645,7 @@ static void handle_key_itfmap(struct key_event * k)
 	status.flags |= NEED_UPDATE;
 }
 
-static void confirm_font_save_ok(void *vf)
+static void confirm_font_save_ok(void *vf, SCHISM_UNUSED void *final_data)
 {
 	char *f = vf;
 	if (font_save(f) != 0)
@@ -697,7 +697,7 @@ static void handle_key_fontlist(struct key_event * k)
 						confirm_font_save_ok, NULL, 1, flist.files[cur_font]->base);
 					return;
 				}
-				confirm_font_save_ok(flist.files[cur_font]->base);
+				confirm_font_save_ok(flist.files[cur_font]->base, NULL);
 			}
 			selected_item = EDITBOX;
 			/* fontlist_mode = MODE_OFF; */

--- a/schism/main.c
+++ b/schism/main.c
@@ -605,7 +605,7 @@ SCHISM_NORETURN static void event_loop(void)
 						}
 						break;
 					case KEY_DRAG:
-						kk.on_target = (widget_find_xy(kk.x, kk.y) == *selected_widget);
+						kk.on_target = (widget_find_xy(kk.x, kk.y) == widget_context->selected_widget);
 					}
 					if (se.type == SCHISM_MOUSEBUTTONUP && downtrip) {
 						downtrip = 0;

--- a/schism/main.c
+++ b/schism/main.c
@@ -350,11 +350,11 @@ static void check_update(void)
 static void _do_clipboard_paste_op(schism_event_t *e)
 {
 	if (ACTIVE_WIDGET.clipboard_paste
-	&& ACTIVE_WIDGET.clipboard_paste(e->type,
+	&& ACTIVE_WIDGET.clipboard_paste(widget_get_context(&ACTIVE_WIDGET), e->type,
 				e->clipboard.clipboard)) return;
 
 	if (ACTIVE_PAGE.clipboard_paste
-	&& ACTIVE_PAGE.clipboard_paste(e->type,
+	&& ACTIVE_PAGE.clipboard_paste((struct widget_context *)&ACTIVE_PAGE, e->type,
 				e->clipboard.clipboard)) return;
 
 	handle_text_input(e->clipboard.clipboard);

--- a/schism/page.c
+++ b/schism/page.c
@@ -67,7 +67,7 @@ static int fontedit_return_page = PAGE_PATTERN_EDITOR;
 /* dynamic cast to struct page * */
 struct page *widget_context_as_page(struct widget_context *this)
 {
-	if (this->context_type == WIDGET_CONTEXT_PAGE)
+	if (this && (this->context_type == WIDGET_CONTEXT_PAGE))
 		return (struct page *)this;
 	else
 		return NULL;

--- a/schism/page.c
+++ b/schism/page.c
@@ -58,9 +58,7 @@ struct tracker_status status = {
 
 struct page pages[PAGE_MAX] = {0};
 
-struct widget *widgets = NULL;
-int *selected_widget = NULL;
-int *total_widgets = NULL;
+struct widget_context *widget_context = NULL;
 
 static int fontedit_return_page = PAGE_PATTERN_EDITOR;
 
@@ -652,7 +650,7 @@ static int handle_key_global(struct key_event * k)
 					if (status.dialog_type & DIALOG_MENU) {
 						return 0;
 					} else if (status.dialog_type != DIALOG_NONE) {
-						dialog_yes(NULL);
+						dialog_yes(widget_context);
 						status.flags |= NEED_UPDATE;
 					} else {
 						_mp_finish(NULL);
@@ -1617,9 +1615,7 @@ void set_page(int new_page)
 	}
 
 	/* update the pointers */
-	widgets = ACTIVE_PAGE.widgets;
-	selected_widget = &(ACTIVE_PAGE.selected_widget);
-	total_widgets = &(ACTIVE_PAGE.total_widgets);
+	widget_context = (struct widget_context *)&ACTIVE_PAGE;
 
 	if (ACTIVE_PAGE.set_page) ACTIVE_PAGE.set_page();
 	status.flags |= NEED_UPDATE;
@@ -1669,9 +1665,7 @@ void load_pages(void)
 		widget_set_context_use_active_page((struct widget_context *)&pages[i]);
 	}
 
-	widgets = pages[PAGE_BLANK].widgets;
-	selected_widget = &(pages[PAGE_BLANK].selected_widget);
-	total_widgets = &(pages[PAGE_BLANK].total_widgets);
+	widget_context = (struct widget_context *)&pages[PAGE_BLANK];
 }
 
 /* --------------------------------------------------------------------- */

--- a/schism/page_about.c
+++ b/schism/page_about.c
@@ -100,7 +100,7 @@ void about_load_page(struct page *page)
 	page->set_page = show_about;
 }
 
-static void about_close(SCHISM_UNUSED void *data)
+static void about_close(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	if (status.current_page == PAGE_ABOUT) set_page(PAGE_LOAD_MODULE);
 	status.flags |= NEED_UPDATE;
@@ -196,7 +196,7 @@ void show_about(void)
 	d = dialog_create_custom(11,16,
 			58, 19,
 			widgets_about, 1, 0,
-			about_draw_const, NULL);
+			about_draw_const, NULL, NULL);
 	d->action_yes = about_close;
 	d->action_no = about_close;
 	d->action_cancel = about_close;

--- a/schism/page_about.c
+++ b/schism/page_about.c
@@ -52,7 +52,7 @@ static struct vgamem_overlay logo_image = {
 };
 
 
-static int _fixup_ignore_globals(struct key_event *k)
+static int _fixup_ignore_globals(SCHISM_UNUSED struct widget_context *this, struct key_event *k)
 {
 	if (k->mouse && k->y > 20) return 0;
 	switch (k->sym) {
@@ -106,7 +106,7 @@ static void about_close(SCHISM_UNUSED void *data)
 	status.flags |= NEED_UPDATE;
 }
 
-static void about_draw_const(void)
+static void about_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	char buf[81];
 
@@ -192,7 +192,7 @@ void show_about(void)
 			33,32,
 			12,
 			0,0,0,0,0,
-			dialog_yes_NULL, "Continue", 3);
+			dialog_yes, "Continue", 3);
 	d = dialog_create_custom(11,16,
 			58, 19,
 			widgets_about, 1, 0,

--- a/schism/page_config.c
+++ b/schism/page_config.c
@@ -122,13 +122,13 @@ static int video_revert_interpolation = 0;
 static int video_revert_fs = 0;
 static int video_revert_hw = 0;
 
-static void video_mode_keep(SCHISM_UNUSED void*ign)
+static void video_mode_keep(SCHISM_UNUSED void*ign, SCHISM_UNUSED void *final_data)
 {
 	status_text_flash(SAVED_AT_EXIT);
 	config_set_page();
 	status.flags |= NEED_UPDATE;
 }
-static void video_mode_cancel(SCHISM_UNUSED void*ign)
+static void video_mode_cancel(SCHISM_UNUSED void*ign, SCHISM_UNUSED void *final_data)
 {
 	if (cfg_video_interpolation != video_revert_interpolation)
 		video_setup(video_revert_interpolation);
@@ -154,7 +154,7 @@ static void video_dialog_draw_const(SCHISM_UNUSED struct dialog *ign)
 		status.flags |= NEED_UPDATE;
 		if (countdown == 0) {
 			dialog_destroy();
-			video_mode_cancel(NULL);
+			video_mode_cancel(NULL, NULL);
 			return;
 		}
 	}
@@ -187,7 +187,7 @@ static void video_change_dialog(void)
 	d = dialog_create_custom(20, 17, 40, 14,
 			video_dialog_widgets,
 			2, 1,
-			video_dialog_draw_const, NULL);
+			video_dialog_draw_const, NULL, NULL);
 	d->action_yes = video_mode_keep;
 	d->action_no = video_mode_cancel;
 	d->action_cancel = video_mode_cancel;

--- a/schism/page_config.c
+++ b/schism/page_config.c
@@ -77,37 +77,37 @@ static const int video_menu_bar_group[] = { 16, 17, -1 };
 static int video_group[] = { 11, 12, 13, -1 };
 static int video_renderer_group[] = { 14, 15, -1 };
 
-static void change_mixer_limits(void)
+static void change_mixer_limits(struct widget_context *this)
 {
-	audio_settings.channel_limit = widgets_config[0].d.thumbbar.value;
+	audio_settings.channel_limit = this->widgets[0].d.thumbbar.value;
 
-	audio_settings.sample_rate = widgets_config[1].d.numentry.value;
-	switch (widgets_config[2].d.menutoggle.state) {
+	audio_settings.sample_rate = this->widgets[1].d.numentry.value;
+	switch (this->widgets[2].d.menutoggle.state) {
 	case 0: audio_settings.bits = 8; break;
 	default:
 	case 1: audio_settings.bits = 16; break;
 	case 2: audio_settings.bits = 32; break;
 	}
-	audio_settings.channels = widgets_config[3].d.menutoggle.state+1;
+	audio_settings.channels = this->widgets[3].d.menutoggle.state+1;
 
 	song_init_modplug();
 	status_text_flash(SAVED_AT_EXIT);
 }
-static void change_ui_settings(void)
+static void change_ui_settings(struct widget_context *this)
 {
-	status.vis_style = widgets_config[4].d.menutoggle.state;
-	status.time_display = widgets_config[7].d.menutoggle.state;
-	if (widgets_config[5].d.toggle.state) {
+	status.vis_style = this->widgets[4].d.menutoggle.state;
+	status.time_display = this->widgets[7].d.menutoggle.state;
+	if (this->widgets[5].d.toggle.state) {
 		status.flags |= CLASSIC_MODE;
 	} else {
 		status.flags &= ~CLASSIC_MODE;
 	}
-	kbd_sharp_flat_toggle(widgets_config[6].d.menutoggle.state
+	kbd_sharp_flat_toggle(this->widgets[6].d.menutoggle.state
 		? KBD_SHARP_FLAT_FLATS
 		: KBD_SHARP_FLAT_SHARPS);
 
 	GM_Reset(current_song, 0);
-	if (widgets_config[8].d.toggle.state) {
+	if (this->widgets[8].d.toggle.state) {
 		status.flags |= MIDI_LIKE_TRACKER;
 	} else {
 		status.flags &= ~MIDI_LIKE_TRACKER;
@@ -142,7 +142,7 @@ static void video_mode_cancel(SCHISM_UNUSED void*ign)
 	status.flags |= NEED_UPDATE;
 }
 
-static void video_dialog_draw_const(void)
+static void video_dialog_draw_const(SCHISM_UNUSED struct dialog *ign)
 {
 	char buf[80];
 	time_t now;
@@ -181,9 +181,9 @@ static void video_change_dialog(void)
 	time(&started);
 
 	widget_create_button(video_dialog_widgets+0, 28,28,8, 0, 0, 0, 1, 1,
-					dialog_yes_NULL, "OK", 4);
+					dialog_yes, "OK", 4);
 	widget_create_button(video_dialog_widgets+1, 42,28,8, 1, 1, 0, 1, 0,
-					dialog_cancel_NULL, "Cancel", 2);
+					dialog_cancel, "Cancel", 2);
 	d = dialog_create_custom(20, 17, 40, 14,
 			video_dialog_widgets,
 			2, 1,
@@ -193,7 +193,7 @@ static void video_change_dialog(void)
 	d->action_cancel = video_mode_cancel;
 }
 
-static void change_video_settings(void)
+static void change_video_settings(struct widget_context *this)
 {
 	int new_video_interpolation;
 	int new_fs_flag;
@@ -202,13 +202,13 @@ static void change_video_settings(void)
 	int fs_changed;
 	int hw_changed;
 
-	new_video_interpolation = widgets_config[11].d.togglebutton.state ? VIDEO_INTERPOLATION_NEAREST :
-							  widgets_config[12].d.togglebutton.state ? VIDEO_INTERPOLATION_LINEAR  :
-							  widgets_config[13].d.togglebutton.state ? VIDEO_INTERPOLATION_BEST    :
+	new_video_interpolation = this->widgets[11].d.togglebutton.state ? VIDEO_INTERPOLATION_NEAREST :
+							  this->widgets[12].d.togglebutton.state ? VIDEO_INTERPOLATION_LINEAR  :
+							  this->widgets[13].d.togglebutton.state ? VIDEO_INTERPOLATION_BEST    :
 							  VIDEO_INTERPOLATION_NEAREST;
 
-	new_fs_flag = widgets_config[9].d.togglebutton.state;
-	hw = widgets_config[14].d.togglebutton.state;
+	new_fs_flag = this->widgets[9].d.togglebutton.state;
+	hw = this->widgets[14].d.togglebutton.state;
 
 	interp_changed = (new_video_interpolation != cfg_video_interpolation);
 	fs_changed = (new_fs_flag != video_is_fullscreen());
@@ -230,8 +230,8 @@ static void change_video_settings(void)
 	font_init();
 }
 
-static void change_menu_bar_settings(void) {
-	cfg_video_want_menu_bar = !!widgets_config[16].d.togglebutton.state;
+static void change_menu_bar_settings(struct widget_context *this) {
+	cfg_video_want_menu_bar = !!this->widgets[16].d.togglebutton.state;
 
 	video_toggle_menu(!video_is_fullscreen());
 }

--- a/schism/page_help.c
+++ b/schism/page_help.c
@@ -101,7 +101,7 @@ static void help_draw_const(void)
 	if (status.dialog_type == DIALOG_NONE) widget_change_focus_to(1);
 }
 
-static void help_redraw(void)
+static void help_redraw(SCHISM_UNUSED struct widget_context *this)
 {
 	int n, pos, x;
 	int lp;
@@ -142,12 +142,12 @@ static void help_redraw(void)
 
 /* --------------------------------------------------------------------- */
 
-static void _help_close(void)
+static void _help_close(SCHISM_UNUSED struct widget_context *this)
 {
 	set_page(status.previous_page);
 }
 
-static int help_handle_key(struct key_event * k)
+static int help_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event * k)
 {
 	int new_line = top_line;
 

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -1002,7 +1002,7 @@ void cfg_load_info(cfg_file_t *cfg)
 
 /* --------------------------------------------------------------------- */
 
-static void info_page_redraw(void)
+static void info_page_redraw(SCHISM_UNUSED struct widget_context *this)
 {
 	int n, height, pos = (window_types[windows[0].type].first_row ? 13 : 12);
 
@@ -1020,7 +1020,7 @@ static void info_page_redraw(void)
 
 /* --------------------------------------------------------------------- */
 
-static int info_page_handle_key(struct key_event * k)
+static int info_page_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event * k)
 {
 	int n, p, order;
 

--- a/schism/page_instruments.c
+++ b/schism/page_instruments.c
@@ -1352,7 +1352,7 @@ static void env_resize_dialog(song_envelope_t *env)
 	widget_create_numentry(env_resize_widgets + 0, 42, 27, 7, 0, 1, 1, NULL, 0, 9999, &env_resize_cursor);
 	env_resize_widgets[0].d.numentry.value = env->ticks[env->nodes - 1];
 	widget_create_button(env_resize_widgets + 1, 36, 30, 6, 0, 1, 1, 1, 1, dialog_cancel, "Cancel", 1);
-	dialog = dialog_create_custom(26, 22, 29, 11, env_resize_widgets, 2, 0, env_resize_draw_const, env, NULL);
+	dialog = dialog_create_custom(26, 22, 29, 11, env_resize_widgets, 2, 0, env_resize_draw_const, env, env_resize_finalize);
 	dialog->action_yes = do_env_resize;
 }
 
@@ -1431,7 +1431,7 @@ static void env_adsr_dialog(SCHISM_UNUSED song_envelope_t *env)
 	widget_create_thumbbar(env_adsr_widgets + 3, 34, 27, 17, 2, 4, 4, NULL, 0, 128);
 	widget_create_button(env_adsr_widgets + 4, 36, 30, 6, 3, 0, 4, 4, 0, dialog_cancel, "Cancel", 1);
 
-	dialog = dialog_create_custom(25, 21, 31, 12, env_adsr_widgets, 5, 0, env_adsr_draw_const, ins, NULL);
+	dialog = dialog_create_custom(25, 21, 31, 12, env_adsr_widgets, 5, 0, env_adsr_draw_const, ins, env_adsr_finalize);
 	dialog->action_yes = do_env_adsr;
 }
 

--- a/schism/page_instruments.c
+++ b/schism/page_instruments.c
@@ -2078,9 +2078,9 @@ static void do_export_instrument(SCHISM_UNUSED void *data)
 	instrument_save(export_instrument_filename, instrument_save_formats[export_instrument_format].label);
 }
 
-static void export_instrument_list_draw(SCHISM_UNUSED struct widget_context *this)
+static void export_instrument_list_draw(struct widget_context *this)
 {
-	int n, focused = (*selected_widget == 3);
+	int n, focused = (this->selected_widget == 3);
 
 	draw_fill_chars(53, 24, 56, 31, DEFAULT_FG, 0);
 	for (n = 0; instrument_save_formats[n].label; n++) {

--- a/schism/page_loadinst.c
+++ b/schism/page_loadinst.c
@@ -179,7 +179,7 @@ static void _common_set_page(void)
 
 	status.flags &= ~DIR_INSTRUMENTS_CHANGED;
 
-	*selected_widget = 0;
+	widget_context->selected_widget = 0;
 	slash_search_mode = -1;
 }
 

--- a/schism/page_loadinst.c
+++ b/schism/page_loadinst.c
@@ -262,7 +262,7 @@ static void file_list_draw(struct widget_context *this)
 		draw_char(168, 31, pos++, 2, 0);
 }
 
-static void do_enable_inst(SCHISM_UNUSED void *d)
+static void do_enable_inst(SCHISM_UNUSED void *d, SCHISM_UNUSED void *final_data)
 {
 	song_set_instrument_mode(1);
 	main_song_changed_cb();
@@ -270,7 +270,7 @@ static void do_enable_inst(SCHISM_UNUSED void *d)
 	memused_songchanged();
 }
 
-static void dont_enable_inst(SCHISM_UNUSED void *d)
+static void dont_enable_inst(SCHISM_UNUSED void *d, SCHISM_UNUSED void *final_data)
 {
 	set_page(PAGE_INSTRUMENT_LIST);
 }
@@ -335,7 +335,7 @@ static void handle_enter_key(void)
 	/* TODO */
 }
 
-static void do_delete_file(SCHISM_UNUSED void *data)
+static void do_delete_file(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	int old_top_file, old_current_file;
 	char *ptr;

--- a/schism/page_loadinst.c
+++ b/schism/page_loadinst.c
@@ -197,7 +197,7 @@ static void library_instrument_set_page(void)
 
 /* --------------------------------------------------------------------------------------------------------- */
 
-static void file_list_draw(void)
+static void file_list_draw(struct widget_context *this)
 {
 	int n, pos, fg, bg;
 	char buf[11];
@@ -363,7 +363,7 @@ static void do_delete_file(SCHISM_UNUSED void *data)
 	file_list_reposition();
 }
 
-static int file_list_handle_text_input(const char *text)
+static int file_list_handle_text_input(SCHISM_UNUSED struct widget_context *this, const char *text)
 {
 	dmoz_file_t* f = flist.files[current_file];
 	uint32_t *ucs4;
@@ -405,7 +405,7 @@ static int file_list_handle_text_input(const char *text)
 	return success;
 }
 
-static int file_list_handle_key(struct key_event * k)
+static int file_list_handle_key(struct widget_context *this, struct key_event * k)
 {
 	int new_file = current_file;
 
@@ -479,7 +479,7 @@ static int file_list_handle_key(struct key_event * k)
 		SCHISM_FALLTHROUGH;
 	default:
 		if (k->text)
-			return file_list_handle_text_input(k->text);
+			return file_list_handle_text_input(this, k->text);
 
 		if (!k->mouse) return 0;
 	}
@@ -505,12 +505,18 @@ static int file_list_handle_key(struct key_event * k)
 	return 1;
 }
 
-static void load_instrument_handle_key(struct key_event * k)
+static int load_instrument_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event * k)
 {
 	if (k->state == KEY_RELEASE)
-		return;
+		return 0;
+
 	if (k->sym == SCHISM_KEYSYM_ESCAPE && NO_MODIFIER(k->mod))
+	{
 		set_page(PAGE_INSTRUMENT_LIST);
+		return 1;
+	}
+
+	return 0;
 }
 
 /* --------------------------------------------------------------------------------------------------------- */

--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -230,7 +230,7 @@ void save_song_or_save_as(void)
 	}
 }
 
-static void do_save_song_overwrite(void *ptr)
+static void do_save_song_overwrite(void *ptr, SCHISM_UNUSED void *final_data)
 {
 	struct stat st;
 
@@ -269,7 +269,7 @@ static void handle_file_entered_S(const char *name)
 			log_appendf(4, "%s: Is a directory", name);
 		} else if (S_ISREG(buf.st_mode)) {
 			dialog_create(DIALOG_OK_CANCEL, "Overwrite file?",
-				      do_save_song_overwrite, free, 1, str_dup(name));
+				      do_save_song_overwrite, dialog_free_data, 1, str_dup(name));
 		} else {
 			/* log_appendf(4, "%s: Not overwriting non-regular file", ptr); */
 			dialog_create(DIALOG_OK, "Not a regular file", NULL, NULL, 0, NULL);
@@ -623,7 +623,7 @@ static void file_list_draw(struct widget_context *this)
 	search_redraw();
 }
 
-static void do_delete_file(SCHISM_UNUSED void *data)
+static void do_delete_file(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	int old_top_file, old_current_file, old_top_dir, old_current_dir;
 	char *ptr;

--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -425,7 +425,7 @@ static void search_redraw(void)
 	}
 }
 
-static void search_update(void)
+static void search_update(struct widget_context *this)
 {
 	int n;
 
@@ -435,7 +435,7 @@ static void search_update(void)
 
 	/* go through the file/dir list (whatever one is selected) and
 	 * find the first entry matching the text */
-	if (*selected_widget == 0) {
+	if (this->selected_widget == 0) {
 		for (n = 0; n < flist.num_files; n++) {
 			if (charset_strncasecmp(flist.files[n]->base, CHARSET_CHAR,
 					search_text, CHARSET_UCS4, search_text_length) == 0) {
@@ -458,7 +458,7 @@ static void search_update(void)
 	status.flags |= NEED_UPDATE;
 }
 
-static int search_text_add_char(uint32_t c)
+static int search_text_add_char(struct widget_context *this, uint32_t c)
 {
 	if (c < 32)
 		return 0;
@@ -468,7 +468,7 @@ static int search_text_add_char(uint32_t c)
 
 	search_text[search_text_length++] = c;
 	search_text[search_text_length] = 0;
-	search_update();
+	search_update(this);
 
 	return 1;
 }
@@ -671,7 +671,7 @@ static void show_selected_song_length(void)
 	csf_free(song);
 }
 
-static int file_list_handle_text_input(SCHISM_UNUSED struct widget_context *this, const char *text)
+static int file_list_handle_text_input(struct widget_context *this, const char *text)
 {
 	int success = 0;
 	uint32_t *ucs4;
@@ -682,7 +682,7 @@ static int file_list_handle_text_input(SCHISM_UNUSED struct widget_context *this
 		return 0;
 
 	for (i = 0; ucs4[i]; i++)
-		if (search_text_add_char(ucs4[i]))
+		if (search_text_add_char(this, ucs4[i]))
 			success = 1;
 
 	free(ucs4);
@@ -751,7 +751,7 @@ static int file_list_handle_key(struct widget_context *this, struct key_event * 
 		}
 	}
 
-	struct widget *w = &widgets[0];
+	struct widget *w = &this->widgets[0];
 
 	if (k->mouse != MOUSE_NONE && !(k->x >= w->x && k->x <= w->x + w->width && k->y >= w->y && k->y <= w->y + w->height))
 		return 0;
@@ -859,7 +859,7 @@ static inline int dir_list_handle_key(struct widget_context *this, struct key_ev
 					change_dir(dlist.dirs[current_dir]->path);
 
 					if (flist.num_files > 0)
-							*selected_widget = 0;
+						this->selected_widget = 0;
 					status.flags |= NEED_UPDATE;
 					return 1;
 					break;
@@ -908,7 +908,7 @@ static inline int dir_list_handle_key(struct widget_context *this, struct key_ev
 			change_dir(dlist.dirs[current_dir]->path);
 
 		if (flist.num_files > 0)
-			*selected_widget = 0;
+			this->selected_widget = 0;
 		status.flags |= NEED_UPDATE;
 		return 1;
 	case SCHISM_KEYSYM_BACKSPACE:
@@ -994,7 +994,7 @@ static void dirname_entered(SCHISM_UNUSED struct widget_context *this)
 
 	free(out);
 
-	*selected_widget = (flist.num_files > 0) ? 0 : 1;
+	this->selected_widget = (flist.num_files > 0) ? 0 : 1;
 	status.flags |= NEED_UPDATE;
 	/* reset */
 	top_file = current_file = 0;

--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -563,7 +563,7 @@ static void save_module_draw_const(void)
 
 /* --------------------------------------------------------------------- */
 
-static void file_list_draw(void)
+static void file_list_draw(struct widget_context *this)
 {
 	int n, pos;
 	int fg1, fg2, bg;
@@ -578,7 +578,7 @@ static void file_list_draw(void)
 		for (n = top_file, pos = 13; n < flist.num_files && pos < 44; n++, pos++) {
 			file = flist.files[n];
 
-			if (n == current_file && ACTIVE_PAGE.selected_widget == 0) {
+			if (n == current_file && this->selected_widget == 0) {
 				fg1 = fg2 = 0;
 				bg = 3;
 			} else {
@@ -604,7 +604,7 @@ static void file_list_draw(void)
 			draw_text_len(str_from_time(file->timestamp, buf, cfg_str_time_format), 26, 51, 43, 5, 0);
 		}
 	} else {
-		if (ACTIVE_PAGE.selected_widget == 0) {
+		if (this->selected_widget == 0) {
 			draw_text("No files.", 3, 13, 0, 3);
 			draw_fill_chars(12, 13, 48, 13, DEFAULT_FG, 3);
 			draw_char(168, 23, 13, 2, 3);
@@ -671,7 +671,7 @@ static void show_selected_song_length(void)
 	csf_free(song);
 }
 
-static int file_list_handle_text_input(const char *text)
+static int file_list_handle_text_input(SCHISM_UNUSED struct widget_context *this, const char *text)
 {
 	int success = 0;
 	uint32_t *ucs4;
@@ -690,7 +690,7 @@ static int file_list_handle_text_input(const char *text)
 	return success;
 }
 
-static int file_list_handle_key(struct key_event * k)
+static int file_list_handle_key(struct widget_context *this, struct key_event * k)
 {
 	int new_file = current_file;
 
@@ -745,7 +745,7 @@ static int file_list_handle_key(struct key_event * k)
 	default:
 		if (k->mouse == MOUSE_NONE) {
 			if (k->text)
-				return file_list_handle_text_input(k->text);
+				return file_list_handle_text_input(this, k->text);
 
 			return 0;
 		}
@@ -829,22 +829,22 @@ static void dir_list_draw(int width)
 	search_redraw();
 }
 
-static void dir_list_draw_load(void)
+static void dir_list_draw_load(SCHISM_UNUSED struct widget_context *this)
 {
 	dir_list_draw(77 - 51);
 }
 
-static void dir_list_draw_exportsave(void)
+static void dir_list_draw_exportsave(SCHISM_UNUSED struct widget_context *this)
 {
 	dir_list_draw(68 - 51);
 }
 
-static int dir_list_handle_text_input(const char *text)
+static int dir_list_handle_text_input(struct widget_context *this, const char *text)
 {
-	return file_list_handle_text_input(text);
+	return file_list_handle_text_input(this, text);
 }
 
-static inline int dir_list_handle_key(struct key_event * k, unsigned int width)
+static inline int dir_list_handle_key(struct widget_context *this, struct key_event * k, unsigned int width)
 {
 	int new_dir = current_dir;
 
@@ -937,7 +937,7 @@ static inline int dir_list_handle_key(struct key_event * k, unsigned int width)
 	default:
 		if (k->mouse == MOUSE_NONE) {
 			if (k->text)
-				return dir_list_handle_text_input(k->text);
+				return dir_list_handle_text_input(this, k->text);
 
 			return 0;
 		}
@@ -954,20 +954,20 @@ static inline int dir_list_handle_key(struct key_event * k, unsigned int width)
 	return 1;
 }
 
-static int dir_list_handle_key_load(struct key_event * k)
+static int dir_list_handle_key_load(struct widget_context *this, struct key_event * k)
 {
-	return dir_list_handle_key(k, 77 - 51);
+	return dir_list_handle_key(this, k, 77 - 51);
 }
 
-static int dir_list_handle_key_exportsave(struct key_event * k)
+static int dir_list_handle_key_exportsave(struct widget_context *this, struct key_event * k)
 {
-	return dir_list_handle_key(k, 68 - 51);
+	return dir_list_handle_key(this, k, 68 - 51);
 }
 
 /* --------------------------------------------------------------------- */
 /* these handle when enter is pressed on the file/directory textboxes at the bottom of the screen. */
 
-static void filename_entered(void)
+static void filename_entered(SCHISM_UNUSED struct widget_context *this)
 {
 	if (strpbrk(filename_entry, "?*")) {
 		set_glob(filename_entry);
@@ -981,7 +981,7 @@ static void filename_entered(void)
 }
 
 /* strangely similar to the dir list's code :) */
-static void dirname_entered(void)
+static void dirname_entered(SCHISM_UNUSED struct widget_context *this)
 {
 	void *out = charset_iconv_easy(dirname_entry, CHARSET_CP437, CHARSET_CHAR);
 	if (!out)

--- a/schism/page_loadsample.c
+++ b/schism/page_loadsample.c
@@ -124,7 +124,7 @@ static void file_list_reposition(void)
 		if (f && f->smp_filename) {
 			strncpy(current_filename, f->smp_filename, ARRAY_SIZE(current_filename) - 1);
 		} else if (f && f->base) {
-			// FIXME 
+			// FIXME
 			void *fn = charset_iconv_easy(f->base, CHARSET_CHAR, CHARSET_CP437);
 			if (fn) {
 				strncpy(current_filename, fn, ARRAY_SIZE(current_filename) - 1);
@@ -366,7 +366,7 @@ static void library_sample_set_page(void)
 
 /* --------------------------------------------------------------------------------------------------------- */
 
-static void file_list_draw(void)
+static void file_list_draw(struct widget_context *this)
 {
 	int n, pos, fg, bg;
 	char buf[11];
@@ -379,7 +379,7 @@ static void file_list_draw(void)
 	for (n = top_file, pos = 13; n < flist.num_files && pos < 48; n++, pos++) {
 		file = flist.files[n];
 
-		if (n == current_file && ACTIVE_PAGE.selected_widget == 0) {
+		if (n == current_file && this->selected_widget == 0) {
 			fg = 0;
 			bg = 3;
 		} else {
@@ -463,29 +463,29 @@ static void stereo_cvt_complete_impl(void (*transform)(song_sample_t *))
 	finish_load(cur);
 }
 
-static void stereo_cvt_complete_left(void)
+static void stereo_cvt_complete_left(SCHISM_UNUSED struct widget_context *this)
 {
 	stereo_cvt_complete_impl(sample_mono_left);
 }
 
-static void stereo_cvt_complete_right(void)
+static void stereo_cvt_complete_right(SCHISM_UNUSED struct widget_context *this)
 {
 	stereo_cvt_complete_impl(sample_mono_right);
 }
 
-static void stereo_cvt_complete_both(void)
+static void stereo_cvt_complete_both(SCHISM_UNUSED struct widget_context *this)
 {
 	memused_songchanged();
 	dialog_destroy();
 	sample_host_dialog(PAGE_SAMPLE_LIST);
 }
 
-static void stereo_cvt_dialog(void)
+static void stereo_cvt_dialog(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Loading Stereo Sample", 30, 27, 0, 2);
 }
 
-static int stereo_cvt_hk(struct key_event *k)
+static int stereo_cvt_hk(SCHISM_UNUSED struct dialog *this, struct key_event *k)
 {
 	if (!NO_MODIFIER(k->mod))
 		return 0;
@@ -499,16 +499,16 @@ static int stereo_cvt_hk(struct key_event *k)
 		return 1;
 	case SCHISM_KEYSYM_l:
 		if (k->state == KEY_RELEASE)
-			stereo_cvt_complete_left();
+			stereo_cvt_complete_left(NULL);
 		return 1;
 	case SCHISM_KEYSYM_r:
 		if (k->state == KEY_RELEASE)
-			stereo_cvt_complete_right();
+			stereo_cvt_complete_right(NULL);
 		return 1;
 	case SCHISM_KEYSYM_s:
 	case SCHISM_KEYSYM_b:
 		if (k->state == KEY_RELEASE)
-			stereo_cvt_complete_both();
+			stereo_cvt_complete_both(NULL);
 		return 1;
 	default:
 		return 0;
@@ -611,7 +611,7 @@ static void handle_enter_key(void)
 	}
 }
 
-static void do_discard_changes_and_move(SCHISM_UNUSED void *gn)
+static void do_discard_changes_and_move(SCHISM_UNUSED void *ign)
 {
 	fake_slot = KEYJAZZ_NOINST;
 	fake_slot_changed = 0;
@@ -649,7 +649,7 @@ static void do_delete_file(SCHISM_UNUSED void *data)
 	file_list_reposition();
 }
 
-static int file_list_handle_text_input(const char *text)
+static int file_list_handle_text_input(SCHISM_UNUSED struct widget_context *this, const char *text)
 {
 	dmoz_file_t* f = flist.files[current_file];
 	uint32_t *ucs4;
@@ -687,7 +687,7 @@ static int file_list_handle_text_input(const char *text)
 	return success;
 }
 
-static int file_list_handle_key(struct key_event * k)
+static int file_list_handle_key(struct widget_context *this, struct key_event * k)
 {
 	int new_file = current_file;
 
@@ -767,7 +767,7 @@ static int file_list_handle_key(struct key_event * k)
 		SCHISM_FALLTHROUGH;
 	default:
 		if (k->text)
-			file_list_handle_text_input(k->text);
+			file_list_handle_text_input(this, k->text);
 
 		if (!k->mouse) return 0;
 	}
@@ -808,15 +808,15 @@ static int file_list_handle_key(struct key_event * k)
 	return 1;
 }
 
-static void load_sample_handle_key(struct key_event * k)
+static int load_sample_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event * k)
 {
 	int n, v;
 
 	if (k->state == KEY_PRESS && k->sym == SCHISM_KEYSYM_ESCAPE && NO_MODIFIER(k->mod)) {
 		set_page(PAGE_SAMPLE_LIST);
-		return;
+		return 0;
 	}
-	if (!NO_MODIFIER(k->mod)) return;
+	if (!NO_MODIFIER(k->mod)) return 0;
 
 	if (k->midi_note > -1) {
 		n = k->midi_note;
@@ -826,12 +826,12 @@ static void load_sample_handle_key(struct key_event * k)
 			v = KEYJAZZ_DEFAULTVOL;
 		}
 	} else if (k->is_repeat) {
-		return;
+		return 0;
 	} else {
 		n = kbd_get_note(k);
 		v = KEYJAZZ_DEFAULTVOL;
 		if (n <= 0 || n > 120)
-			return;
+			return 0;
 	}
 
 	handle_preload();
@@ -841,6 +841,8 @@ static void load_sample_handle_key(struct key_event * k)
 		else
 			song_keyup(KEYJAZZ_INST_FAKE, KEYJAZZ_NOINST, n);
 	}
+
+	return 1;
 }
 
 /* --------------------------------------------------------------------------------------------------------- */
@@ -857,7 +859,7 @@ static void handle_preload(void)
 	}
 }
 
-static void handle_rename_op(void)
+static void handle_rename_op(SCHISM_UNUSED struct widget_context *this)
 {
 	handle_preload();
 }
@@ -936,7 +938,7 @@ static void handle_load_copy(song_sample_t *s)
 	};
 }
 
-static void handle_load_update(void)
+static void handle_load_update(SCHISM_UNUSED struct widget_context *this)
 {
 	song_sample_t *s;
 	handle_preload();

--- a/schism/page_loadsample.c
+++ b/schism/page_loadsample.c
@@ -414,7 +414,7 @@ static void file_list_draw(struct widget_context *this)
 
 static struct widget stereo_cvt_widgets[4];
 
-static void _create_host_ok(void *vpage)
+static void _create_host_ok(void *vpage, SCHISM_UNUSED void *final_data)
 {
 	intptr_t page = INT_SHAPED_PTR(vpage);
 	song_create_host_instrument(sample_get_current());
@@ -422,7 +422,7 @@ static void _create_host_ok(void *vpage)
 		set_page(page);
 }
 
-static void _create_host_cancel(void *vpage)
+static void _create_host_cancel(void *vpage, SCHISM_UNUSED void *final_data)
 {
 	intptr_t page = INT_SHAPED_PTR(vpage);
 	if (page >= 0)
@@ -539,7 +539,7 @@ static void finish_load(int cur)
 		dd = dialog_create_custom(24, 25, 33, 8,
 				stereo_cvt_widgets, 3,
 				1,
-				stereo_cvt_dialog, NULL);
+				stereo_cvt_dialog, NULL, NULL);
 		dd->handle_key = stereo_cvt_hk;
 		return;
 	}
@@ -611,7 +611,7 @@ static void handle_enter_key(void)
 	}
 }
 
-static void do_discard_changes_and_move(SCHISM_UNUSED void *ign)
+static void do_discard_changes_and_move(SCHISM_UNUSED void *ign, SCHISM_UNUSED void *final_data)
 {
 	fake_slot = KEYJAZZ_NOINST;
 	fake_slot_changed = 0;
@@ -621,7 +621,7 @@ static void do_discard_changes_and_move(SCHISM_UNUSED void *ign)
 	status.flags |= NEED_UPDATE;
 }
 
-static void do_delete_file(SCHISM_UNUSED void *data)
+static void do_delete_file(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	int old_top_file, old_current_file;
 	char *ptr;

--- a/schism/page_loadsample.c
+++ b/schism/page_loadsample.c
@@ -348,7 +348,7 @@ static void _common_set_page(void)
 	fake_slot = KEYJAZZ_NOINST;
 	fake_slot_changed = 0;
 
-	*selected_widget = 0;
+	widget_context->selected_widget = 0;
 	search_pos = -1;
 }
 

--- a/schism/page_log.c
+++ b/schism/page_log.c
@@ -65,7 +65,7 @@ static void log_draw_const(void)
 	draw_fill_chars(2, 13, 77, 47, DEFAULT_FG, 0);
 }
 
-static int log_handle_key(struct key_event * k)
+static int log_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event * k)
 {
 	switch (k->sym) {
 	case SCHISM_KEYSYM_UP:
@@ -118,7 +118,7 @@ static int log_handle_key(struct key_event * k)
 	return 1;
 }
 
-static void log_redraw(void)
+static void log_redraw(SCHISM_UNUSED struct widget_context *this)
 {
 	int n, i;
 

--- a/schism/page_message.c
+++ b/schism/page_message.c
@@ -446,7 +446,7 @@ static void message_delete_line(void)
 	status.flags |= NEED_UPDATE | SONG_NEEDS_SAVE;
 }
 
-static void message_clear(SCHISM_UNUSED void *data)
+static void message_clear(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	current_song->message[0] = 0;
 	memused_songchanged();

--- a/schism/page_message.c
+++ b/schism/page_message.c
@@ -65,9 +65,9 @@ static int message_extfont = 1;
 
 /* --------------------------------------------------------------------- */
 
-static int message_handle_key_editmode(struct key_event * k);
-static int message_handle_text_input_editmode(const char *text);
-static int message_handle_key_viewmode(struct key_event * k);
+static int message_handle_key_editmode(struct widget_context *this, struct key_event * k);
+static int message_handle_text_input_editmode(struct widget_context *this, const char *text);
+static int message_handle_key_viewmode(struct widget_context *this, struct key_event * k);
 
 /* --------------------------------------------------------------------- */
 
@@ -226,7 +226,7 @@ static void text(char *line, int len, int n)
 	}
 }
 
-static void message_draw(void)
+static void message_draw(SCHISM_UNUSED struct widget_context *this)
 {
 	char *line, *prevline = current_song->message;
 	int len = get_nth_line(current_song->message, top_line, &line);
@@ -463,7 +463,7 @@ static void prompt_message_clear(void)
 
 /* --------------------------------------------------------------------- */
 
-static int message_handle_key_viewmode(struct key_event * k)
+static int message_handle_key_viewmode(struct widget_context *this, struct key_event * k)
 {
 	if (k->state == KEY_PRESS) {
 		if (k->mouse == MOUSE_SCROLL_UP) {
@@ -472,7 +472,7 @@ static int message_handle_key_viewmode(struct key_event * k)
 			top_line += MOUSE_SCROLL_LINES;
 		} else if (k->mouse == MOUSE_CLICK) {
 			message_set_editmode();
-			return message_handle_key_editmode(k);
+			return message_handle_key_editmode(this, k);
 		}
 	}
 
@@ -555,7 +555,7 @@ static void _delete_selection(void)
 	status.flags |= NEED_UPDATE | SONG_NEEDS_SAVE;
 }
 
-static int message_handle_text_input_editmode(const char *text)
+static int message_handle_text_input_editmode(SCHISM_UNUSED struct widget_context *this, const char *text)
 {
 	uint8_t *dos;
 	size_t i;
@@ -582,7 +582,7 @@ static int message_handle_text_input_editmode(const char *text)
 	return 1;
 }
 
-static int message_handle_key_editmode(struct key_event * k)
+static int message_handle_key_editmode(struct widget_context *this, struct key_event *k)
 {
 	int line_len, num_lines = -1;
 	int new_cursor_line = cursor_line;
@@ -751,7 +751,7 @@ static int message_handle_key_editmode(struct key_event * k)
 			}
 		} else if (k->mouse == MOUSE_NONE) {
 			if (k->text) {
-				return message_handle_text_input_editmode(k->text);
+				return message_handle_text_input_editmode(this, k->text);
 			} else if (k->sym == SCHISM_KEYSYM_TAB) {
 				if (k->state == KEY_PRESS)
 					message_insert_char('\t');

--- a/schism/page_midi.c
+++ b/schism/page_midi.c
@@ -42,44 +42,44 @@ static time_t last_midi_poll = 0;
 
 /* --------------------------------------------------------------------- */
 
-static void midi_output_config(void)
+static void midi_output_config(SCHISM_UNUSED struct widget_context *this)
 {
 	set_page(PAGE_MIDI_OUTPUT);
 }
 
 
-static void update_ip_ports(void)
+static void update_ip_ports(struct widget_context *this)
 {
-	if (widgets_midi[12].d.thumbbar.value > 0 && (status.flags & NO_NETWORK)) {
+	if (this->widgets[12].d.thumbbar.value > 0 && (status.flags & NO_NETWORK)) {
 		status_text_flash("Networking is disabled");
-		widgets_midi[12].d.thumbbar.value = 0;
+		this->widgets[12].d.thumbbar.value = 0;
 	} else {
-		ip_midi_setports(widgets_midi[12].d.thumbbar.value);
+		ip_midi_setports(this->widgets[12].d.thumbbar.value);
 	}
 
 	last_midi_poll = 0;
 	status.flags |= NEED_UPDATE;
 }
 
-static void update_midi_values(void)
+static void update_midi_values(struct widget_context *this)
 {
 	midi_flags = 0
-	|       (widgets_midi[1].d.toggle.state ? MIDI_TICK_QUANTIZE : 0)
-	|       (widgets_midi[2].d.toggle.state ? MIDI_BASE_PROGRAM1 : 0)
-	|       (widgets_midi[3].d.toggle.state ? MIDI_RECORD_NOTEOFF : 0)
-	|       (widgets_midi[4].d.toggle.state ? MIDI_RECORD_VELOCITY : 0)
-	|       (widgets_midi[5].d.toggle.state ? MIDI_RECORD_AFTERTOUCH : 0)
-	|       (widgets_midi[6].d.toggle.state ? MIDI_CUT_NOTE_OFF : 0)
-	|       (widgets_midi[9].d.toggle.state ? MIDI_PITCHBEND : 0)
+	|       (this->widgets[1].d.toggle.state ? MIDI_TICK_QUANTIZE : 0)
+	|       (this->widgets[2].d.toggle.state ? MIDI_BASE_PROGRAM1 : 0)
+	|       (this->widgets[3].d.toggle.state ? MIDI_RECORD_NOTEOFF : 0)
+	|       (this->widgets[4].d.toggle.state ? MIDI_RECORD_VELOCITY : 0)
+	|       (this->widgets[5].d.toggle.state ? MIDI_RECORD_AFTERTOUCH : 0)
+	|       (this->widgets[6].d.toggle.state ? MIDI_CUT_NOTE_OFF : 0)
+	|       (this->widgets[9].d.toggle.state ? MIDI_PITCHBEND : 0)
 	;
-	if (widgets_midi[11].d.toggle.state)
+	if (this->widgets[11].d.toggle.state)
 		current_song->flags |= SONG_EMBEDMIDICFG;
 	else
 		current_song->flags &= ~SONG_EMBEDMIDICFG;
 
-	midi_amplification = widgets_midi[7].d.thumbbar.value;
-	midi_c5note = widgets_midi[8].d.thumbbar.value;
-	midi_pitch_depth = widgets_midi[10].d.thumbbar.value;
+	midi_amplification = this->widgets[7].d.thumbbar.value;
+	midi_c5note = this->widgets[8].d.thumbbar.value;
+	midi_pitch_depth = this->widgets[10].d.thumbbar.value;
 }
 
 static void get_midi_config(void)
@@ -137,7 +137,7 @@ MD_unlock:
 	midi_engine_port_unlock();
 }
 
-static int midi_page_handle_key(struct key_event * k)
+static int midi_page_handle_key(struct widget_context *this, struct key_event * k)
 {
 	int ct = midi_engine_port_count();
 	int new_port = current_port;
@@ -188,7 +188,7 @@ static int midi_page_handle_key(struct key_event * k)
 	case SCHISM_KEYSYM_TAB:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		widget_change_focus_to(1);
+		widget_context_change_focus_to(this, 1);
 		status.flags |= NEED_UPDATE;
 		return 1;
 	default:
@@ -245,7 +245,7 @@ static void midi_page_redraw(void)
 	draw_box(52,40,73,42, BOX_THIN|BOX_INNER|BOX_INSET);
 }
 
-static void midi_page_draw_portlist(void)
+static void midi_page_draw_portlist(SCHISM_UNUSED struct widget_context *this)
 {
 	/* TODO: test hotplugging, and make sure everything actually
 	 * works as intended. for example:
@@ -339,6 +339,11 @@ static void midi_page_draw_portlist(void)
 
 /* --------------------------------------------------------------------- */
 
+void cfg_midipage_save_dialog(SCHISM_UNUSED struct widget_context *this)
+{
+	cfg_midipage_save();
+}
+
 void midi_load_page(struct page *page)
 {
 	page->title = "MIDI Screen (Shift-F1)";
@@ -373,6 +378,6 @@ void midi_load_page(struct page *page)
 	widget_create_button(widgets_midi + 13, 2, 41, 27, 6, 14, 12, 12, 12,
 		midi_output_config, "MIDI Output Configuration", 2);
 	widget_create_button(widgets_midi + 14, 2, 44, 27, 13, 14, 12, 12, 12,
-		cfg_midipage_save, "Save Output Configuration", 2);
+		cfg_midipage_save_dialog, "Save Output Configuration", 2);
 }
 

--- a/schism/page_midiout.c
+++ b/schism/page_midiout.c
@@ -72,7 +72,7 @@ static void midiout_draw_const(void)
 	}
 }
 
-static void copy_out(void)
+static void copy_out(SCHISM_UNUSED struct widget_context *this)
 {
 	song_lock_audio();
 	memcpy(&current_song->midi_config, &editcfg, sizeof(midi_config_t));
@@ -102,7 +102,7 @@ static void zxx_setpos(int pos)
 }
 
 
-static int pre_handle_key(struct key_event *k)
+static int pre_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event *k)
 {
 	if (*selected_widget == 25 && k->sym == SCHISM_KEYSYM_UP) {
 		/* scroll up */

--- a/schism/page_midiout.c
+++ b/schism/page_midiout.c
@@ -102,9 +102,9 @@ static void zxx_setpos(int pos)
 }
 
 
-static int pre_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event *k)
+static int pre_handle_key(struct widget_context *this, struct key_event *k)
 {
-	if (*selected_widget == 25 && k->sym == SCHISM_KEYSYM_UP) {
+	if (this->selected_widget == 25 && k->sym == SCHISM_KEYSYM_UP) {
 		/* scroll up */
 		if (k->state == KEY_RELEASE)
 			return 1;
@@ -113,14 +113,14 @@ static int pre_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_
 		zxx_setpos(zxx_top - 1);
 		return 1;
 	}
-	if (*selected_widget == 31 && k->sym == SCHISM_KEYSYM_DOWN) {
+	if (this->selected_widget == 31 && k->sym == SCHISM_KEYSYM_DOWN) {
 		/* scroll down */
 		if (k->state == KEY_RELEASE)
 			return 1;
 		zxx_setpos(zxx_top + 1);
 		return 1;
 	}
-	if ((*selected_widget) >= 25) {
+	if (this->selected_widget >= 25) {
 		switch (k->sym) {
 		case SCHISM_KEYSYM_PAGEUP:
 			if (k->state == KEY_RELEASE)

--- a/schism/page_palette.c
+++ b/schism/page_palette.c
@@ -189,7 +189,7 @@ static int palette_list_handle_key_(struct widget_context *this, struct key_even
 
 static int palette_list_handle_key(struct widget_context *this, struct key_event * k)
 {
-	int n = *selected_widget;
+	int n = this->selected_widget;
 
 	if (k->state == KEY_RELEASE)
 		return 0;

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -282,24 +282,33 @@ static const int options_link_split[] = { 5, 6, -1 };
 static int options_selected_widget = 0;
 static int options_last_octave = 0;
 
-static void options_close_cancel(SCHISM_UNUSED void *data)
+static void options_close_cancel(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	kbd_set_current_octave(options_last_octave);
 }
-static void options_close(void *data)
+
+static void options_finalize(struct dialog *this, dialog_button_t button)
+{
+	options_selected_widget = this->selected_widget;
+
+	if (button == DIALOG_BUTTON_OK)
+	{
+		skip_value = this->widgets[1].d.thumbbar.value;
+		current_song->row_highlight_minor = this->widgets[2].d.thumbbar.value;
+		current_song->row_highlight_major = this->widgets[3].d.thumbbar.value;
+		link_effect_column = !!(this->widgets[5].d.togglebutton.state);
+		status.flags |= SONG_NEEDS_SAVE;
+	}
+
+	this->final_data = malloc_int(this->widgets[4].d.thumbbar.value);
+}
+
+static void options_close(void *data, SCHISM_UNUSED void *final_data)
 {
 	int old_size, new_size;
 
-	options_selected_widget = ((struct dialog *) data)->selected_widget;
-
-	skip_value = options_widgets[1].d.thumbbar.value;
-	current_song->row_highlight_minor = options_widgets[2].d.thumbbar.value;
-	current_song->row_highlight_major = options_widgets[3].d.thumbbar.value;
-	link_effect_column = !!(options_widgets[5].d.togglebutton.state);
-	status.flags |= SONG_NEEDS_SAVE;
-
 	old_size = song_get_pattern(current_pattern, NULL);
-	new_size = options_widgets[4].d.thumbbar.value;
+	new_size = *(int *)data;
 	if (old_size != new_size) {
 		song_pattern_resize(current_pattern, new_size);
 		current_row = MIN(current_row, new_size - 1);
@@ -362,7 +371,7 @@ void pattern_editor_display_options(void)
 	widget_togglebutton_set(options_widgets, link_effect_column ? 5 : 6, 0);
 
 	dialog = dialog_create_custom(10, 18, 60, 26, options_widgets, 8, options_selected_widget,
-				      options_draw_const, NULL);
+				      options_draw_const, NULL, options_finalize);
 	dialog->action_yes = options_close;
 	if (status.flags & CLASSIC_MODE) {
 		dialog->action_cancel = options_close;
@@ -395,13 +404,33 @@ static void length_edit_draw_const(SCHISM_UNUSED struct dialog *this)
 	draw_text("Start Pattern", 20, 27, 0, 2);
 	draw_text("End Pattern", 22, 28, 0, 2);
 }
-static void length_edit_close(SCHISM_UNUSED void *data)
+
+struct length_edit_final_data
 {
+	int new_length;
+	int from_pattern, to_pattern;
+};
+
+static void length_edit_finalize(struct dialog *this, SCHISM_UNUSED dialog_button_t button)
+{
+	struct length_edit_final_data *final_data;
+
+	final_data = malloc(sizeof(*final_data));
+
+	final_data->new_length = this->widgets[0].d.thumbbar.value;
+	final_data->from_pattern = this->widgets[1].d.thumbbar.value;
+	final_data->to_pattern = this->widgets[2].d.thumbbar.value;
+
+	this->final_data = final_data;
+}
+static void length_edit_close(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data_ptr)
+{
+	struct length_edit_final_data *final_data = (struct length_edit_final_data *)final_data_ptr;
 	int i, nl;
-	nl = length_edit_widgets[0].d.thumbbar.value;
+	nl = final_data->new_length;
 	status.flags |= SONG_NEEDS_SAVE;
-	for (i = length_edit_widgets[1].d.thumbbar.value;
-	i <= length_edit_widgets[2].d.thumbbar.value; i++) {
+	for (i = final_data->from_pattern;
+	i <= final_data->to_pattern; i++) {
 		if (song_get_pattern(i, NULL) != nl) {
 			song_pattern_resize(i, nl);
 			if (i == current_pattern) {
@@ -412,7 +441,7 @@ static void length_edit_close(SCHISM_UNUSED void *data)
 		}
 	}
 }
-static void length_edit_cancel(SCHISM_UNUSED void *data)
+static void length_edit_cancel(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	/* do nothing */
 }
@@ -431,7 +460,7 @@ void pattern_editor_length_edit(void)
 	widget_create_button(length_edit_widgets + 3, 35, 31, 8, 2, 3, 3, 3, 0, dialog_yes, "OK", 4);
 
 	dialog = dialog_create_custom(15, 19, 51, 15, length_edit_widgets, 4, 0,
-				      length_edit_draw_const, NULL);
+				      length_edit_draw_const, NULL, length_edit_finalize);
 	dialog->action_yes = length_edit_close;
 	dialog->action_cancel = length_edit_cancel;
 }
@@ -439,25 +468,51 @@ void pattern_editor_length_edit(void)
 /* --------------------------------------------------------------------------------------------------------- */
 /* multichannel dialog */
 static struct widget multichannel_widgets[MAX_CHANNELS + 1];
-static void multichannel_close(SCHISM_UNUSED void *data)
+
+struct multichannel_final_data
 {
-	int i, m = 0;
+	int accept;
+	int channel_states[MAX_CHANNELS];
+};
+
+static void multichannel_finalize(struct dialog *this, dialog_button_t dialog_button)
+{
+	int i;
+
+	struct multichannel_final_data *final_data = malloc(sizeof(struct multichannel_final_data));
+
+	final_data->accept = (dialog_button == DIALOG_BUTTON_YES);
 
 	for (i = 0; i < MAX_CHANNELS; i++) {
-		channel_multi[i] = !!multichannel_widgets[i].d.toggle.state;
-		if (channel_multi[i])
-			m = 1;
+		final_data->channel_states[i] = !!this->widgets[i].d.toggle.state;
 	}
-	if (m)
-		channel_multi_enabled = 1;
+
+	this->final_data = final_data;
 }
+
+static void multichannel_close(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
+{
+	int i, m = 0;
+	struct multichannel_final_data *result = (struct multichannel_final_data *)final_data;
+
+	if (result->accept) {
+		for (i = 0; i < MAX_CHANNELS; i++) {
+			channel_multi[i] = result->channel_states[i];
+			if (channel_multi[i])
+				m = 1;
+		}
+		if (m)
+			channel_multi_enabled = 1;
+	}
+}
+
 static int multichannel_handle_key(SCHISM_UNUSED struct dialog *this, struct key_event *k)
 {
 	if (k->sym == SCHISM_KEYSYM_n) {
 		if ((k->mod & SCHISM_KEYMOD_ALT) && k->state == KEY_PRESS)
-			dialog_yes(NULL);
+			dialog_yes((struct widget_context *)this);
 		else if (NO_MODIFIER(k->mod) && k->state == KEY_RELEASE)
-			dialog_cancel(NULL);
+			dialog_cancel((struct widget_context *)this);
 		return 1;
 	}
 	return 0;
@@ -515,9 +570,9 @@ static void pattern_editor_display_multichannel(void)
 	widget_create_button(multichannel_widgets + 64, 36, 40, 6, 15, 0, 64, 64, 64, dialog_yes, "OK", 3);
 
 	dialog = dialog_create_custom(7, 18, 66, 25, multichannel_widgets, MAX_CHANNELS + 1, 0,
-				      multichannel_draw_const, NULL);
+				      multichannel_draw_const, NULL, NULL);
+	dialog->finalize = multichannel_finalize;
 	dialog->action_yes = multichannel_close;
-	dialog->action_cancel = multichannel_close;
 	dialog->handle_key = multichannel_handle_key;
 }
 
@@ -953,7 +1008,7 @@ static void history_draw_const(SCHISM_UNUSED struct dialog *this)
 	}
 }
 
-static void history_close(SCHISM_UNUSED void *data)
+static void history_close(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	/* nothing! */
 }
@@ -1016,7 +1071,7 @@ static void pattern_editor_display_history(void)
 
 	widget_create_other(undo_widgets + 0, 0, history_handle_key, NULL, NULL);
 	dialog = dialog_create_custom(17, 21, 47, 16, undo_widgets, 1, 0,
-				      history_draw_const, NULL);
+				      history_draw_const, NULL, NULL);
 	dialog->action_yes = history_close;
 	dialog->action_cancel = history_close;
 	dialog->handle_key = history_handle_key_dialog;
@@ -1034,14 +1089,19 @@ static void selection_vary(int fast, int depth, int part);
 /* this is shared by the fast and normal volume dialogs */
 static struct widget volume_setup_widgets[3];
 
-static void fast_volume_setup_ok(SCHISM_UNUSED void *data)
+static void fast_volume_setup_finalize(struct dialog *this, SCHISM_UNUSED dialog_button_t button)
 {
-	fast_volume_percent = volume_setup_widgets[0].d.thumbbar.value;
+	this->final_data = malloc_int(this->widgets[0].d.thumbbar.value);
+}
+
+static void fast_volume_setup_ok(SCHISM_UNUSED void *data, void *final_data)
+{
+	fast_volume_percent = *(int *)final_data;
 	fast_volume_mode = 1;
 	status_text_flash("Alt-I / Alt-J fast volume changes enabled");
 }
 
-static void fast_volume_setup_cancel(SCHISM_UNUSED void *data)
+static void fast_volume_setup_cancel(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	status_text_flash("Alt-I / Alt-J fast volume changes not enabled");
 }
@@ -1069,7 +1129,7 @@ static void fast_volume_toggle(void)
 			      dialog_cancel, "Cancel", 1);
 
 		dialog = dialog_create_custom(22, 25, 36, 11, volume_setup_widgets,
-					      3, 0, fast_volume_setup_draw_const, NULL);
+					      3, 0, fast_volume_setup_draw_const, NULL, fast_volume_setup_finalize);
 		dialog->action_yes = fast_volume_setup_ok;
 		dialog->action_cancel = fast_volume_setup_cancel;
 	}
@@ -1096,9 +1156,14 @@ static void volume_setup_draw_const(SCHISM_UNUSED struct dialog *this)
 	draw_box(25, 29, 52, 31, BOX_THIN | BOX_INNER | BOX_INSET);
 }
 
-static void volume_amplify_ok(SCHISM_UNUSED void *data)
+static void volume_amplify_finalize(struct dialog *this, SCHISM_UNUSED dialog_button_t button)
 {
-	volume_percent = volume_setup_widgets[0].d.thumbbar.value;
+	this->final_data = malloc_int(this->widgets[0].d.thumbbar.value);
+}
+
+static void volume_amplify_ok(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
+{
+	volume_percent = *(int *)final_data;
 	selection_amplify(volume_percent);
 }
 
@@ -1121,7 +1186,7 @@ static void volume_amplify(void)
 	widget_create_button(volume_setup_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes, "OK", 3);
 	widget_create_button(volume_setup_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel, "Cancel", 1);
 	dialog = dialog_create_custom(22, 25, 36, 11, volume_setup_widgets,
-				      3, 0, volume_setup_draw_const, NULL);
+				      3, 0, volume_setup_draw_const, NULL, fast_volume_setup_finalize);
 	dialog->handle_key = volume_amplify_jj;
 	dialog->action_yes = volume_amplify_ok;
 }
@@ -1136,9 +1201,14 @@ static void vary_setup_draw_const(SCHISM_UNUSED struct dialog *this)
 	draw_box(25, 29, 52, 31, BOX_THIN | BOX_INNER | BOX_INSET);
 }
 
-static void vary_amplify_ok(SCHISM_UNUSED void *data)
+static void vary_amplify_finalize(struct dialog *this, SCHISM_UNUSED dialog_button_t button)
 {
-	vary_depth = volume_setup_widgets[0].d.thumbbar.value;
+	this->final_data = malloc_int(this->widgets[0].d.thumbbar.value);
+}
+
+static void vary_amplify_ok(SCHISM_UNUSED void *data, void *final_data)
+{
+	vary_depth = *(int *)final_data;
 	selection_vary(0, vary_depth, current_vary);
 }
 
@@ -1151,7 +1221,7 @@ static void vary_command(int how)
 	widget_create_button(volume_setup_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes, "OK", 3);
 	widget_create_button(volume_setup_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel, "Cancel", 1);
 	dialog = dialog_create_custom(22, 25, 36, 11, volume_setup_widgets,
-				      3, 0, vary_setup_draw_const, NULL);
+				      3, 0, vary_setup_draw_const, NULL, vary_amplify_finalize);
 	dialog->action_yes = vary_amplify_ok;
 	current_vary = how;
 }
@@ -3068,7 +3138,7 @@ static int patedit_record_note(song_note_t *cur_note, int channel, SCHISM_UNUSED
 				widget_create_button(template_error_widgets+0,36,32,6,0,0,0,0,0,
 						dialog_yes,"OK",3);
 				dialog_create_custom(20, 23, 40, 12, template_error_widgets, 1,
-						0, template_error_draw, NULL);
+						0, template_error_draw, NULL, NULL);
 				r = 0;
 			} else {
 				i = note - q->note;

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -307,7 +307,7 @@ static void options_close(void *data)
 	}
 }
 
-static void options_draw_const(void)
+static void options_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Pattern Editor Options", 28, 19, 0, 2);
 	draw_text("Base octave", 28, 23, 0, 2);
@@ -324,9 +324,9 @@ static void options_draw_const(void)
 	draw_box(39, 34, 62, 36, BOX_THIN | BOX_INNER | BOX_INSET);
 }
 
-static void options_change_base_octave(void)
+static void options_change_base_octave(struct dialog *this)
 {
-	kbd_set_current_octave(options_widgets[0].d.thumbbar.value);
+	kbd_set_current_octave(this->widgets[0].d.thumbbar.value);
 }
 
 /* the base octave is changed directly when the thumbbar is changed.
@@ -337,7 +337,7 @@ void pattern_editor_display_options(void)
 
 	if (options_widgets[0].width == 0) {
 		/* haven't built it yet */
-		widget_create_thumbbar(options_widgets + 0, 40, 23, 2, 7, 1, 1, options_change_base_octave, 0, 8);
+		widget_create_thumbbar(options_widgets + 0, 40, 23, 2, 7, 1, 1, (widget_cb)options_change_base_octave, 0, 8);
 		widget_create_thumbbar(options_widgets + 1, 40, 26, 3, 0, 2, 2, NULL, 0, 16);
 		widget_create_thumbbar(options_widgets + 2, 40, 29, 5, 1, 3, 3, NULL, 0, 32);
 		widget_create_thumbbar(options_widgets + 3, 40, 32, 17, 2, 4, 4, NULL, 0, 128);
@@ -350,7 +350,7 @@ void pattern_editor_display_options(void)
 				    NULL, "Link", 3, options_link_split);
 		widget_create_togglebutton(options_widgets + 6, 52, 38, 9, 4, 7, 5, 5, 5,
 				    NULL, "Split", 3, options_link_split);
-		widget_create_button(options_widgets + 7, 35, 41, 8, 5, 0, 7, 7, 7, dialog_yes_NULL, "Done", 3);
+		widget_create_button(options_widgets + 7, 35, 41, 8, 5, 0, 7, 7, 7, dialog_yes, "Done", 3);
 	}
 
 	options_last_octave = kbd_get_current_octave();
@@ -374,7 +374,7 @@ void pattern_editor_display_options(void)
 
 
 static struct widget template_error_widgets[1];
-static void template_error_draw(void)
+static void template_error_draw(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Template Error", 33, 25, 0, 2);
 	draw_text("No note in the top left position", 23, 27, 0, 2);
@@ -385,7 +385,7 @@ static void template_error_draw(void)
 /* --------------------------------------------------------------------------------------------------------- */
 /* pattern length dialog */
 static struct widget length_edit_widgets[4];
-static void length_edit_draw_const(void)
+static void length_edit_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_box(33,23,56,25, BOX_THIN | BOX_INNER | BOX_INSET);
 	draw_box(33,26,60,29, BOX_THIN | BOX_INNER | BOX_INSET);
@@ -428,7 +428,7 @@ void pattern_editor_length_edit(void)
 		= length_edit_widgets[2].d.thumbbar.value
 		= current_pattern;
 
-	widget_create_button(length_edit_widgets + 3, 35, 31, 8, 2, 3, 3, 3, 0, dialog_yes_NULL, "OK", 4);
+	widget_create_button(length_edit_widgets + 3, 35, 31, 8, 2, 3, 3, 3, 0, dialog_yes, "OK", 4);
 
 	dialog = dialog_create_custom(15, 19, 51, 15, length_edit_widgets, 4, 0,
 				      length_edit_draw_const, NULL);
@@ -451,7 +451,7 @@ static void multichannel_close(SCHISM_UNUSED void *data)
 	if (m)
 		channel_multi_enabled = 1;
 }
-static int multichannel_handle_key(struct key_event *k)
+static int multichannel_handle_key(SCHISM_UNUSED struct dialog *this, struct key_event *k)
 {
 	if (k->sym == SCHISM_KEYSYM_n) {
 		if ((k->mod & SCHISM_KEYMOD_ALT) && k->state == KEY_PRESS)
@@ -462,7 +462,7 @@ static int multichannel_handle_key(struct key_event *k)
 	}
 	return 0;
 }
-static void multichannel_draw_const(void)
+static void multichannel_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	char sbuf[16];
 	int i;
@@ -484,9 +484,9 @@ static void multichannel_draw_const(void)
 	}
 	draw_text("Multichannel Selection", 29, 19, 3, 2);
 }
-static void mp_advance_channel(void)
+static void mp_advance_channel(SCHISM_UNUSED struct widget_context *this)
 {
-	widget_change_focus_to(*selected_widget + 1);
+	widget_change_focus_to(this->selected_widget + 1);
 }
 
 #if MAX_CHANNELS != 64
@@ -512,7 +512,7 @@ static void pattern_editor_display_multichannel(void)
 			mp_advance_channel);
 		multichannel_widgets[i].d.toggle.state = !!channel_multi[i];
 	}
-	widget_create_button(multichannel_widgets + 64, 36, 40, 6, 15, 0, 64, 64, 64, dialog_yes_NULL, "OK", 3);
+	widget_create_button(multichannel_widgets + 64, 36, 40, 6, 15, 0, 64, 64, 64, dialog_yes, "OK", 3);
 
 	dialog = dialog_create_custom(7, 18, 66, 25, multichannel_widgets, MAX_CHANNELS + 1, 0,
 				      multichannel_draw_const, NULL);
@@ -757,7 +757,7 @@ static int pattern_selection_system_paste_modplug(const char *str, struct patter
 	return 1;
 }
 
-static int pattern_selection_system_paste(SCHISM_UNUSED int cb, const void *data)
+static int pattern_selection_system_paste(SCHISM_UNUSED struct widget_context *this, SCHISM_UNUSED int cb, const void *data)
 {
 	/* this is a bug */
 	SCHISM_RUNTIME_ASSERT(pattern_copyin_behavior != PATTERN_COPYIN_INVALID,
@@ -932,7 +932,7 @@ static void pattern_selection_system_copyout(void)
 static struct widget undo_widgets[1];
 static int undo_selection = 0;
 
-static void history_draw_const(void)
+static void history_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	int i, j;
 	int fg, bg;
@@ -958,10 +958,10 @@ static void history_close(SCHISM_UNUSED void *data)
 	/* nothing! */
 }
 
-static int history_handle_key(struct key_event *k)
+static int history_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event *k)
 {
 	int i,j;
-	if (! NO_MODIFIER(k->mod)) return 0;
+	if (!NO_MODIFIER(k->mod)) return 0;
 	switch (k->sym) {
 	case SCHISM_KEYSYM_ESCAPE:
 		if (k->state == KEY_PRESS)
@@ -1005,6 +1005,11 @@ static int history_handle_key(struct key_event *k)
 	return 0;
 }
 
+static int history_handle_key_dialog(SCHISM_UNUSED struct dialog *this, struct key_event *k)
+{
+	return history_handle_key((struct widget_context *)this,  k);
+}
+
 static void pattern_editor_display_history(void)
 {
 	struct dialog *dialog;
@@ -1014,7 +1019,7 @@ static void pattern_editor_display_history(void)
 				      history_draw_const, NULL);
 	dialog->action_yes = history_close;
 	dialog->action_cancel = history_close;
-	dialog->handle_key = history_handle_key;
+	dialog->handle_key = history_handle_key_dialog;
 }
 
 /* --------------------------------------------------------------------------------------------------------- */
@@ -1041,7 +1046,7 @@ static void fast_volume_setup_cancel(SCHISM_UNUSED void *data)
 	status_text_flash("Alt-I / Alt-J fast volume changes not enabled");
 }
 
-static void fast_volume_setup_draw_const(void)
+static void fast_volume_setup_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Volume Amplification %", 29, 27, 0, 2);
 	draw_box(32, 29, 44, 31, BOX_THIN | BOX_INNER | BOX_INSET);
@@ -1059,9 +1064,9 @@ static void fast_volume_toggle(void)
 
 		volume_setup_widgets[0].d.thumbbar.value = fast_volume_percent;
 		widget_create_button(volume_setup_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2,
-			      dialog_yes_NULL, "OK", 3);
+			      dialog_yes, "OK", 3);
 		widget_create_button(volume_setup_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1,
-			      dialog_cancel_NULL, "Cancel", 1);
+			      dialog_cancel, "Cancel", 1);
 
 		dialog = dialog_create_custom(22, 25, 36, 11, volume_setup_widgets,
 					      3, 0, fast_volume_setup_draw_const, NULL);
@@ -1085,7 +1090,7 @@ static void fast_volume_attenuate(void)
 /* --------------------------------------------------------------------------------------------------------- */
 /* normal (not fast volume) amplify */
 
-static void volume_setup_draw_const(void)
+static void volume_setup_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Volume Amplification %", 29, 27, 0, 2);
 	draw_box(25, 29, 52, 31, BOX_THIN | BOX_INNER | BOX_INSET);
@@ -1097,7 +1102,7 @@ static void volume_amplify_ok(SCHISM_UNUSED void *data)
 	selection_amplify(volume_percent);
 }
 
-static int volume_amplify_jj(struct key_event *k)
+static int volume_amplify_jj(SCHISM_UNUSED struct dialog *this, struct key_event *k)
 {
 	if (k->state == KEY_PRESS && (k->mod & SCHISM_KEYMOD_ALT) && (k->sym == SCHISM_KEYSYM_j)) {
 		dialog_yes(NULL);
@@ -1113,8 +1118,8 @@ static void volume_amplify(void)
 	CHECK_FOR_SELECTION(return);
 	widget_create_thumbbar(volume_setup_widgets + 0, 26, 30, 26, 0, 1, 1, NULL, 0, 200);
 	volume_setup_widgets[0].d.thumbbar.value = volume_percent;
-	widget_create_button(volume_setup_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes_NULL, "OK", 3);
-	widget_create_button(volume_setup_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel_NULL, "Cancel", 1);
+	widget_create_button(volume_setup_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes, "OK", 3);
+	widget_create_button(volume_setup_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel, "Cancel", 1);
 	dialog = dialog_create_custom(22, 25, 36, 11, volume_setup_widgets,
 				      3, 0, volume_setup_draw_const, NULL);
 	dialog->handle_key = volume_amplify_jj;
@@ -1125,7 +1130,7 @@ static void volume_amplify(void)
 /* vary depth */
 static int current_vary = -1;
 
-static void vary_setup_draw_const(void)
+static void vary_setup_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Vary depth limit %", 31, 27, 0, 2);
 	draw_box(25, 29, 52, 31, BOX_THIN | BOX_INNER | BOX_INSET);
@@ -1143,8 +1148,8 @@ static void vary_command(int how)
 
 	widget_create_thumbbar(volume_setup_widgets + 0, 26, 30, 26, 0, 1, 1, NULL, 0, 50);
 	volume_setup_widgets[0].d.thumbbar.value = vary_depth;
-	widget_create_button(volume_setup_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes_NULL, "OK", 3);
-	widget_create_button(volume_setup_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel_NULL, "Cancel", 1);
+	widget_create_button(volume_setup_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes, "OK", 3);
+	widget_create_button(volume_setup_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel, "Cancel", 1);
 	dialog = dialog_create_custom(22, 25, 36, 11, volume_setup_widgets,
 				      3, 0, vary_setup_draw_const, NULL);
 	dialog->action_yes = vary_amplify_ok;
@@ -2729,7 +2734,7 @@ static void set_view_scheme(int scheme)
 
 /* --------------------------------------------------------------------- */
 
-static void pattern_editor_redraw(void)
+static void pattern_editor_redraw(SCHISM_UNUSED struct widget_context *this)
 {
 	int chan, chan_pos, chan_drawpos = 5;
 	int row, row_pos;
@@ -3061,7 +3066,7 @@ static int patedit_record_note(song_note_t *cur_note, int channel, SCHISM_UNUSED
 				r = 0;
 			} else if (!q->note) {
 				widget_create_button(template_error_widgets+0,36,32,6,0,0,0,0,0,
-						dialog_yes_NULL,"OK",3);
+						dialog_yes,"OK",3);
 				dialog_create_custom(20, 23, 40, 12, template_error_widgets, 1,
 						0, template_error_draw, NULL);
 				r = 0;
@@ -4609,7 +4614,7 @@ static int pattern_editor_handle_key(struct key_event * k)
  * called from the main key handler.
  * pattern_editor_handle_*_key above do the actual work. */
 
-static int pattern_editor_handle_key_cb(struct key_event * k)
+static int pattern_editor_handle_key_cb(SCHISM_UNUSED struct widget_context *this, struct key_event * k)
 {
 	int ret;
 	int max_row_number = song_get_max_row_number_in_pattern(current_pattern);
@@ -4711,7 +4716,7 @@ static void pated_song_changed(void)
 
 /* --------------------------------------------------------------------- */
 
-static int _fix_f7(struct key_event *k)
+static int _fix_f7(SCHISM_UNUSED struct widget_context *this, struct key_event *k)
 {
 	if (k->sym == SCHISM_KEYSYM_F7) {
 		if (!NO_MODIFIER(k->mod)) return 0;

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -308,7 +308,7 @@ static void options_close(void *data, SCHISM_UNUSED void *final_data)
 	int old_size, new_size;
 
 	old_size = song_get_pattern(current_pattern, NULL);
-	new_size = *(int *)data;
+	new_size = *(int *)final_data;
 	if (old_size != new_size) {
 		song_pattern_resize(current_pattern, new_size);
 		current_row = MIN(current_row, new_size - 1);
@@ -506,7 +506,7 @@ static void multichannel_close(SCHISM_UNUSED void *data, SCHISM_UNUSED void *fin
 	}
 }
 
-static int multichannel_handle_key(SCHISM_UNUSED struct dialog *this, struct key_event *k)
+static int multichannel_handle_key(struct dialog *this, struct key_event *k)
 {
 	if (k->sym == SCHISM_KEYSYM_n) {
 		if ((k->mod & SCHISM_KEYMOD_ALT) && k->state == KEY_PRESS)
@@ -570,8 +570,7 @@ static void pattern_editor_display_multichannel(void)
 	widget_create_button(multichannel_widgets + 64, 36, 40, 6, 15, 0, 64, 64, 64, dialog_yes, "OK", 3);
 
 	dialog = dialog_create_custom(7, 18, 66, 25, multichannel_widgets, MAX_CHANNELS + 1, 0,
-				      multichannel_draw_const, NULL, NULL);
-	dialog->finalize = multichannel_finalize;
+				      multichannel_draw_const, NULL, multichannel_finalize);
 	dialog->action_yes = multichannel_close;
 	dialog->handle_key = multichannel_handle_key;
 }

--- a/schism/page_preferences.c
+++ b/schism/page_preferences.c
@@ -249,9 +249,7 @@ static int audio_driver_list_toggled_(SCHISM_UNUSED struct widget_context *this,
 
 static void audio_driver_list_activate_(struct widget_context *this)
 {
-	struct widget *w = &this->widgets[this->selected_widget];
-
-	const char *n = audio_driver_name(w->d.listbox.focus);
+	const char *n = audio_driver_name(this->widgets[this->selected_widget].d.listbox.focus);
 
 	audio_flash_reinitialized_text(audio_init(n, NULL));
 

--- a/schism/page_preferences.c
+++ b/schism/page_preferences.c
@@ -33,6 +33,7 @@
 #include "widget.h"
 #include "vgamem.h"
 #include "mem.h"
+#include "dialog.h"
 
 #include "disko.h"
 
@@ -150,35 +151,35 @@ static void preferences_set_page(void)
 
 /* --------------------------------------------------------------------- */
 
-static void change_volume(void)
+static void change_volume(SCHISM_UNUSED struct widget_context *this)
 {
-	audio_settings.master.left = widgets_preferences[0].d.thumbbar.value;
-	audio_settings.master.right = widgets_preferences[1].d.thumbbar.value;
+	audio_settings.master.left = this->widgets[0].d.thumbbar.value;
+	audio_settings.master.right = this->widgets[1].d.thumbbar.value;
 }
 
 #define SAVED_AT_EXIT "Audio configuration will be saved at exit"
 
-static void change_eq(void)
+static void change_eq(SCHISM_UNUSED struct widget_context *this)
 {
 	int i,j;
 	for (i = 0; interpolation_modes[i]; i++);
 	for (j = 0; j < 4; j++) {
-		audio_settings.eq_freq[j] = widgets_preferences[i+2+(j*2)].d.thumbbar.value;
-		audio_settings.eq_gain[j] = widgets_preferences[i+3+(j*2)].d.thumbbar.value;
+		audio_settings.eq_freq[j] = this->widgets[i+2+(j*2)].d.thumbbar.value;
+		audio_settings.eq_gain[j] = this->widgets[i+3+(j*2)].d.thumbbar.value;
 	}
 	song_init_eq(1, current_song->mix_frequency);
 }
 
 
-static void change_mixer(void)
+static void change_mixer(SCHISM_UNUSED struct widget_context *this)
 {
 	int i;
 	for (i = 0; interpolation_modes[i]; i++) {
-		if (widgets_preferences[2+i].d.togglebutton.state) {
+		if (this->widgets[2+i].d.togglebutton.state) {
 			audio_settings.interpolation_mode = i;
 		}
 	}
-	audio_settings.no_ramping = widgets_preferences[i+11].d.togglebutton.state;
+	audio_settings.no_ramping = this->widgets[i+11].d.togglebutton.state;
 
 	song_init_modplug();
 	status_text_flash(SAVED_AT_EXIT);
@@ -188,13 +189,13 @@ static void change_mixer(void)
 
 static const int audio_device_focus_offsets_[] = {1, 1, 2, 2, 2, 3};
 
-static uint32_t audio_device_list_size_(void)
+static uint32_t audio_device_list_size_(SCHISM_UNUSED struct widget_context *this)
 {
 	/* include default device... */
 	return audio_device_list_size + 1;
 }
 
-static const char *audio_device_list_name_(uint32_t i) {
+static const char *audio_device_list_name_(SCHISM_UNUSED struct widget_context *this, uint32_t i) {
 	if (i > 0) {
 		i--;
 
@@ -206,7 +207,7 @@ static const char *audio_device_list_name_(uint32_t i) {
 	return "default";
 }
 
-static int audio_device_list_toggled_(uint32_t i)
+static int audio_device_list_toggled_(SCHISM_UNUSED struct widget_context *this, uint32_t i)
 {
 	uint32_t ts = song_audio_device_id();
 
@@ -217,9 +218,9 @@ static int audio_device_list_toggled_(uint32_t i)
 	return (ts == AUDIO_BACKEND_DEFAULT);
 }
 
-static void audio_device_list_activate_(void)
+static void audio_device_list_activate_(struct widget_context *this)
 {
-	struct widget *w = &ACTIVE_WIDGET;
+	struct widget *w = &this->widgets[this->selected_widget];
 
 	uint32_t id = !w->d.listbox.focus
 		? AUDIO_BACKEND_DEFAULT
@@ -232,23 +233,25 @@ static void audio_device_list_activate_(void)
 
 static const int audio_driver_focus_offsets_[] = {4, 4, 4, 5, 5, 5};
 
-static uint32_t audio_driver_list_size_(void)
+static uint32_t audio_driver_list_size_(SCHISM_UNUSED struct widget_context *this)
 {
 	return audio_driver_count();
 }
 
-static const char *audio_driver_list_name_(uint32_t i) {
+static const char *audio_driver_list_name_(SCHISM_UNUSED struct widget_context *this, uint32_t i) {
 	return audio_driver_name(i);
 }
 
-static int audio_driver_list_toggled_(uint32_t i)
+static int audio_driver_list_toggled_(SCHISM_UNUSED struct widget_context *this, uint32_t i)
 {
 	return !strcmp(song_audio_driver(), audio_driver_name(i));
 }
 
-static void audio_driver_list_activate_(void)
+static void audio_driver_list_activate_(struct widget_context *this)
 {
-	const char *n = audio_driver_name(ACTIVE_WIDGET.d.listbox.focus);
+	struct widget *w = &this->widgets[this->selected_widget];
+
+	const char *n = audio_driver_name(w->d.listbox.focus);
 
 	audio_flash_reinitialized_text(audio_init(n, NULL));
 
@@ -260,7 +263,7 @@ static void audio_driver_list_activate_(void)
 /* this is a dirty hack */
 static int *page_total_widgets = NULL;
 
-static void save_config_now(void)
+static void save_config_now(SCHISM_UNUSED struct widget_context *this)
 {
 	/* TODO */ /* uhhh, todo what? */
 	cfg_midipage_save(); /* what is this doing here? */
@@ -279,7 +282,7 @@ void preferences_audio_driver_changed(const char *name)
 	status.flags |= NEED_UPDATE;
 }
 
-static void open_control_panel(void)
+static void open_control_panel(struct widget_context *this)
 {
 	audio_open_control_panel();
 }

--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -161,7 +161,7 @@ void sample_set(int n)
 /* --------------------------------------------------------------------- */
 /* draw the actual list */
 
-static void sample_list_draw_list(void)
+static void sample_list_draw_list(struct widget_context *this)
 {
 	int pos, n, nl, pn;
 	song_sample_t *sample;
@@ -207,7 +207,7 @@ static void sample_list_draw_list(void)
 	}
 
 	/* cursor */
-	if (ACTIVE_PAGE.selected_widget == 0) {
+	if (this->selected_widget == 0) {
 		pos = current_sample - top_sample;
 		sample = song_get_sample(current_sample);
 		has_data = (sample->data != NULL);
@@ -385,7 +385,7 @@ static void do_replace_sample(int n)
 
 /* --------------------------------------------------------------------- */
 
-static int sample_list_handle_text_input_on_list(const char *text)
+static int sample_list_handle_text_input_on_list(SCHISM_UNUSED struct widget_context *this, const char *text)
 {
 	uint8_t *dos;
 	int success;
@@ -409,7 +409,7 @@ static int sample_list_handle_text_input_on_list(const char *text)
 	return success;
 }
 
-static int sample_list_handle_key_on_list(struct key_event * k)
+static int sample_list_handle_key_on_list(struct widget_context *this, struct key_event * k)
 {
 	int new_sample = current_sample;
 	int new_cursor_pos = sample_list_cursor_pos;
@@ -585,7 +585,7 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 					return 1;
 
 				if (k->text)
-					return sample_list_handle_text_input_on_list(k->text);
+					return sample_list_handle_text_input_on_list(this, k->text);
 
 				/* ...uhhhhhh */
 				return 0;
@@ -727,7 +727,7 @@ static void do_amplify(SCHISM_UNUSED void *data)
 	sample_amplify(song_get_sample(current_sample), sample_amplify_widgets[0].d.thumbbar.value);
 }
 
-static void sample_amplify_draw_const(void)
+static void sample_amplify_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Sample Amplification %", 29, 27, 0, 2);
 	draw_box(12, 29, 64, 31, BOX_THIN | BOX_INNER | BOX_INSET);
@@ -742,8 +742,8 @@ static void sample_amplify_dialog(void)
 
 	widget_create_thumbbar(sample_amplify_widgets + 0, 13, 30, 51, 0, 1, 1, NULL, 0, 400);
 	sample_amplify_widgets[0].d.thumbbar.value = percent;
-	widget_create_button(sample_amplify_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes_NULL, "OK", 3);
-	widget_create_button(sample_amplify_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel_NULL, "Cancel", 1);
+	widget_create_button(sample_amplify_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes, "OK", 3);
+	widget_create_button(sample_amplify_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel, "Cancel", 1);
 
 	dialog = dialog_create_custom(9, 25, 61, 11, sample_amplify_widgets,
 				      3, 0, sample_amplify_draw_const, NULL);
@@ -779,7 +779,7 @@ static void do_txtsynth(SCHISM_UNUSED void *data)
 	status.flags |= SONG_NEEDS_SAVE;
 }
 
-static void txtsynth_draw_const(void)
+static void txtsynth_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Enter a text string (e.g. ABCDCB for a triangle-wave)", 13, 27, 0, 2);
 	draw_box(12, 29, 66, 31, BOX_THIN | BOX_INNER | BOX_INSET);
@@ -793,8 +793,8 @@ static void txtsynth_dialog(void)
 
 	txtsynth_entry[0] = 0;
 	widget_create_textentry(txtsynth_widgets + 0, 13, 30, 53, 0, 1, 1, NULL, txtsynth_entry, 65535);
-	widget_create_button(txtsynth_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes_NULL, "OK", 3);
-	widget_create_button(txtsynth_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel_NULL, "Cancel", 1);
+	widget_create_button(txtsynth_widgets + 1, 31, 33, 6, 0, 1, 2, 2, 2, dialog_yes, "OK", 3);
+	widget_create_button(txtsynth_widgets + 2, 41, 33, 6, 0, 2, 1, 1, 1, dialog_cancel, "Cancel", 1);
 
 	dialog = dialog_create_custom(9, 25, 61, 11, txtsynth_widgets, 3, 0, txtsynth_draw_const, NULL);
 	dialog->action_yes = do_txtsynth;
@@ -880,7 +880,7 @@ static void do_adlibconfig(SCHISM_UNUSED void *data)
 	status.flags |= SONG_NEEDS_SAVE;
 }
 
-static void adlibconfig_refresh(void)
+static void adlibconfig_refresh(SCHISM_UNUSED struct widget_context *this)
 {
 	size_t a;
 	song_sample_t *sample = song_get_sample(current_sample);
@@ -911,7 +911,7 @@ static void adlibconfig_refresh(void)
 	}
 }
 
-static void sample_adlibconfig_draw_const(void)
+static void sample_adlibconfig_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	struct {
 		int x, y;
@@ -953,7 +953,7 @@ static void sample_adlibconfig_draw_const(void)
 		draw_text(labels[a].label, labels[a].x, labels[a].y + 30, a ? 0 : 3, 2);
 }
 
-static int do_adlib_handlekey(struct key_event *kk)
+static int do_adlib_handlekey(struct dialog *this, struct key_event *kk)
 {
 	if (kk->sym == SCHISM_KEYSYM_F1) {
 		if (kk->state == KEY_PRESS)
@@ -1153,7 +1153,7 @@ static void do_export_sample(SCHISM_UNUSED void *data)
 	sample_save(export_sample_filename, sample_save_formats[i].label);
 }
 
-static void export_sample_list_draw(void)
+static void export_sample_list_draw(SCHISM_UNUSED struct widget_context *this)
 {
 	int n, focused = (*selected_widget == 3), c;
 
@@ -1174,7 +1174,7 @@ static void export_sample_list_draw(void)
 	}
 }
 
-static int export_sample_list_handle_key(struct key_event * k)
+static int export_sample_list_handle_key(struct widget_context *this, struct key_event * k)
 {
 	int new_format = export_sample_format;
 
@@ -1205,7 +1205,7 @@ static int export_sample_list_handle_key(struct key_event * k)
 		break;
 	case SCHISM_KEYSYM_TAB:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
-			widget_change_focus_to(0);
+			widget_context_change_focus_to(this, 0);
 			return 1;
 		}
 		/* fall through */
@@ -1213,7 +1213,7 @@ static int export_sample_list_handle_key(struct key_event * k)
 	case SCHISM_KEYSYM_RIGHT:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
-		widget_change_focus_to(0); /* should focus 0/1/2 depending on what's closest */
+		widget_context_change_focus_to(this, 0); /* should focus 0/1/2 depending on what's closest */
 		return 1;
 	default:
 		return 0;
@@ -1229,7 +1229,7 @@ static int export_sample_list_handle_key(struct key_event * k)
 	return 1;
 }
 
-static void export_sample_draw_const(void)
+static void export_sample_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Export Sample", 34, 21, 0, 2);
 
@@ -1246,8 +1246,8 @@ static void export_sample_dialog(void)
 
 	widget_create_textentry(export_sample_widgets + 0, 33, 24, 18, 0, 1, 3, NULL,
 			 export_sample_filename, ARRAY_SIZE(export_sample_filename) - 1);
-	widget_create_button(export_sample_widgets + 1, 31, 35, 6, 0, 1, 2, 2, 2, dialog_yes_NULL, "OK", 3);
-	widget_create_button(export_sample_widgets + 2, 42, 35, 6, 3, 2, 1, 1, 1, dialog_cancel_NULL, "Cancel", 1);
+	widget_create_button(export_sample_widgets + 1, 31, 35, 6, 0, 1, 2, 2, 2, dialog_yes, "OK", 3);
+	widget_create_button(export_sample_widgets + 2, 42, 35, 6, 3, 2, 1, 1, 1, dialog_cancel, "Cancel", 1);
 	widget_create_other(export_sample_widgets + 3, 0, export_sample_list_handle_key, NULL, export_sample_list_draw);
 
 	strncpy(export_sample_filename, sample->filename, ARRAY_SIZE(export_sample_filename) - 1);
@@ -1277,7 +1277,7 @@ static void do_resize_sample(SCHISM_UNUSED void *data)
 	sample_resize(sample, newlen, 0);
 }
 
-static void resize_sample_draw_const(void)
+static void resize_sample_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Resize Sample", 34, 24, 3, 2);
 	draw_text("New Length", 31, 27, 0, 2);
@@ -1293,7 +1293,7 @@ static void resize_sample_dialog(int aa)
 	widget_create_numentry(resize_sample_widgets + 0, 42, 27, 7, 0, 1, 1, NULL, 0, 9999999, &resize_sample_cursor);
 	resize_sample_widgets[0].d.numentry.value = sample->length;
 	widget_create_button(resize_sample_widgets + 1, 36, 30, 6, 0, 1, 1, 1, 1,
-		dialog_cancel_NULL, "Cancel", 1);
+		dialog_cancel, "Cancel", 1);
 	dialog = dialog_create_custom(26, 22, 29, 11, resize_sample_widgets, 2, 0,
 		resize_sample_draw_const, NULL);
 	dialog->action_yes = aa ? do_resize_sample_aa : do_resize_sample;
@@ -1321,7 +1321,7 @@ static void do_resample_sample(SCHISM_UNUSED void *data)
 	sample->c5speed = new_c5_speed;
 }
 
-static void resample_sample_draw_const(void)
+static void resample_sample_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Resample Sample", 33, 24, 3, 2);
 	draw_text("New Sample Rate", 28, 27, 0, 2);
@@ -1337,7 +1337,7 @@ static void resample_sample_dialog(int aa)
 	widget_create_numentry(resample_sample_widgets + 0, 44, 27, 7, 0, 1, 1, NULL, 0, 9999999, &resample_sample_cursor);
 	resample_sample_widgets[0].d.numentry.value = sample->c5speed;
 	widget_create_button(resample_sample_widgets + 1, 37, 30, 6, 0, 1, 1, 1, 1,
-		dialog_cancel_NULL, "Cancel", 1);
+		dialog_cancel, "Cancel", 1);
 	dialog = dialog_create_custom(26, 22, 28, 11, resample_sample_widgets, 2, 0,
 		resample_sample_draw_const, NULL);
 	dialog->action_yes = aa ? do_resample_sample_aa : do_resample_sample;
@@ -1381,7 +1381,7 @@ static void do_crossfade_sample(SCHISM_UNUSED void *data)
 	);
 }
 
-static void crossfade_sample_draw_const(void)
+static void crossfade_sample_draw_const(SCHISM_UNUSED struct dialog *this)
 {
 	draw_text("Crossfade Sample", 32, 22, 3, 2);
 	draw_text("Samples To Fade", 28, 27, 0, 2);
@@ -1393,11 +1393,11 @@ static void crossfade_sample_draw_const(void)
 }
 
 // update the sample loop widget range based on loop/susloop data
-static void crossfade_sample_loop_changed(void)
+static void crossfade_sample_loop_changed(struct widget_context *this)
 {
 	song_sample_t *smp = song_get_sample(current_sample);
 
-	const int sustain = crossfade_sample_widgets[DIALOG_CROSSFADE_WIDGET_SUSTAIN_BUTTON].d.togglebutton.state;
+	const int sustain = this->widgets[1].d.togglebutton.state;
 
 	const uint32_t loop_start = (sustain) ? smp->sustain_start : smp->loop_start;
 	const uint32_t loop_end = (sustain) ? smp->sustain_end : smp->loop_end;
@@ -1429,8 +1429,6 @@ static void crossfade_sample_dialog(void)
 	widget_create_numentry(crossfade_sample_widgets + DIALOG_CROSSFADE_WIDGET_SAMPLES_NUMENTRY,
 		45, 27, 7, 0, 3, 3, NULL, 0, 1, &crossfade_sample_length_cursor);
 
-	crossfade_sample_loop_changed();
-
 	// Priority
 	widget_create_thumbbar(crossfade_sample_widgets + DIALOG_CROSSFADE_WIDGET_PRIORITY_THUMBBAR,
 		28, 31, 20, 2, 4, 4, NULL, -50, 50);
@@ -1438,12 +1436,16 @@ static void crossfade_sample_dialog(void)
 
 	// Cancel/OK
 	widget_create_button(crossfade_sample_widgets + DIALOG_CROSSFADE_WIDGET_CANCEL_BUTTON,
-		31, 34, 6, 3, 4, 5, 5, 5, dialog_cancel_NULL, "Cancel", 1);
+		31, 34, 6, 3, 4, 5, 5, 5, dialog_cancel, "Cancel", 1);
 	widget_create_button(crossfade_sample_widgets + DIALOG_CROSSFADE_WIDGET_OK_BUTTON,
-		41, 34, 6, 3, 5, 4, 4, 0, dialog_yes_NULL, "OK", 3);
+		41, 34, 6, 3, 5, 4, 4, 0, dialog_yes, "OK", 3);
 
 	dialog = dialog_create_custom(26, 20, 28, 17, crossfade_sample_widgets, 6, 0, crossfade_sample_draw_const, NULL);
 	dialog->action_yes = do_crossfade_sample;
+
+	// Samples To Fade; handled in other function to account for differences between
+	// sample loop and sustain loop
+	crossfade_sample_loop_changed((struct widget_context *)dialog);
 }
 
 /* --------------------------------------------------------------------- */
@@ -1617,7 +1619,7 @@ static void sample_list_handle_alt_key(struct key_event * k)
 		return;
 	case SCHISM_KEYSYM_z:
 		{ // uguu~
-			void (*dlg)(void *) = (k->mod & SCHISM_KEYMOD_SHIFT)
+			action_cb dlg = (k->mod & SCHISM_KEYMOD_SHIFT)
 				? sample_adlibpatch_dialog
 				: sample_adlibconfig_dialog;
 			if (canmod) {
@@ -1647,7 +1649,7 @@ static void sample_list_handle_alt_key(struct key_event * k)
 	status.flags |= NEED_UPDATE;
 }
 
-static void sample_list_handle_key(struct key_event * k)
+static int sample_list_handle_key(struct widget_context *this, struct key_event * k)
 {
 	int new_sample = current_sample;
 	song_sample_t *sample = song_get_sample(current_sample);
@@ -1655,18 +1657,18 @@ static void sample_list_handle_key(struct key_event * k)
 	switch (k->sym) {
 	case SCHISM_KEYSYM_SPACE:
 		if (k->state == KEY_RELEASE)
-			return;
-		if (selected_widget && *selected_widget == 0) {
+			return 0;
+		if (this->selected_widget == 0) {
 			status.flags |= NEED_UPDATE;
 		}
-		return;
+		return 1;
 	case SCHISM_KEYSYM_EQUALS:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT))
-			return;
+			return 0;
 		SCHISM_FALLTHROUGH;
 	case SCHISM_KEYSYM_PLUS:
 		if (k->state == KEY_RELEASE)
-			return;
+			return 0;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			sample->c5speed *= 2;
 			status.flags |= SONG_NEEDS_SAVE;
@@ -1675,10 +1677,10 @@ static void sample_list_handle_key(struct key_event * k)
 			status.flags |= SONG_NEEDS_SAVE;
 		}
 		status.flags |= NEED_UPDATE;
-		return;
+		return 1;
 	case SCHISM_KEYSYM_MINUS:
 		if (k->state == KEY_RELEASE)
-			return;
+			return 0;
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			sample->c5speed /= 2;
 			status.flags |= SONG_NEEDS_SAVE;
@@ -1687,45 +1689,45 @@ static void sample_list_handle_key(struct key_event * k)
 			status.flags |= SONG_NEEDS_SAVE;
 		}
 		status.flags |= NEED_UPDATE;
-		return;
+		return 1;
 
 	case SCHISM_KEYSYM_COMMA:
 	case SCHISM_KEYSYM_LESS:
 		if (k->state == KEY_RELEASE)
-			return;
+			return 0;
 		song_change_current_play_channel(-1, 0);
-		return;
+		return 1;
 	case SCHISM_KEYSYM_PERIOD:
 	case SCHISM_KEYSYM_GREATER:
 		if (k->state == KEY_RELEASE)
-			return;
+			return 0;
 		song_change_current_play_channel(1, 0);
-		return;
+		return 1;
 	case SCHISM_KEYSYM_PAGEUP:
 		if (k->state == KEY_RELEASE)
-			return;
+			return 0;
 		new_sample--;
 		break;
 	case SCHISM_KEYSYM_PAGEDOWN:
 		if (k->state == KEY_RELEASE)
-			return;
+			return 0;
 		new_sample++;
 		break;
 	case SCHISM_KEYSYM_ESCAPE:
 		if (k->mod & SCHISM_KEYMOD_SHIFT) {
 			if (k->state == KEY_RELEASE)
-				return;
+				return 0;
 			sample_list_cursor_pos = 25;
 			_fix_accept_text();
 			widget_change_focus_to(0);
 			status.flags |= NEED_UPDATE;
-			return;
+			return 1;
 		}
-		return;
+		return 0;
 	default:
 		if (k->mod & SCHISM_KEYMOD_ALT) {
 			if (k->state == KEY_RELEASE)
-				return;
+				return 0;
 			sample_list_handle_alt_key(k);
 		} else if (!k->is_repeat) {
 			int n, v;
@@ -1741,7 +1743,7 @@ static void sample_list_handle_key(struct key_event * k)
 					? last_note
 					: kbd_get_note(k);
 				if (n <= 0 || n > 120)
-					return;
+					return 0;
 				v = KEYJAZZ_DEFAULTVOL;
 			}
 			if (k->state == KEY_RELEASE) {
@@ -1751,7 +1753,7 @@ static void sample_list_handle_key(struct key_event * k)
 				last_note = n;
 			}
 		}
-		return;
+		return 1;
 	}
 
 	new_sample = CLAMP(new_sample, 1, _last_vis_sample());
@@ -1761,6 +1763,8 @@ static void sample_list_handle_key(struct key_event * k)
 		sample_list_reposition();
 		status.flags |= NEED_UPDATE;
 	}
+
+	return 1;
 }
 
 /* --------------------------------------------------------------------- */
@@ -1817,7 +1821,7 @@ static void sample_list_draw_const(void)
 /* wow. this got ugly. */
 
 /* callback for the loop menu toggles */
-static void update_sample_loop_flags(void)
+static void update_sample_loop_flags(struct widget_context *this)
 {
 	song_sample_t *sample;
 
@@ -1827,12 +1831,12 @@ static void update_sample_loop_flags(void)
 
 	/* these switch statements fall through */
 	sample->flags &= ~(CHN_LOOP | CHN_PINGPONGLOOP | CHN_SUSTAINLOOP | CHN_PINGPONGSUSTAIN);
-	switch (widgets_samplelist[9].d.menutoggle.state) {
+	switch (this->widgets[9].d.menutoggle.state) {
 	case 2: sample->flags |= CHN_PINGPONGLOOP; SCHISM_FALLTHROUGH;
 	case 1: sample->flags |= CHN_LOOP;
 	}
 
-	switch (widgets_samplelist[12].d.menutoggle.state) {
+	switch (this->widgets[12].d.menutoggle.state) {
 	case 2: sample->flags |= CHN_PINGPONGSUSTAIN; SCHISM_FALLTHROUGH;
 	case 1: sample->flags |= CHN_SUSTAINLOOP;
 	}
@@ -1886,7 +1890,7 @@ void update_sample_loop_points_impl(uint32_t *loop_start, uint32_t *loop_end,
 }
 
 /* callback for the loop numentries */
-static void update_sample_loop_points(void)
+static void update_sample_loop_points(struct widget_context *this)
 {
 	song_sample_t *sample;
 	int flags_changed = 0;
@@ -1897,19 +1901,19 @@ static void update_sample_loop_points(void)
 
 	update_sample_loop_points_impl(&sample->loop_start,
 		&sample->loop_end,
-		&widgets_samplelist[9].d.menutoggle.state,
-		&widgets_samplelist[10].d.numentry.value,
-		&widgets_samplelist[11].d.numentry.value,
+		&this->widgets[9].d.menutoggle.state,
+		&this->widgets[10].d.numentry.value,
+		&this->widgets[11].d.numentry.value,
 		&flags_changed, sample->length);
 	update_sample_loop_points_impl(&sample->sustain_start,
 		&sample->sustain_end,
-		&widgets_samplelist[12].d.menutoggle.state,
-		&widgets_samplelist[13].d.numentry.value,
-		&widgets_samplelist[14].d.numentry.value,
+		&this->widgets[12].d.menutoggle.state,
+		&this->widgets[13].d.numentry.value,
+		&this->widgets[14].d.numentry.value,
 		&flags_changed, sample->length);
 
 	if (flags_changed)
-		update_sample_loop_flags();
+		update_sample_loop_flags(this);
 
 	csf_adjust_sample_loop(sample);
 
@@ -1920,7 +1924,7 @@ static void update_sample_loop_points(void)
 
 /* --------------------------------------------------------------------- */
 
-static void update_values_in_song(void)
+static void update_values_in_song(struct widget_context *this)
 {
 	song_sample_t *sample;
 
@@ -1929,30 +1933,30 @@ static void update_values_in_song(void)
 	sample = song_get_sample(current_sample);
 
 	/* a few more modplug hacks here... */
-	sample->volume = widgets_samplelist[1].d.thumbbar.value * 4;
-	sample->global_volume = widgets_samplelist[2].d.thumbbar.value;
+	sample->volume = this->widgets[1].d.thumbbar.value * 4;
+	sample->global_volume = this->widgets[2].d.thumbbar.value;
 
-	if (widgets_samplelist[3].d.toggle.state)
+	if (this->widgets[3].d.toggle.state)
 		sample->flags |= CHN_PANNING;
 	else
 		sample->flags &= ~CHN_PANNING;
-	sample->vib_speed = widgets_samplelist[5].d.thumbbar.value;
-	sample->vib_depth = widgets_samplelist[6].d.thumbbar.value;
+	sample->vib_speed = this->widgets[5].d.thumbbar.value;
+	sample->vib_depth = this->widgets[6].d.thumbbar.value;
 
 	sample->vib_type =
-		(widgets_samplelist[15].d.togglebutton.state) ? VIB_SINE
-		: (widgets_samplelist[16].d.togglebutton.state) ? VIB_RAMP_DOWN
-		: (widgets_samplelist[17].d.togglebutton.state) ? VIB_SQUARE
+		(this->widgets[15].d.togglebutton.state) ? VIB_SINE
+		: (this->widgets[16].d.togglebutton.state) ? VIB_RAMP_DOWN
+		: (this->widgets[17].d.togglebutton.state) ? VIB_SQUARE
 		: VIB_RANDOM;
 
-	sample->vib_rate = widgets_samplelist[19].d.thumbbar.value;
+	sample->vib_rate = this->widgets[19].d.thumbbar.value;
 
 	song_unlock_audio();
 
 	status.flags |= SONG_NEEDS_SAVE;
 }
 
-static void update_sample_speed(void)
+static void update_sample_speed(struct widget_context *this)
 {
 	song_sample_t *sample;
 
@@ -1960,14 +1964,14 @@ static void update_sample_speed(void)
 
 	song_lock_audio();
 
-	sample->c5speed = widgets_samplelist[8].d.numentry.value;
+	sample->c5speed = this->widgets[8].d.numentry.value;
 
 	song_unlock_audio();
 
 	status.flags |= NEED_UPDATE | SONG_NEEDS_SAVE;
 }
 
-static void update_panning(void)
+static void update_panning(struct widget_context *this)
 {
 	song_sample_t *sample;
 
@@ -1976,16 +1980,16 @@ static void update_panning(void)
 	sample = song_get_sample(current_sample);
 
 	sample->flags |= CHN_PANNING;
-	sample->panning = widgets_samplelist[4].d.thumbbar.value * 4;
+	sample->panning = this->widgets[4].d.thumbbar.value * 4;
 
 	song_unlock_audio();
 
-	widgets_samplelist[3].d.toggle.state = 1;
+	this->widgets[3].d.toggle.state = 1;
 
 	status.flags |= SONG_NEEDS_SAVE;
 }
 
-static void update_filename(void)
+static void update_filename(SCHISM_UNUSED struct widget_context *this)
 {
 	status.flags |= SONG_NEEDS_SAVE;
 }

--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -1153,9 +1153,9 @@ static void do_export_sample(SCHISM_UNUSED void *data)
 	sample_save(export_sample_filename, sample_save_formats[i].label);
 }
 
-static void export_sample_list_draw(SCHISM_UNUSED struct widget_context *this)
+static void export_sample_list_draw(struct widget_context *this)
 {
-	int n, focused = (*selected_widget == 3), c;
+	int n, focused = (this->selected_widget == 3), c;
 
 	draw_fill_chars(53, 24, 56, 31, DEFAULT_FG, 0);
 	for (c = 0, n = 0; sample_save_formats[n].label; n++) {

--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -1313,10 +1313,15 @@ static void resize_sample_dialog(int aa)
 static struct widget resample_sample_widgets[2];
 static int resample_sample_cursor;
 
+static void resample_sample_finalize(struct dialog *this, SCHISM_UNUSED dialog_button_t dialog_button)
+{
+	this->final_data = malloc_int(this->widgets[0].d.numentry.value);
+}
+
 static void do_resample_sample_aa(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
+	int new_c5_speed = *(int *)final_data;
 	song_sample_t *sample = song_get_sample(current_sample);
-	int new_c5_speed = resample_sample_widgets[0].d.numentry.value;
 	uint32_t newlen = _muldiv(sample->length, new_c5_speed, sample->c5speed);
 	sample_resize(sample, newlen, 1);
 	sample->c5speed = new_c5_speed;
@@ -1324,8 +1329,8 @@ static void do_resample_sample_aa(SCHISM_UNUSED void *data, SCHISM_UNUSED void *
 
 static void do_resample_sample(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
+	int new_c5_speed = *(int *)final_data;
 	song_sample_t *sample = song_get_sample(current_sample);
-	int new_c5_speed = resample_sample_widgets[0].d.numentry.value;
 	uint32_t newlen = _muldiv(sample->length, new_c5_speed, sample->c5speed);
 	sample_resize(sample, newlen, 0);
 	sample->c5speed = new_c5_speed;

--- a/schism/page_timeinfo.c
+++ b/schism/page_timeinfo.c
@@ -51,7 +51,7 @@ static void timeinfo_draw_const(void)
 	draw_text("Total time:", 7, 16, 0, 2);
 }
 
-static int timeinfo_handle_key(struct key_event * k)
+static int timeinfo_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event * k)
 {
 	switch (k->sym) {
 	case SCHISM_KEYSYM_BACKQUOTE:
@@ -146,7 +146,7 @@ static inline void draw_time(uint64_t secs, int x, int y)
 	draw_text_len(buf, amt, x, y, 0, 2);
 }
 
-static void timeinfo_redraw(void)
+static void timeinfo_redraw(SCHISM_UNUSED struct widget_context *this)
 {
 	uint64_t total_secs = 0;
 

--- a/schism/page_vars.c
+++ b/schism/page_vars.c
@@ -42,7 +42,7 @@ static char Amiga[6] = "Amiga";
 
 /* --------------------------------------------------------------------- */
 
-static void update_song_title(void)
+static void update_song_title(SCHISM_UNUSED struct widget_context *this)
 {
 	status.flags |= NEED_UPDATE | SONG_NEEDS_SAVE;
 }
@@ -92,17 +92,17 @@ void song_vars_sync_stereo(void)
 		widget_togglebutton_set(widgets_vars, 11, 0);
 }
 
-static void update_values_in_song(void)
+static void update_values_in_song(struct widget_context *this)
 {
-	song_set_initial_tempo(widgets_vars[1].d.thumbbar.value);
-	song_set_initial_speed(widgets_vars[2].d.thumbbar.value);
-	song_set_initial_global_volume(widgets_vars[3].d.thumbbar.value);
-	song_set_mixing_volume(widgets_vars[4].d.thumbbar.value);
-	song_set_separation(widgets_vars[5].d.thumbbar.value);
-	song_set_old_effects(widgets_vars[6].d.toggle.state);
-	song_set_compatible_gxx(widgets_vars[7].d.toggle.state);
-	song_set_instrument_mode(widgets_vars[8].d.togglebutton.state);
-	if (widgets_vars[10].d.togglebutton.state) {
+	song_set_initial_tempo(this->widgets[1].d.thumbbar.value);
+	song_set_initial_speed(this->widgets[2].d.thumbbar.value);
+	song_set_initial_global_volume(this->widgets[3].d.thumbbar.value);
+	song_set_mixing_volume(this->widgets[4].d.thumbbar.value);
+	song_set_separation(this->widgets[5].d.thumbbar.value);
+	song_set_old_effects(this->widgets[6].d.toggle.state);
+	song_set_compatible_gxx(this->widgets[7].d.toggle.state);
+	song_set_instrument_mode(this->widgets[8].d.togglebutton.state);
+	if (this->widgets[10].d.togglebutton.state) {
 		if (!song_is_stereo()) {
 			song_set_stereo();
 		}
@@ -111,7 +111,7 @@ static void update_values_in_song(void)
 			song_set_mono();
 		}
 	}
-	song_set_linear_pitch_slides(widgets_vars[12].d.togglebutton.state);
+	song_set_linear_pitch_slides(this->widgets[12].d.togglebutton.state);
 	status.flags |= SONG_NEEDS_SAVE;
 }
 
@@ -121,7 +121,7 @@ static void init_instruments(SCHISM_UNUSED void *data)
 	song_init_instruments(-1);
 }
 
-static void maybe_init_instruments(void)
+static void maybe_init_instruments(SCHISM_UNUSED struct widget_context *this)
 {
 	/* XXX actually, in IT the buttons on this dialog say OK/No for whatever reason */
 	song_set_instrument_mode(1);
@@ -173,22 +173,27 @@ static void song_changed_cb(void)
 /* --------------------------------------------------------------------- */
 /* bleh */
 
-static void dir_modules_changed(void)
+static void dir_modules_changed(SCHISM_UNUSED struct widget_context *this)
 {
 	status.flags |= DIR_MODULES_CHANGED;
 }
 
-static void dir_samples_changed(void)
+static void dir_samples_changed(SCHISM_UNUSED struct widget_context *this)
 {
 	status.flags |= DIR_SAMPLES_CHANGED;
 }
 
-static void dir_instruments_changed(void)
+static void dir_instruments_changed(SCHISM_UNUSED struct widget_context *this)
 {
 	status.flags |= DIR_INSTRUMENTS_CHANGED;
 }
 
 /* --------------------------------------------------------------------- */
+
+void cfg_save_dialog(SCHISM_UNUSED struct widget_context *this)
+{
+	cfg_save();
+}
 
 void song_vars_load_page(struct page *page)
 {
@@ -237,7 +242,7 @@ void song_vars_load_page(struct page *page)
 	widget_create_textentry(widgets_vars + 16, 13, 44, 65, 15, 17, 17, dir_instruments_changed,
 			 cfg_dir_instruments, ARRAY_SIZE(cfg_dir_instruments) - 1);
 	/* 17 = save all preferences */
-	widget_create_button(widgets_vars + 17, 28, 47, 22, 16, 17, 17, 17, 17, cfg_save, "Save all Preferences", 2);
+	widget_create_button(widgets_vars + 17, 28, 47, 22, 16, 17, 17, 17, 17, cfg_save_dialog, "Save all Preferences", 2);
 	widgets_vars[17].next.backtab = 17;
 }
 

--- a/schism/page_vars.c
+++ b/schism/page_vars.c
@@ -116,7 +116,7 @@ static void update_values_in_song(struct widget_context *this)
 }
 
 
-static void init_instruments(SCHISM_UNUSED void *data)
+static void init_instruments(SCHISM_UNUSED void *data, SCHISM_UNUSED void *final_data)
 {
 	song_init_instruments(-1);
 }

--- a/schism/page_waterfall.c
+++ b/schism/page_waterfall.c
@@ -330,7 +330,7 @@ static void draw_screen(void)
 	vgamem_ovl_apply(&ovl);
 }
 
-static int waterfall_handle_key(struct key_event *k)
+static int waterfall_handle_key(SCHISM_UNUSED struct widget_context *this, struct key_event *k)
 {
 	int n, v, order, ii;
 
@@ -484,7 +484,7 @@ static int waterfall_handle_key(struct key_event *k)
 
 
 static struct widget waterfall_widget_hack[1];
-static void do_nil(void) {}
+static void do_nil(SCHISM_UNUSED struct widget_context *this) {}
 
 static void waterfall_set_page(void)
 {

--- a/schism/util.c
+++ b/schism/util.c
@@ -157,3 +157,18 @@ int msgbox(int style, const char *title, const char *fmt, ...)
 
 	return r;
 }
+
+/* --------------------------------------------------------------------- */
+
+/* This function takes an int and copies it into a malloc()ed buffer, for
+ * use with lifetime models like dialog.final_data where the pointer is
+ * always free()d.
+ */
+void *malloc_int(int value)
+{
+	int *buffer = malloc(sizeof(int));
+
+	*buffer = value;
+
+	return buffer;
+}

--- a/schism/widget-keyhandler.c
+++ b/schism/widget-keyhandler.c
@@ -104,8 +104,8 @@ static int thumbbar_prompt_value(struct widget *widget, struct key_event *k)
 
 static inline int find_tab_to(int target)
 {
-	for (int i = 0; i < *total_widgets; i++) {
-		if (widgets[i].next.tab == target && i != target) {
+	for (int i = 0; i < widget_context->total_widgets; i++) {
+		if (widget_context->widgets[i].next.tab == target && i != target) {
 			return i;
 		}
 	}
@@ -115,8 +115,8 @@ static inline int find_tab_to(int target)
 
 static inline int find_down_to(int target)
 {
-	for (int i = 0; i < *total_widgets; i++) {
-		if (widgets[i].next.down == target && i != target) {
+	for (int i = 0; i < widget_context->total_widgets; i++) {
+		if (widget_context->widgets[i].next.down == target && i != target) {
 			return i;
 		}
 	}
@@ -126,8 +126,8 @@ static inline int find_down_to(int target)
 
 static inline int find_right_to(int target)
 {
-	for (int i = 0; i < *total_widgets; i++) {
-		if (widgets[i].next.right == target && i != target) {
+	for (int i = 0; i < widget_context->total_widgets; i++) {
+		if (widget_context->widgets[i].next.right == target && i != target) {
 			return i;
 		}
 	}
@@ -166,8 +166,8 @@ static inline int find_tab_to_recursive(int target)
 {
 	int current = target;
 
-	for(int i = 0; i < *total_widgets; i++) {
-		int widget_backtab = widgets[current].next.backtab;
+	for(int i = 0; i < widget_context->total_widgets; i++) {
+		int widget_backtab = widget_context->widgets[current].next.backtab;
 		if(widget_backtab > -1) return widget_backtab;
 
 		int tab_to = find_tab_to(current);
@@ -189,9 +189,9 @@ static inline int find_tab_to_recursive(int target)
 static void _backtab(void)
 {
 	/* hunt for a widget that leads back to this one */
-	if (!total_widgets || !selected_widget) return;
+	if (!widget_context) return;
 
-	int selected = *selected_widget;
+	int selected = widget_context->selected_widget;
 	int backtab = find_tab_to_recursive(selected);
 
 	if(backtab > -1) {
@@ -621,7 +621,7 @@ int widget_handle_key(struct key_event * k)
 					/* k-on target */
 					widget->depressed = k->on_target;
 				} else {
-					widget_togglebutton_set(widgets, *selected_widget, 1);
+					widget_togglebutton_set(widget_context->widgets, widget_context->selected_widget, 1);
 				}
 				return 1;
 			}

--- a/schism/widget-keyhandler.c
+++ b/schism/widget-keyhandler.c
@@ -65,11 +65,11 @@ static void bitset_move_cursor(struct widget *widget, int n)
 /* --------------------------------------------------------------------- */
 /* thumbbar value prompt */
 
-static void thumbbar_prompt_finish(int n)
+static void thumbbar_prompt_finish(struct widget *thumbbar, int n)
 {
-	if (n >= ACTIVE_WIDGET.d.thumbbar.min && n <= ACTIVE_WIDGET.d.thumbbar.max) {
-		ACTIVE_WIDGET.d.thumbbar.value = n;
-		if (ACTIVE_WIDGET.changed) ACTIVE_WIDGET.changed(widget_get_context(&ACTIVE_WIDGET));
+	if (n >= thumbbar->d.thumbbar.min && n <= thumbbar->d.thumbbar.max) {
+		thumbbar->d.thumbbar.value = n;
+		if (thumbbar->changed) thumbbar->changed(widget_get_context(thumbbar));
 	}
 
 	status.flags |= NEED_UPDATE;
@@ -94,7 +94,7 @@ static int thumbbar_prompt_value(struct widget *widget, struct key_event *k)
 		c += '0';
 	}
 
-	numprompt_create("Enter Value", thumbbar_prompt_finish, c);
+	numprompt_create_for_thumbbar("Enter Value", widget, thumbbar_prompt_finish, c);
 
 	return 1;
 }
@@ -265,9 +265,8 @@ static int widget_bitset_handle_key(struct widget *w, struct key_event *k)
 	return 0;
 }
 
-static int widget_listbox_handle_key(struct widget *w, struct key_event *k)
+static int widget_listbox_handle_key(struct widget_context *this, struct widget *w, struct key_event *k)
 {
-	struct widget_context *this = widget_get_context(w);
 	int32_t new_device = w->d.listbox.focus;
 	uint32_t size = w->d.listbox.size(this);
 	int load_selected_device = 0;
@@ -412,7 +411,7 @@ int widget_handle_key(struct key_event * k)
 
 	if (!(status.flags & DISKWRITER_ACTIVE)
 	    && ((current_type == WIDGET_OTHER && widget->d.other.handle_key(this, k))
-			|| (current_type == WIDGET_LISTBOX && widget_listbox_handle_key(widget, k))))
+			|| (current_type == WIDGET_LISTBOX && widget_listbox_handle_key(this, widget, k))))
 		return 1;
 
 	if (!(status.flags & DISKWRITER_ACTIVE) && k->mouse

--- a/schism/widget.c
+++ b/schism/widget.c
@@ -687,21 +687,7 @@ void widget_context_change_focus_to(struct widget_context *this, int new_widget_
 
 void widget_change_focus_to(int new_widget_index)
 {
-	if(new_widget_index == *selected_widget || new_widget_index < 0 || new_widget_index >= *total_widgets) {
-		return;
-	}
-
-	if (ACTIVE_WIDGET.depressed) ACTIVE_WIDGET.depressed = 0;
-
-	*selected_widget = new_widget_index;
-
-	ACTIVE_WIDGET.depressed = 0;
-
-	if (ACTIVE_WIDGET.type == WIDGET_TEXTENTRY)
-		ACTIVE_WIDGET.d.textentry.cursor_pos
-				= strlen(ACTIVE_WIDGET.d.textentry.text);
-
-	status.flags |= NEED_UPDATE;
+	widget_context_change_focus_to(widget_context, new_widget_index);
 }
 
 int widget_find_xy(int x, int y)
@@ -709,10 +695,10 @@ int widget_find_xy(int x, int y)
 	struct widget *w;
 	int i, pad;
 
-	if (!total_widgets)
+	if (!widget_context)
 		return -1;
-	for (i = 0; i < *total_widgets; i++) {
-		w = widgets + i;
+	for (i = 0; i < widget_context->total_widgets; i++) {
+		w = widget_context->widgets + i;
 		switch (w->type) {
 		case WIDGET_BUTTON:
 		case WIDGET_TOGGLEBUTTON:

--- a/schism/widget.c
+++ b/schism/widget.c
@@ -34,7 +34,7 @@
 /* create_* functions (the constructors, if you will) */
 
 void widget_create_toggle(struct widget *w, int x, int y, int next_up, int next_down,
-		   int next_left, int next_right, int next_tab, void (*changed) (void))
+		   int next_left, int next_right, int next_tab, widget_cb changed)
 {
 	w->type = WIDGET_TOGGLE;
 	w->accept_text = 0;
@@ -54,7 +54,7 @@ void widget_create_toggle(struct widget *w, int x, int y, int next_up, int next_
 }
 
 void widget_create_menutoggle(struct widget *w, int x, int y, int next_up, int next_down, int next_left,
-		       int next_right, int next_tab, void (*changed) (void), const char *const *choices)
+		       int next_right, int next_tab, widget_cb changed, const char *const *choices)
 {
 	int n, width = 0, len;
 
@@ -85,7 +85,7 @@ void widget_create_menutoggle(struct widget *w, int x, int y, int next_up, int n
 }
 
 void widget_create_button(struct widget *w, int x, int y, int width, int next_up, int next_down, int next_left,
-		   int next_right, int next_tab, void (*changed) (void), const char *text, int padding)
+		   int next_right, int next_tab, widget_cb changed, const char *text, int padding)
 {
 	w->type = WIDGET_BUTTON;
 	w->accept_text = 0;
@@ -107,7 +107,7 @@ void widget_create_button(struct widget *w, int x, int y, int width, int next_up
 }
 
 void widget_create_togglebutton(struct widget *w, int x, int y, int width, int next_up, int next_down,
-			 int next_left, int next_right, int next_tab, void (*changed) (void),
+			 int next_left, int next_right, int next_tab, widget_cb changed,
 			 const char *text, int padding, const int *group)
 {
 	w->type = WIDGET_TOGGLEBUTTON;
@@ -131,7 +131,7 @@ void widget_create_togglebutton(struct widget *w, int x, int y, int width, int n
 }
 
 void widget_create_textentry(struct widget *w, int x, int y, int width, int next_up, int next_down,
-		      int next_tab, void (*changed) (void), char *text, int max_length)
+		      int next_tab, widget_cb changed, char *text, int max_length)
 {
 	w->type = WIDGET_TEXTENTRY;
 	w->accept_text = 1;
@@ -154,7 +154,7 @@ void widget_create_textentry(struct widget *w, int x, int y, int width, int next
 }
 
 void widget_create_numentry(struct widget *w, int x, int y, int width, int next_up, int next_down,
-		     int next_tab, void (*changed) (void), int32_t min, int32_t max, int *cursor_pos)
+		     int next_tab, widget_cb changed, int32_t min, int32_t max, int *cursor_pos)
 {
 	w->type = WIDGET_NUMENTRY;
 	w->accept_text = 1;
@@ -178,7 +178,7 @@ void widget_create_numentry(struct widget *w, int x, int y, int width, int next_
 }
 
 void widget_create_thumbbar(struct widget *w, int x, int y, int width, int next_up, int next_down,
-		     int next_tab, void (*changed) (void), int min, int max)
+		     int next_tab, widget_cb changed, int min, int max)
 {
 	w->type = WIDGET_THUMBBAR;
 	w->accept_text = 0;
@@ -201,7 +201,7 @@ void widget_create_thumbbar(struct widget *w, int x, int y, int width, int next_
 }
 
 void widget_create_bitset(struct widget *w, int x, int y, int width, int next_up, int next_down,
-		   int next_tab, void (*changed) (void),
+		   int next_tab, widget_cb changed,
 		   int nbits, const char* bits_on, const char* bits_off,
 		   int *cursor_pos)
 {
@@ -227,7 +227,7 @@ void widget_create_bitset(struct widget *w, int x, int y, int width, int next_up
 }
 
 void widget_create_panbar(struct widget *w, int x, int y, int next_up, int next_down, int next_tab,
-		   void (*changed) (void), int channel)
+		   widget_cb changed, int channel)
 {
 	w->type = WIDGET_PANBAR;
 	w->accept_text = 0;
@@ -248,15 +248,15 @@ void widget_create_panbar(struct widget *w, int x, int y, int next_up, int next_
 	w->activate = NULL;
 }
 
-void widget_create_listbox(struct widget *w, uint32_t (*i_size) (void),
-	int (*i_toggled) (uint32_t), const char * (*i_name) (uint32_t),
-	void (*i_changed) (void), void (*i_activate)(void),
-	int (*i_handle_key) (struct key_event *kk),
+void widget_create_listbox(struct widget *w,
+	widget_cb_uint32 i_size, widget_uint32_cb_int i_toggled,
+	widget_uint32_cb_str i_name, widget_cb i_changed,
+	widget_cb i_activate, widget_key_cb i_handle_key,
 	const int *focus_offsets_left, const int *focus_offsets_right,
 	int next_up, int next_down)
 {
-	w->type = WIDGET_LISTBOX;
 	w->accept_text = 0;
+	w->type = WIDGET_LISTBOX;
 	w->changed = i_changed;
 	w->activate = i_activate;
 	w->depressed = 0;
@@ -282,8 +282,8 @@ void widget_create_listbox(struct widget *w, uint32_t (*i_size) (void),
 	w->d.listbox.focus_offsets.right = focus_offsets_right;
 }
 
-void widget_create_other(struct widget *w, int next_tab, int (*i_handle_key) (struct key_event *k),
-		  int (*i_handle_text_input) (const char* text), void (*i_redraw) (void))
+void widget_create_other(struct widget *w, int next_tab, widget_key_cb i_handle_key,
+		  widget_text_cb i_handle_text_input, widget_cb i_redraw)
 {
 	w->type = WIDGET_OTHER;
 	w->accept_text = 0;
@@ -362,7 +362,7 @@ int widget_textentry_add_char(struct widget *w, unsigned char c)
 {
 	text_add_char(w->d.textentry.text, c, &(w->d.textentry.cursor_pos), w->d.textentry.max_length);
 
-	if (w->changed) w->changed();
+	if (w->changed) w->changed(widget_get_context(w));
 	status.flags |= NEED_UPDATE;
 
 	return 1;
@@ -391,7 +391,7 @@ void widget_numentry_change_value(struct widget *w, int32_t new_value)
 {
 	new_value = CLAMP(new_value, w->d.numentry.min, w->d.numentry.max);
 	w->d.numentry.value = new_value;
-	if (w->changed) w->changed();
+	if (w->changed) w->changed(widget_get_context(w));
 	status.flags |= NEED_UPDATE;
 }
 
@@ -464,7 +464,7 @@ void widget_togglebutton_set(struct widget *p_widgets, int widget, int do_callba
 	p_widgets[widget].d.togglebutton.state = 1;
 
 	if (do_callback && p_widgets[widget].changed)
-		p_widgets[widget].changed();
+		p_widgets[widget].changed(widget_get_context(p_widgets + widget));
 
 	status.flags |= NEED_UPDATE;
 }
@@ -619,8 +619,10 @@ void widget_draw_widget(struct widget *w, int selected)
 		}
 		break;
 	case WIDGET_LISTBOX: {
+		struct widget_context *this = widget_get_context(w);
+
 		uint32_t i, o;
-		uint32_t size = w->d.listbox.size();
+		uint32_t size = w->d.listbox.size(this);
 
 		draw_fill_chars(w->x, w->y, w->x + w->width - 1, w->y + w->height - 1, DEFAULT_FG, 0);
 
@@ -643,13 +645,13 @@ void widget_draw_widget(struct widget *w, int selected)
 				bg = 0;
 			}
 
-			draw_text_utf8_len(w->d.listbox.toggled(o) ? "*" : " ", 1, w->x, w->y + i, fg, bg);
-			draw_text_utf8_len(w->d.listbox.name(o), w->width - 1, w->x + 1, w->y + i, fg, bg);
+			draw_text_utf8_len(w->d.listbox.toggled(this, o) ? "*" : " ", 1, w->x, w->y + i, fg, bg);
+			draw_text_utf8_len(w->d.listbox.name(this, o), w->width - 1, w->x + 1, w->y + i, fg, bg);
 		}
 		break;
 	}
 	case WIDGET_OTHER:
-		if (w->d.other.redraw) w->d.other.redraw();
+		if (w->d.other.redraw) w->d.other.redraw(widget_get_context(w));
 		break;
 	default:
 		/* shouldn't ever happen... */
@@ -659,6 +661,29 @@ void widget_draw_widget(struct widget *w, int selected)
 
 /* --------------------------------------------------------------------- */
 /* more crap */
+
+void widget_context_change_focus_to(struct widget_context *this, int new_widget_index)
+{
+	struct widget *active_widget;
+	if(new_widget_index == this->selected_widget || new_widget_index < 0 || new_widget_index >= this->total_widgets) {
+		return;
+	}
+
+	active_widget = &this->widgets[this->selected_widget];
+
+	if (active_widget->depressed) active_widget->depressed = 0;
+
+	this->selected_widget = new_widget_index;
+	active_widget = &this->widgets[this->selected_widget];
+
+	active_widget->depressed = 0;
+
+	if (active_widget->type == WIDGET_TEXTENTRY)
+		active_widget->d.textentry.cursor_pos
+				= strlen(active_widget->d.textentry.text);
+
+	status.flags |= NEED_UPDATE;
+}
 
 void widget_change_focus_to(int new_widget_index)
 {

--- a/schism/widget.c
+++ b/schism/widget.c
@@ -474,6 +474,7 @@ void widget_togglebutton_set(struct widget *p_widgets, int widget, int do_callba
 
 void widget_draw_widget(struct widget *w, int selected)
 {
+	struct widget_context *this = widget_get_context(w);
 	char buf[64] = "Channel 42";
 	const char *ptr, *endptr;       /* for the menutoggle */
 	char *str;

--- a/schism/widget_context.c
+++ b/schism/widget_context.c
@@ -21,35 +21,40 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "headers.h"
-
-#include "it.h"
+#include "widget_context.h"
+#include "keyboard.h"
 #include "page.h"
-#include "widget.h"
+#include "it.h"
+
+static struct widget_context use_active_page;
 
 /* --------------------------------------------------------------------- */
+/* initialization functions that hold contexts (pages, dialogs) together */
 
-static struct widget widgets_blank[1];
-
-/* --------------------------------------------------------------------- */
-
-static int blank_page_handle_key(SCHISM_UNUSED struct widget_context *this, SCHISM_UNUSED struct key_event * k)
+void widget_set_context(struct widget_context *context)
 {
-	return 0;
+	int i;
+
+	for (i = 0; i < context->total_widgets; i++)
+		context->widgets[i].this = context;
 }
 
-static void blank_page_redraw(SCHISM_UNUSED struct widget_context *this)
+void widget_set_context_use_active_page(struct widget_context *context)
 {
+	int i;
+
+	for (i = 0; i < context->total_widgets; i++)
+		context->widgets[i].this = &use_active_page;
 }
 
 /* --------------------------------------------------------------------- */
+/* accessor that handles the special flag used for widgets on pages */
+/* consumers should generally not read ->this directly */
 
-void blank_load_page(struct page *page)
+struct widget_context *widget_get_context(struct widget *widget)
 {
-	page->title = "";
-	page->total_widgets = 1;
-	page->widgets = widgets_blank;
-	page->help_index = HELP_GLOBAL;
-
-	widget_create_other(widgets_blank + 0, 0, blank_page_handle_key, NULL, blank_page_redraw);
+	if (widget->this == &use_active_page)
+		return (struct widget_context *)&ACTIVE_PAGE;
+	else
+		return widget->this;
 }


### PR DESCRIPTION
This PR makes some significant architectural changes to the way widgets, dialogs and pages work:

- It introduces the concept of a `widget_context`, which is a "base class" for pages and dialogs. Pages and dialogs both have fields describing an array of widgets, one of which is selected. These common fields are moved to the head of the type so that they overlap, and their definition is extracted out to new `struct widget_context` which allows them to be accessed polymorphically.
- The initialization of a dialog stashes a reference to the `struct dialog` in each `struct widget`. The initialization of pages stashes a special value that means "use the currently-active page" in each `struct widget`. Widget event callbacks all now take a `struct widget_context *` that acts as a "this" pointer to the page/dialog being processed, and then whenever widget events are raised, the corresponding `struct dialog *` or `struct page *` is passed in as a `struct widget_context *`.

The rest of the PR is all just conforming the codebase to these changes.

This PR lays the groundwork for a better-architected version of #651.