### PR TITLE
page_samples: capture user's new c5speed exactly

### DIFF
--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -1286,15 +1286,19 @@ static int resample_sample_cursor;
 static void do_resample_sample_aa(SCHISM_UNUSED void *data)
 {
 	song_sample_t *sample = song_get_sample(current_sample);
-	uint32_t newlen = _muldiv(sample->length, resample_sample_widgets[0].d.numentry.value, sample->c5speed);
+	int new_c5_speed = resample_sample_widgets[0].d.numentry.value;
+	uint32_t newlen = _muldiv(sample->length, new_c5_speed, sample->c5speed);
 	sample_resize(sample, newlen, 1);
+	sample->c5speed = new_c5_speed;
 }
 
 static void do_resample_sample(SCHISM_UNUSED void *data)
 {
 	song_sample_t *sample = song_get_sample(current_sample);
-	uint32_t newlen = _muldiv(sample->length, resample_sample_widgets[0].d.numentry.value, sample->c5speed);
+	int new_c5_speed = resample_sample_widgets[0].d.numentry.value;
+	uint32_t newlen = _muldiv(sample->length, new_c5_speed, sample->c5speed);
 	sample_resize(sample, newlen, 0);
+	sample->c5speed = new_c5_speed;
 }
 
 static void resample_sample_draw_const(void)


### PR DESCRIPTION
The do_resample_sample function works by converting the requested new C5 speed to an equivalent new sample length and then calling sample_resize. But due to rounding, when converting back from that length to reproduce the C5 speed, it can't always hit exactly, so it'll sometimes be off by 1. This PR overwrites the computed value with the supplied value to make sure it's always exactly what the user input.