### PR TITLE
page_patedit: fixed the calculation in fast_volume_amplify

### DIFF
--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -1069,7 +1069,9 @@ static void fast_volume_toggle(void)
 
 static void fast_volume_amplify(void)
 {
-	selection_amplify((100/fast_volume_percent)*100);
+	/* multiply before divide here, otherwise most of the time
+	 * (100 / percentage) is just always going to be 0 or 1 */
+	selection_amplify(100 * 100 / fast_volume_percent);
 }
 
 static void fast_volume_attenuate(void)


### PR DESCRIPTION
Calculation was computing the volume ratio as an int, meaning that for anything over 50% it would always multiply by exactly 0 or 1.