### PR TITLE
page_patedit: Corrected error handling for track_view_scheme in cfg_load_patedit

### DIFF
--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -1231,7 +1231,7 @@ void cfg_load_patedit(cfg_file_t *cfg)
 			s[n] -= 'A';
 		} else {
 			log_appendf(4, "Track view scheme corrupted; using default");
-			n = 64;
+			n = 0;
 			r = 0;
 			break;
 		}


### PR DESCRIPTION
When the parser detects an invalid value in the config file string for `track_view_scheme`, it logs that it is going to ignore the config file and revert to defaults. However, what it actually does is just blindly use the data from the config file. It sets `n` to 64, meaning 64 valid characters, instead of to 0, meaning 0 valid characters. I have confirmed that the behaviour is considerably incorrect with the old code, and that with this change it does in fact revert to default.

![image](https://github.com/user-attachments/assets/1539e15a-3f93-4823-95ff-d441cbe2b1a9)
