### PR TITLE
sdl3/video: fixed sdl3_video_get_logical_coordinates

### DIFF
--- a/sys/sdl3/video.c
+++ b/sys/sdl3/video.c
@@ -523,6 +523,9 @@ static void sdl3_video_get_logical_coordinates(int x, int y, int *trans_x, int *
 		float xx, yy;
 
 		sdl3_RenderCoordinatesFromWindow(video.renderer, x, y, &xx, &yy);
+
+		*trans_x = (int)xx;
+		*trans_y = (int)yy;
 	}
 }
 


### PR DESCRIPTION
Apparently, this function had the lines that actually assign the return value baleeted accidentally.