### PR TITLE
page_patedit: fix buffer overread in copy_note_to_mask

### DIFF
--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -2882,11 +2882,13 @@ static void transpose_notes(int amount)
 
 static void copy_note_to_mask(void)
 {
-	int row = current_row, num_rows;
+	int row, num_rows;
 	song_note_t *pattern, *note;
 
 	num_rows = song_get_pattern(current_pattern, &pattern);
+
 	note = pattern + 64 * current_row + current_channel - 1;
+	row = current_row;
 
 	mask_note = *note;
 
@@ -2896,7 +2898,9 @@ static void copy_note_to_mask(void)
 			row--;
 		}
 		if (mask_copy_search_mode == COPY_INST_UP_THEN_DOWN && !note->instrument) {
-			note = pattern + 64 * current_row + current_channel - 1; // Reset
+			// Reset
+			note = pattern + 64 * current_row + current_channel - 1;
+			row = current_row;
 			while (!note->instrument && row < num_rows) {
 				note += 64;
 				row++;


### PR DESCRIPTION
When `mask_copy_search_mode` is set to `COPY_INST_UP_THEN_DOWN` (as far as I can tell, this can only be done by manually putting the value 2 into the configuration file), then when `copy_note_to_mask` is activated (by pressing Return), if the upward search fails to find a note, the downward search resets the note pointer but not the row counter. As such, it is now pointing at data from the current row, but it _thinks_ it's row 0 because of the completion of the upward search. It will read potentially up to one less than the current pattern's row count past the end of the pattern data allocation.

In this PR, I also reorganized the initialization of row at the top of the function so that all assignments to `note` and `row` are paired, to visually reinforce their association.