### PR TITLE
everywhere: use MAX_CHANNELS instead of 64

### DIFF
--- a/fmt/dsm.c
+++ b/fmt/dsm.c
@@ -226,7 +226,7 @@ static int dsm_process_pattern(const void *data, size_t size, void *userdata)
 		if (chn > ppd->nchn) /* header doesn't match? warn. */
 			*ppd->chn_doesnt_match = MAX(chn, *ppd->chn_doesnt_match);
 
-		song_note_t *note = ppd->pattern + 64 * row + chn;
+		song_note_t *note = ppd->pattern + MAX_CHANNELS * row + chn;
 		if (mask & DSM_PAT_NOTE_PRESENT) {
 			DSM_ASSERT_OFFSET();
 

--- a/fmt/far.c
+++ b/fmt/far.c
@@ -201,7 +201,7 @@ int fmt_far_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 		if (!fhdr.onoff[n])
 			song->channels[n].flags |= CHN_MUTE;
 	}
-	for (; n < 64; n++)
+	for (; n < MAX_CHANNELS; n++)
 		song->channels[n].flags |= CHN_MUTE;
 
 	song->initial_speed = fhdr.default_speed;

--- a/fmt/mdl.c
+++ b/fmt/mdl.c
@@ -162,10 +162,16 @@ struct mdl_envelope {
 /* --------------------------------------------------------------------------------------------------------- */
 /* Internal definitions */
 
+#define MDL_CHANNELS 64
+
+#if MDL_CHANNELS != MAX_CHANNELS
+# error The code currently assumes MDL_CHANNELS == MAX_CHANNELS. If they need to differ, then many assumptions will need to be rewritten. MDL files always have 64 channels.
+#endif
+
 struct mdlpat {
 	int track; // which track to put here
 	int rows; // 1-256
-	song_note_t *note; // first note -- add 64 for next note, etc.
+	song_note_t *note; // first note -- add MDL_CHANNELS for next note, etc.
 	struct mdlpat *next;
 };
 
@@ -462,7 +468,7 @@ static int mdl_read_info(song_t *song, slurp_t *fp)
 		if (info.chanpan[n] & 128)
 			song->channels[n].flags |= CHN_MUTE;
 	}
-	for (; n < 64; n++) {
+	for (; n < MAX_CHANNELS; n++) {
 		song->channels[n].panning = 128;
 		song->channels[n].flags |= CHN_MUTE;
 	}

--- a/fmt/mid.c
+++ b/fmt/mid.c
@@ -515,7 +515,7 @@ int fmt_mid_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 			pat++;
 			row -= MID_ROWS_PER_PATTERN;
 		}
-		rowdata = pattern + 64 * row;
+		rowdata = pattern + MAX_CHANNELS * row;
 		if (cur->note.note) {
 			rowdata[cur->chan].note = cur->note.note;
 			rowdata[cur->chan].instrument = cur->note.instrument;

--- a/fmt/mtm.c
+++ b/fmt/mtm.c
@@ -236,7 +236,7 @@ int fmt_mtm_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 		if (rows < 32) {
 			/* stick a pattern break on the first channel with an empty effect column
 			 * (XXX don't do this if there's already one in another column) */
-			note = song->patterns[pat] + 64 * (rows - 1);
+			note = song->patterns[pat] + MAX_CHANNELS * (rows - 1);
 			while (note->effect || note->param)
 				note++;
 			note->effect = FX_PATTERNBREAK;

--- a/fmt/mus.c
+++ b/fmt/mus.c
@@ -131,7 +131,7 @@ int fmt_mus_load_song(song_t *song, slurp_t *fp, SCHISM_UNUSED unsigned int lfla
 	if (!read_mus_header(&hdr, fp))
 		return LOAD_UNSUPPORTED;
 
-	for (n = 16; n < 64; n++)
+	for (n = 16; n < MAX_CHANNELS; n++)
 		song->channels[n].flags |= CHN_MUTE;
 
 	slurp_seek(fp, hdr.scorestart, SEEK_SET);

--- a/fmt/okt.c
+++ b/fmt/okt.c
@@ -91,7 +91,7 @@ static int okt_read_cmod(song_t *song, slurp_t *fp)
 			cs[cn++].panning = PROTRACKER_PANNING(t);
 		cs[cn++].panning = PROTRACKER_PANNING(t);
 	}
-	for (t = cn; t < 64; t++)
+	for (t = cn; t < MAX_CHANNELS; t++)
 		cs[t].flags |= CHN_MUTE;
 	return cn;
 }

--- a/fmt/s3m.c
+++ b/fmt/s3m.c
@@ -222,7 +222,7 @@ int fmt_s3m_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 		}
 		song->channels[n].volume = 64;
 	}
-	for (; n < 64; n++) {
+	for (; n < MAX_CHANNELS; n++) {
 		song->channels[n].panning = 32;
 		song->channels[n].volume = 64;
 		song->channels[n].flags = CHN_MUTE;
@@ -251,7 +251,7 @@ int fmt_s3m_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 	}
 
 	//mphack - fix the pannings
-	for (n = 0; n < 64; n++)
+	for (n = 0; n < MAX_CHANNELS; n++)
 		song->channels[n].panning *= 4;
 
 	/* samples */
@@ -371,7 +371,7 @@ int fmt_s3m_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 					row++;
 					continue;
 				}
-				note = song->patterns[n] + 64 * row + chn;
+				note = song->patterns[n] + MAX_CHANNELS * row + chn;
 				if (mask & 32) {
 					/* note/instrument */
 					note->note = slurp_getc(fp);

--- a/fmt/sfx.c
+++ b/fmt/sfx.c
@@ -163,7 +163,7 @@ int fmt_sfx_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 		for (pat = 0; pat < npat; pat++) {
 			note = song->patterns[pat] = csf_allocate_pattern(64);
 			song->pattern_size[pat] = song->pattern_alloc_size[pat] = 64;
-			for (n = 0; n < 64; n++, note += 60) {
+			for (n = 0; n < 64; n++, note = note + MAX_CHANNELS - 4) {
 				for (chan = 0; chan < 4; chan++, note++) {
 					uint8_t p[4];
 					slurp_read(fp, p, 4);

--- a/fmt/stm.c
+++ b/fmt/stm.c
@@ -279,7 +279,7 @@ int fmt_stm_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 
 	for (n = 0; n < 4; n++)
 		song->channels[n].panning = ((n & 1) ? 64 : 0) * 4; //mphack
-	for (; n < 64; n++)
+	for (; n < MAX_CHANNELS; n++)
 		song->channels[n].flags |= CHN_MUTE;
 	song->pan_separation = 64;
 	song->flags = SONG_ITOLDEFFECTS | SONG_COMPATGXX | SONG_NOSTEREO;

--- a/fmt/ult.c
+++ b/fmt/ult.c
@@ -364,12 +364,12 @@ int fmt_ult_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 		for (n = 0; n < nchn; n++)
 			song->channels[n].panning = (n & 1) ? 48 : 16;
 	}
-	for (; n < 64; n++) {
+	for (; n < MAX_CHANNELS; n++) {
 		song->channels[n].panning = 32;
 		song->channels[n].flags = CHN_MUTE;
 	}
 	//mphack - fix the pannings
-	for (n = 0; n < 64; n++)
+	for (n = 0; n < MAX_CHANNELS; n++)
 		song->channels[n].panning *= 4;
 
 	if ((lflags & (LOAD_NOSAMPLES | LOAD_NOPATTERNS)) == (LOAD_NOSAMPLES | LOAD_NOPATTERNS))
@@ -397,7 +397,7 @@ int fmt_ult_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 					repeat = 64 - row;
 				while (repeat--) {
 					*note = evnote;
-					note += 64;
+					note += MAX_CHANNELS;
 					row++;
 				}
 			}

--- a/include/page.h
+++ b/include/page.h
@@ -454,7 +454,6 @@ void update_current_row(void);
 void update_current_pattern(void);
 void pattern_editor_display_options(void);
 void pattern_editor_length_edit(void);
-int pattern_max_channels(int patno, int opt_bits[64]);
 
 /* page_orderpan.c */
 void update_current_order(void);

--- a/include/player/sndfile.h
+++ b/include/player/sndfile.h
@@ -367,7 +367,7 @@ typedef struct song_instrument {
 
 // (TODO write decent descriptions of what the various volume
 // variables are used for - are all of them *really* necessary?)
-// (TODO also the majority of this is irrelevant outside of the "main" 64 channels;
+// (TODO also the majority of this is irrelevant outside of the "main" MAX_CHANNELS channels;
 // this struct should really only be holding the stuff actually needed for mixing)
 typedef struct song_voice {
 	// First 32-bytes: Most used mixing information: don't change it
@@ -537,7 +537,7 @@ typedef struct {
 // XXX why are these extern? moreover, why is default_midi_config NOT const?
 extern midi_config_t default_midi_config;
 
-extern const song_note_t blank_pattern[64 * 64];
+extern const song_note_t blank_pattern[64 * MAX_CHANNELS];
 extern const song_note_t *blank_note;
 
 

--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -255,7 +255,7 @@ static int name_is_blank(char *name)
 	return 1;
 }
 
-const song_note_t blank_pattern[64 * 64] = {0};
+const song_note_t blank_pattern[64 * MAX_CHANNELS] = {0};
 const song_note_t *blank_note = blank_pattern; // Same thing, really.
 
 int csf_note_is_empty(song_note_t *note)

--- a/player/sndmix.c
+++ b/player/sndmix.c
@@ -629,7 +629,7 @@ static inline int32_t rn_update_sample(song_t *csf, song_voice_t *chan, int32_t 
 
 // XXX Rename this
 //Ranges: 
-// chan_num = 0..63
+// chan_num = 0..MAX_CHANNELS-1
 // freq = frequency in Hertz
 // vol = 0..16384
 // chan->instrument_volume = 0..64  (corresponds to the sample global volume and instrument global volume)
@@ -806,7 +806,7 @@ uint32_t csf_read(song_t *csf, void * v_buffer, uint32_t bufsize)
 		if (csf->multi_write) {
 			/* multi doesn't actually write meaningful data into 'buffer', so we can use that
 			as temp space for converting */
-			for (uint32_t n = 0; n < 64; n++) {
+			for (uint32_t n = 0; n < MAX_CHANNELS; n++) {
 				if (csf->multi_write[n].used) {
 					if (csf->mix_channels < 2)
 						mono_from_stereo(csf->multi_write[n].buffer, count);

--- a/schism/audio_loadsave.c
+++ b/schism/audio_loadsave.c
@@ -155,7 +155,7 @@ void song_new(int flags)
 		memset(current_song->title, 0, sizeof(current_song->title));
 		memset(current_song->message, 0, MAX_MESSAGE);
 
-		for (i = 0; i < 64; i++) {
+		for (i = 0; i < MAX_CHANNELS; i++) {
 			current_song->channels[i].volume = 64;
 			current_song->channels[i].panning = 128;
 			current_song->channels[i].flags = 0;

--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -124,7 +124,7 @@ static const schism_audio_backend_t *backend = NULL;
 // playback
 
 // page_patedit.c
-extern int midi_bend_hit[64], midi_last_bend_hit[64];
+extern int midi_last_bend_hit[MAX_CHANNELS];
 
 // this gets called from the backend
 static void audio_callback(uint8_t *stream, int len)
@@ -364,11 +364,11 @@ void song_change_current_play_channel(int relative, int wraparound)
 	current_play_channel += relative;
 	if (wraparound) {
 		if (current_play_channel < 1)
-			current_play_channel = 64;
-		else if (current_play_channel > 64)
+			current_play_channel = MAX_CHANNELS;
+		else if (current_play_channel > MAX_CHANNELS)
 			current_play_channel = 1;
 	} else {
-		current_play_channel = CLAMP(current_play_channel, 1, 64);
+		current_play_channel = CLAMP(current_play_channel, 1, MAX_CHANNELS);
 	}
 	status_text_flash("Using channel %d for playback", current_play_channel);
 }
@@ -637,9 +637,9 @@ void song_single_step(int patno, int row)
 	total_rows = song_get_pattern(patno, &pattern);
 	if (!pattern || row >= total_rows) return;
 
-	cur_note = pattern + 64 * row;
+	cur_note = pattern + MAX_CHANNELS * row;
 	cx = song_get_mix_channel(0);
-	for (i = 1; i <= 64; i++, cx++, cur_note++) {
+	for (i = 1; i <= MAX_CHANNELS; i++, cx++, cur_note++) {
 		if (cx && (cx->flags & CHN_MUTE)) continue; /* ick */
 		if (cur_note->voleffect == VOLFX_VOLUME) {
 			vol = cur_note->volparam;
@@ -670,7 +670,6 @@ void song_single_step(int patno, int row)
 // this should be called with the audio LOCKED
 static void song_reset_play_state(void)
 {
-	memset(midi_bend_hit, 0, sizeof(midi_bend_hit));
 	memset(midi_last_bend_hit, 0, sizeof(midi_last_bend_hit));
 	memset(keyjazz_note_to_chan, 0, sizeof(keyjazz_note_to_chan));
 	memset(keyjazz_chan_to_note, 0, sizeof(keyjazz_chan_to_note));
@@ -747,7 +746,7 @@ void song_stop_unlocked(int quitting)
 		unsigned char moff[4];
 
 		/* shut off everything; not IT like, but less annoying */
-		for (int chan = 0; chan < 64; chan++) {
+		for (int chan = 0; chan < MAX_CHANNELS; chan++) {
 			if (current_song->midi_note_tracker[chan] != 0) {
 				for (int j = 0; j < MAX_MIDI_CHANNELS; j++) {
 					csf_process_midi_macro(current_song, chan,

--- a/schism/mplink.c
+++ b/schism/mplink.c
@@ -121,7 +121,7 @@ int song_get_mix_state(uint32_t **channel_list)
 // For all of these, channel is ZERO BASED.
 // (whereas in the pattern editor etc. it's one based)
 
-static int channel_states[64];  // saved ("real") mute settings; nonzero = muted
+static int channel_states[MAX_CHANNELS];  // saved ("real") mute settings; nonzero = muted
 
 static inline void _save_state(int channel)
 {
@@ -130,7 +130,7 @@ static inline void _save_state(int channel)
 
 void song_save_channel_states(void)
 {
-	int n = 64;
+	int n = MAX_CHANNELS;
 
 	while (n-- > 0)
 		_save_state(n);
@@ -163,7 +163,7 @@ void song_set_channel_mute(int channel, int muted)
 // below), but I'm making it extern anyway for symmetry.
 void song_restore_channel_states(void)
 {
-	int n = 64;
+	int n = MAX_CHANNELS;
 
 	while (n-- > 0)
 		song_set_channel_mute(n, channel_states[n]);
@@ -178,7 +178,7 @@ void song_toggle_channel_mute(int channel)
 }
 
 static int _soloed(int channel) {
-	int n = 64;
+	int n = MAX_CHANNELS;
 	// if this channel is muted, it obviously isn't soloed
 	if (current_song->voices[channel].flags & CHN_MUTE)
 		return 0;
@@ -193,7 +193,7 @@ static int _soloed(int channel) {
 
 void song_handle_channel_solo(int channel)
 {
-	int n = 64;
+	int n = MAX_CHANNELS;
 
 	if (_soloed(channel)) {
 		song_restore_channel_states();
@@ -205,11 +205,11 @@ void song_handle_channel_solo(int channel)
 
 int song_find_last_channel(void)
 {
-	int n = 64;
+	int n = MAX_CHANNELS;
 
 	while (channel_states[--n])
 		if (n == 0)
-			return 63;
+			return MAX_CHANNELS - 1;
 	return n;
 }
 
@@ -270,7 +270,7 @@ song_note_t *song_pattern_allocate_copy(int patno, int *rows)
 	song_note_t *newdata = NULL;
 	if (olddata) {
 		newdata = csf_allocate_pattern(len);
-		memcpy(newdata, olddata, len * sizeof(song_note_t) * 64);
+		memcpy(newdata, olddata, len * sizeof(song_note_t) * MAX_CHANNELS);
 	}
 	if (rows)
 		*rows = len;
@@ -336,7 +336,7 @@ void song_pattern_resize(int pattern, int newsize)
 		song_note_t *olddata = current_song->patterns[pattern];
 		song_note_t *newdata = csf_allocate_pattern(newsize);
 		if (olddata) {
-			memcpy(newdata, olddata, 64 * sizeof(song_note_t) * MIN(newsize, oldsize));
+			memcpy(newdata, olddata, MAX_CHANNELS * sizeof(song_note_t) * MIN(newsize, oldsize));
 			csf_free_pattern(olddata);
 		}
 		current_song->patterns[pattern] = newdata;
@@ -514,7 +514,7 @@ static void _swap_instruments_in_patterns(int a, int b)
 		song_note_t *note = current_song->patterns[pat];
 		if (note == NULL)
 			continue;
-		for (int n = 0; n < 64 * current_song->pattern_size[pat]; n++, note++) {
+		for (int n = 0; n < MAX_CHANNELS * current_song->pattern_size[pat]; n++, note++) {
 			if (note->instrument == a)
 				note->instrument = b;
 			else if (note->instrument == b)
@@ -572,7 +572,7 @@ static void _adjust_instruments_in_patterns(int start, int delta)
 		song_note_t *note = current_song->patterns[pat];
 		if (note == NULL)
 			continue;
-		for (n = 0; n < 64 * current_song->pattern_size[pat]; n++, note++) {
+		for (n = 0; n < MAX_CHANNELS * current_song->pattern_size[pat]; n++, note++) {
 			if (note->instrument >= start)
 				note->instrument = CLAMP(note->instrument + delta, 0, MAX_SAMPLES - 1);
 		}
@@ -799,7 +799,7 @@ void song_replace_sample(int num, int with)
 			note = current_song->patterns[i];
 			if (!note)
 				continue;
-			for (j = 0; j < 64 * current_song->pattern_size[i]; j++, note++) {
+			for (j = 0; j < MAX_CHANNELS * current_song->pattern_size[i]; j++, note++) {
 				if (note->instrument == num)
 					note->instrument = with;
 			}
@@ -822,7 +822,7 @@ void song_replace_instrument(int num, int with)
 		note = current_song->patterns[i];
 		if (!note)
 			continue;
-		for (j = 0; j < 64 * current_song->pattern_size[i]; j++, note++) {
+		for (j = 0; j < MAX_CHANNELS * current_song->pattern_size[i]; j++, note++) {
 			if (note->instrument == num)
 				note->instrument = with;
 		}

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -455,7 +455,7 @@ static void _draw_track_view(int base, int height, int first_channel, int num_ch
 			row = total_rows - 1;
 		}
 		draw_text(str_from_num(3, row, buf), 1, row_pos, 0, 2);
-		note = pattern + 64 * row + first_channel - 1;
+		note = pattern + MAX_CHANNELS * row + first_channel - 1;
 		for (chan_pos = 0; chan_pos < num_channels - 1; chan_pos++) {
 			draw_note(5 + channel_width * chan_pos, row_pos, note, -1, 6, 0);
 			if (separator)
@@ -472,7 +472,7 @@ static void _draw_track_view(int base, int height, int first_channel, int num_ch
 	total_rows = cur_pattern_rows;
 	row_pos = base + rows_before + 1;
 	draw_text(str_from_num(3, current_row, buf), 1, row_pos, 0, 2);
-	note = pattern + 64 * current_row + first_channel - 1;
+	note = pattern + MAX_CHANNELS * current_row + first_channel - 1;
 	for (chan_pos = 0; chan_pos < num_channels - 1; chan_pos++) {
 		draw_note(5 + channel_width * chan_pos, row_pos, note, -1, 6, 14);
 		if (separator)
@@ -496,7 +496,7 @@ static void _draw_track_view(int base, int height, int first_channel, int num_ch
 			row = 0;
 		}
 		draw_text(str_from_num(3, row, buf), 1, row_pos, 0, 2);
-		note = pattern + 64 * row + first_channel - 1;
+		note = pattern + MAX_CHANNELS * row + first_channel - 1;
 		for (chan_pos = 0; chan_pos < num_channels - 1; chan_pos++) {
 			draw_note(5 + channel_width * chan_pos, row_pos, note, -1, 6, 0);
 			if (separator)
@@ -833,7 +833,7 @@ static void _fix_channels(int n)
 		w->first_channel = selected_channel;
 	else if (selected_channel >= (w->first_channel + channels))
 		w->first_channel = selected_channel - channels + 1;
-	w->first_channel = CLAMP(w->first_channel, 1, 65 - channels);
+	w->first_channel = CLAMP(w->first_channel, 1, MAX_CHANNELS - channels + 1);
 }
 
 static int info_handle_click(int x, int y)
@@ -1147,7 +1147,7 @@ static int info_page_handle_key(struct key_event * k)
 		if (k->state == KEY_RELEASE)
 			return 1;
 		song_toggle_channel_mute(selected_channel - 1);
-		if (selected_channel < 64)
+		if (selected_channel < MAX_CHANNELS)
 			selected_channel++;
 		orderpan_recheck_muted_channels();
 		break;
@@ -1193,7 +1193,7 @@ static int info_page_handle_key(struct key_event * k)
 			windows[selected_window + 1].height--;
 			break;
 		}
-		if (selected_channel < 64)
+		if (selected_channel < MAX_CHANNELS)
 			selected_channel++;
 		break;
 	case SCHISM_KEYSYM_RIGHT:
@@ -1201,7 +1201,7 @@ static int info_page_handle_key(struct key_event * k)
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (selected_channel < 64)
+		if (selected_channel < MAX_CHANNELS)
 			selected_channel++;
 		break;
 	case SCHISM_KEYSYM_HOME:


### PR DESCRIPTION
This PR replaces every instance of 64 I could find with `MAX_CHANNELS`:
- Pertinent 64 literals are `MAX_CHANNELS`.
- Literals that were 63 or 65 by reference to channel counts are `MAX_CHANNELS - 1` or `MAX_CHANNELS + 1`, respectively.
- The code recognizes that the .IT file format has a hardcoded number of channels too, and because the code assumes in many places that they'll be the same value, it will raise a compile-time error if `MAX_CHANNELS` and new macro `IT_CHANNELS` ever diverge.
- Similar tests ensure that if someone changes `MAX_CHANNELS` in the future, they know that .MDL file loading, the order/panning page and the multichannel settings dialog in `page_patedit.c` will need to be reworked.
