### PR TITLE
page_patedit: fix defensive range check in snap_paste

### DIFF
--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -2103,7 +2103,7 @@ static void snap_paste(struct pattern_snap *s, int x, int y, int xlate)
 		       s->data + s->channels * row, chan_width * sizeof(song_note_t));
 		if (!xlate) continue;
 		for (chan = 0; chan < chan_width; chan++) {
-			if (chan + x > 64) break; /* defensive */
+			if (chan + x >= 64) break; /* defensive */
 			set_note_note(p_note+chan,
 					p_note[chan].note,
 					xlate);


### PR DESCRIPTION
The defensive range check is off by 1. If it were ever needed, it would not stop it from writing past the end of the row data, which would be past the end of the buffer by 1 element in the last row of the pattern.