### PR TITLE
mplink: fix division by zero in song_get_pattern_offset with patterns of length 1

### DIFF
--- a/include/song.h
+++ b/include/song.h
@@ -55,7 +55,7 @@ struct audio_settings {
 		int left;
 		int right;
 	} master;
-	
+
 	int surround_effect;
 
 	unsigned int eq_freq[4];
@@ -204,7 +204,7 @@ uint8_t *song_get_orderlist(void);
 
 int song_pattern_is_empty(int p);
 
-int song_get_rows_in_pattern(int pattern);
+int song_get_max_row_number_in_pattern(int pattern);
 
 void song_pattern_resize(int pattern, int rows);
 

--- a/schism/mplink.c
+++ b/schism/mplink.c
@@ -225,16 +225,22 @@ int song_get_pattern_offset(int * n, song_note_t ** buf, int * row, int offset)
 	int tot;
 	if (song_get_mode() & MODE_PATTERN_LOOP) {
 		// just wrap around current rows
-		*row = (*row + offset) % song_get_rows_in_pattern(*n);
+		tot = song_get_rows_in_pattern(*n);
+
+		if (tot == 0) // pattern of length 1
+			*row = 0;
+		else
+			*row = (*row + offset) % tot;
+
 		return song_get_pattern(*n, buf);
 	}
 
 	tot = song_get_rows_in_pattern(*n);
 	while (offset + *row > tot) {
-		offset -= tot;
+		offset -= (tot + 1);
 		(*n)++;
 		tot = song_get_rows_in_pattern(*n);
-		if (!tot) {
+		if (tot < 0) {
 			return 0;
 		}
 	}
@@ -315,7 +321,7 @@ int song_next_order_for_pattern(int pat)
 int song_get_rows_in_pattern(int pattern)
 {
 	if (pattern > MAX_PATTERNS)
-		return 0;
+		return -1;
 	return (current_song->pattern_size[pattern] ? current_song->pattern_size[pattern] : 64) - 1;
 }
 

--- a/schism/mplink.c
+++ b/schism/mplink.c
@@ -225,7 +225,7 @@ int song_get_pattern_offset(int * n, song_note_t ** buf, int * row, int offset)
 	int tot;
 	if (song_get_mode() & MODE_PATTERN_LOOP) {
 		// just wrap around current rows
-		tot = song_get_rows_in_pattern(*n);
+		tot = song_get_max_row_number_in_pattern(*n);
 
 		if (tot == 0) // pattern of length 1
 			*row = 0;
@@ -235,11 +235,11 @@ int song_get_pattern_offset(int * n, song_note_t ** buf, int * row, int offset)
 		return song_get_pattern(*n, buf);
 	}
 
-	tot = song_get_rows_in_pattern(*n);
+	tot = song_get_max_row_number_in_pattern(*n);
 	while (offset + *row > tot) {
 		offset -= (tot + 1);
 		(*n)++;
-		tot = song_get_rows_in_pattern(*n);
+		tot = song_get_max_row_number_in_pattern(*n);
 		if (tot < 0) { // n might eventually become out of range
 			return 0;
 		}
@@ -318,7 +318,7 @@ int song_next_order_for_pattern(int pat)
 }
 
 
-int song_get_rows_in_pattern(int pattern)
+int song_get_max_row_number_in_pattern(int pattern)
 {
 	if (pattern > MAX_PATTERNS)
 		return -1;

--- a/schism/mplink.c
+++ b/schism/mplink.c
@@ -240,7 +240,7 @@ int song_get_pattern_offset(int * n, song_note_t ** buf, int * row, int offset)
 		offset -= (tot + 1);
 		(*n)++;
 		tot = song_get_rows_in_pattern(*n);
-		if (tot < 0) {
+		if (tot < 0) { // n might eventually become out of range
 			return 0;
 		}
 	}

--- a/schism/page.c
+++ b/schism/page.c
@@ -458,7 +458,7 @@ static int handle_key_global(struct key_event * k)
 		} else if (k->x >= 12 && k->x <= 18) {
 			if (k->y == 7) {
 				minipop_slide(get_current_row(), "Row",
-					0, song_get_rows_in_pattern(get_current_pattern()),
+					0, song_get_max_row_number_in_pattern(get_current_pattern()),
 					set_current_row, NULL, 14, 7);
 				return 1;
 			} else if (k->y == 6) {

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -2554,6 +2554,8 @@ void set_current_row(int row)
 	int total_rows = song_get_rows_in_pattern(current_pattern);
 
 	current_row = CLAMP(row, 0, total_rows);
+	if (current_row < 0) // if for whatever reason current_pattern isn't valid, total_rows will be -1
+		current_row = 0;
 	pattern_editor_reposition();
 	status.flags |= NEED_UPDATE;
 }
@@ -3609,6 +3611,9 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	int n;
 	int total_rows = song_get_rows_in_pattern(current_pattern);
 
+	if (total_rows < 0)
+		total_rows = 0;
+
 	/* hack to render this useful :) */
 	if (k->sym == SCHISM_KEYSYM_KP_9) {
 		k->sym = SCHISM_KEYSYM_F9;
@@ -3939,6 +3944,9 @@ static int pattern_editor_handle_ctrl_key(struct key_event * k)
 	int n;
 	int total_rows = song_get_rows_in_pattern(current_pattern);
 
+	if (total_rows < 0)
+		total_rows = 0;
+
 	n = numeric_key_event(k, 0);
 	if (n > -1) {
 		if (n < 0 || n >= NUM_TRACK_VIEWS)
@@ -4189,6 +4197,9 @@ static int pattern_editor_handle_key(struct key_event * k)
 	const struct track_view *track_view;
 	int np, nr, nc;
 	unsigned int basex;
+
+	if (total_rows < 0)
+		total_rows = 0;
 
 	if (k->mouse != MOUSE_NONE) {
 		if ((k->mouse == MOUSE_CLICK || k->mouse == MOUSE_DBLCLICK) && k->state == KEY_RELEASE) {
@@ -4594,6 +4605,9 @@ static int pattern_editor_handle_key_cb(struct key_event * k)
 {
 	int ret;
 	int total_rows = song_get_rows_in_pattern(current_pattern);
+
+	if (total_rows < 0)
+		total_rows = 0;
 
 	if (k->mod & SCHISM_KEYMOD_SHIFT) {
 		switch (k->sym) {


### PR DESCRIPTION
I have become aware of an obscure bug. It arises from the fact that `song_get_rows_in_pattern` is misnamed. It does not return the number of rows in the pattern, but _one less than_ than the number of rows in the pattern. It _should_ be named `song_get_max_row_number_in_pattern`. This discrepancy causes some edge cases surrounding patterns of length 1. As mentioned in comments (and in the way the code is written), currently the UI does not let you input a pattern length less than 32, but the file format and other editors support patterns of length 1.

Because the function is named incorrectly, the `song_get_pattern_offset` function makes incorrect assumptions about the return value:

* It assumes that it can use it as the divisor in a `%` calculation. **This crashes the process if the pattern is of length 1, if I'm not mistaken.**
* It assumes that a value of 0 means an invalid pattern number.
* It subtracts the value iteratively to move to the next pattern, but it's off by 1.

There are also several functions in `page_patedit.c` that rely on it returning 0 for invalid patterns.

This PR:
* Updates `song_get_rows_in_pattern` return -1 for an invalid pattern number instead of 0.
* Updates the call sites in `page_patedit.c` that blindly use the value for range calculations to detect -1 and explicitly use 0.
* Fixes the bugs in `song_get_pattern_offset`.