### PR TITLE
mplink: made song_find_last_channel follow the song_ channel numbering convention

### DIFF
--- a/schism/mplink.c
+++ b/schism/mplink.c
@@ -203,16 +203,14 @@ void song_handle_channel_solo(int channel)
 	}
 }
 
-// returned channel number is ONE-based
-// (to make it easier to work with in the pattern editor and info page)
 int song_find_last_channel(void)
 {
 	int n = 64;
 
 	while (channel_states[--n])
 		if (n == 0)
-			return 64;
-	return n + 1;
+			return 63;
+	return n;
 }
 
 // ------------------------------------------------------------------------

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -1216,7 +1216,7 @@ static int info_page_handle_key(struct key_event * k)
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
-		selected_channel = song_find_last_channel();
+		selected_channel = song_find_last_channel() + 1;
 		break;
 	case SCHISM_KEYSYM_INSERT:
 		if (!NO_MODIFIER(k->mod))

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -4424,7 +4424,7 @@ static int pattern_editor_handle_key(struct key_event * k)
 	case SCHISM_KEYSYM_END:
 		if (k->state == KEY_RELEASE)
 			return 0;
-		n = song_find_last_channel();
+		n = song_find_last_channel() + 1;
 		if (current_position == 8) {
 			if (invert_home_end ? (current_row != total_rows) : (current_channel == n)) {
 				current_row = total_rows;


### PR DESCRIPTION
I get the surface-level principle of avoiding having to repeat `+ 1` in two places, but in my opinion, it is objectively terrible to have these functions be zero-based:

* `song_get_channel`
* `song_get_mix_channel`
* `song_get_mix_state`
* `song_set_channel_mute`
* `song_toggle_channel_mute`
* `song_handle_channel_solo`

...and these functions be one-based:

* `song_find_last_channel`

It's a `song_` function in the `song_` world. Consistency is more important than avoiding having to convert at the boundary. :-P