### PR TITLE
video: buffer size and NATIVE_SCREEN_WIDTH/_HEIGHT based on character columns/rows

### DIFF
--- a/include/vgamem.h
+++ b/include/vgamem.h
@@ -24,12 +24,16 @@
 #ifndef SCHISM_VGAMEM_H_
 #define SCHISM_VGAMEM_H_
 
+
 #include "headers.h"
 
 #include "charset.h"
 
-#define NATIVE_SCREEN_WIDTH     640
-#define NATIVE_SCREEN_HEIGHT    400
+#define VGAMEM_COLUMNS      80
+#define VGAMEM_ROWS         50
+
+#define NATIVE_SCREEN_WIDTH     (VGAMEM_COLUMNS * 8)
+#define NATIVE_SCREEN_HEIGHT    (VGAMEM_ROWS * 8)
 
 /* ---------------------------------------------------------------------------
  * standard crap */

--- a/include/vgamem.h
+++ b/include/vgamem.h
@@ -28,6 +28,9 @@
 
 #include "charset.h"
 
+#define NATIVE_SCREEN_WIDTH     640
+#define NATIVE_SCREEN_HEIGHT    400
+
 /* ---------------------------------------------------------------------------
  * standard crap */
 
@@ -53,7 +56,7 @@ struct vgamem_overlay {
 	/* these next ones are filled in with a call to vgamem_ovl_alloc,
 	 * (as in, they are READ ONLY) so don't edit them pl0x thx */
 	unsigned char *q; /* points inside ovl */
-	unsigned int skip; /* (640 - width) (this is stupid and needs to go away) */
+	unsigned int skip; /* (NATIVE_SCREEN_WIDTH - width) (this is stupid and needs to go away) */
 
 	int width, height; /* in pixels; signed to avoid bugs elsewhere */
 };

--- a/schism/config.c
+++ b/schism/config.c
@@ -31,6 +31,7 @@
 #include "str.h"
 #include "palettes.h"
 #include "video.h"
+#include "vgamem.h"
 
 #include "config-parser.h"
 #include "dmoz.h"
@@ -180,14 +181,14 @@ void cfg_load(void)
 # define WIDTH_DEFAULT 640
 # define HEIGHT_DEFAULT 480
 # define WANT_FIXED_DEFAULT 1
-# define WANT_FIXED_WIDTH_DEFAULT 640
-# define WANT_FIXED_HEIGHT_DEFAULT 400
+# define WANT_FIXED_WIDTH_DEFAULT NATIVE_SCREEN_WIDTH
+# define WANT_FIXED_HEIGHT_DEFAULT NATIVE_SCREEN_HEIGHT
 #else
-# define WIDTH_DEFAULT 640
-# define HEIGHT_DEFAULT 400
+# define WIDTH_DEFAULT NATIVE_SCREEN_WIDTH
+# define HEIGHT_DEFAULT NATIVE_SCREEN_HEIGHT
 # define WANT_FIXED_DEFAULT 0
-# define WANT_FIXED_WIDTH_DEFAULT (640 * 5)
-# define WANT_FIXED_HEIGHT_DEFAULT (400 * 6)
+# define WANT_FIXED_WIDTH_DEFAULT (WIDTH_DEFAULT * 5)
+# define WANT_FIXED_HEIGHT_DEFAULT (HEIGHT_DEFAULT * 6)
 #endif
 
 	cfg_get_string(&cfg, "Video", "format", cfg_video_format, ARRAY_SIZE(cfg_video_format) - 1, "");

--- a/schism/main.c
+++ b/schism/main.c
@@ -53,6 +53,7 @@
 #include "timer.h"
 #include "mt.h"
 #include "mem.h"
+#include "vgamem.h"
 
 #include "osdefs.h"
 
@@ -63,9 +64,6 @@
 #if !defined(__amigaos4__) && !defined(SCHISM_WII)
 # define ENABLE_HOOKS 1
 #endif
-
-#define NATIVE_SCREEN_WIDTH     640
-#define NATIVE_SCREEN_HEIGHT    400
 
 /* --------------------------------------------------------------------- */
 /* globals */

--- a/schism/main.c
+++ b/schism/main.c
@@ -365,8 +365,8 @@ static void key_event_reset(struct key_event *kk, int start_x, int start_y)
 	kk->midi_volume = -1;
 	kk->midi_note = -1;
 	/* X/Y resolution */
-	kk->rx = NATIVE_SCREEN_WIDTH / 80;
-	kk->ry = NATIVE_SCREEN_HEIGHT / 50;
+	kk->rx = NATIVE_SCREEN_WIDTH / VGAMEM_COLUMNS;
+	kk->ry = NATIVE_SCREEN_HEIGHT / VGAMEM_ROWS;
 	/* preserve the start position */
 	kk->sx = start_x;
 	kk->sy = start_y;

--- a/schism/page.c
+++ b/schism/page.c
@@ -193,10 +193,10 @@ static void draw_page_title(void)
 		draw_char(0, tpos - 1, 11, 1, 2);
 		draw_text(ACTIVE_PAGE.title, tpos, 11, 0, 2);
 		draw_char(0, tpos + tlen, 11, 1, 2);
-		for (x = tpos + tlen + 1; x < 79; x++)
+		for (x = tpos + tlen + 1; x < (VGAMEM_COLUMNS - 1); x++)
 			draw_char(154, x, 11, 1, 2);
 	} else {
-		for (x = 1; x < 79; x++)
+		for (x = 1; x < (VGAMEM_COLUMNS - 1); x++)
 			draw_char(154, x, 11, 1, 2);
 	}
 }

--- a/schism/page.c
+++ b/schism/page.c
@@ -387,7 +387,7 @@ static void minipop_slide(int cv, const char *name, int min, int max,
 	/* warp mouse to position of slider knob */
 	if (max == 0) max = 1; /* prevent division by zero */
 	video_warp_mouse(
-		video_width()*((midx - 8)*8 + (cv - min)*96.0/(max - min) + 1)/640,
+		video_width()*((midx - 8)*8 + (cv - min)*96.0/(max - min) + 1)/NATIVE_SCREEN_WIDTH,
 		video_height()*midy*8/400.0 + 4);
 
 	_mp_active = 1;

--- a/schism/page_help.c
+++ b/schism/page_help.c
@@ -112,7 +112,7 @@ static void help_redraw(void)
 	draw_fill_chars(2, 13, 77, 44, DEFAULT_FG, 0);
 
 	ptr = lines + top_line;
-	for (pos = 13, n = top_line; pos < 45; pos++, n++) {
+	for (pos = 13, n = top_line; pos < (VGAMEM_ROWS - 5); pos++, n++) {
 		switch (**ptr) {
 		default:
 			lp = strcspn(*ptr+1, "\015\012");
@@ -132,7 +132,7 @@ static void help_redraw(void)
 			}
 			break;
 		case LTYPE_SEPARATOR:
-			for (x = 2; x < 78; x++)
+			for (x = 2; x < (VGAMEM_COLUMNS - 2); x++)
 				draw_char(154, x, pos, 6, 0);
 			break;
 		}

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -710,7 +710,7 @@ static void info_draw_note_dots(int base, int height, int active, int first_chan
 	}
 
 	for (c = first_channel, pos = 0; pos < height - 2; pos++, c++) {
-		for (n = 0; n < 73; n++) {
+		for (n = 0; n < (VGAMEM_COLUMNS - 7); n++) {
 			d = dot_field[n][pos] ? dot_field[n][pos] : 0x06;
 
 			fg = d & 0xf;

--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -575,7 +575,7 @@ static void file_list_draw(void)
 	if (flist.num_files > 0) {
 		if (top_file < 0) top_file = 0;
 		if (current_file < 0) current_file = 0;
-		for (n = top_file, pos = 13; n < flist.num_files && pos < 44; n++, pos++) {
+		for (n = top_file, pos = 13; n < flist.num_files && pos < (VGAMEM_ROWS - 6); n++, pos++) {
 			file = flist.files[n];
 
 			if (n == current_file && ACTIVE_PAGE.selected_widget == 0) {

--- a/schism/page_timeinfo.c
+++ b/schism/page_timeinfo.c
@@ -180,7 +180,7 @@ static void timeinfo_redraw(void)
 	draw_time(total_secs, 18, 16);
 
 	// draw the bar
-	for (int x = 1; x < 79; x++)
+	for (int x = 1; x < (VGAMEM_COLUMNS - 1); x++)
 		draw_char(154, x, 18, 0, 2);
 
 	if (display_session) {

--- a/schism/page_vars.c
+++ b/schism/page_vars.c
@@ -77,7 +77,7 @@ static void song_vars_draw_const(void)
 	draw_text("Sample", 6, 43, 0, 2);
 	draw_text("Instrument", 2, 44, 0, 2);
 
-	for (n = 1; n < 79; n++)
+	for (n = 1; n < (VGAMEM_COLUMNS - 1); n++)
 		draw_char(129, n, 39, 1, 2);
 }
 

--- a/schism/page_waterfall.c
+++ b/schism/page_waterfall.c
@@ -29,8 +29,6 @@
 #include "widget.h"
 #include "vgamem.h"
 
-#define NATIVE_SCREEN_WIDTH     640
-#define NATIVE_SCREEN_HEIGHT    400
 #define SCOPE_ROWS      32
 
 /* This value is used internally to scale the power output of the FFT to decibels. */

--- a/schism/vgamem.c
+++ b/schism/vgamem.c
@@ -142,7 +142,7 @@ static inline SCHISM_ALWAYS_INLINE int vgamem_unpack_halfw(int c)
 static uint32_t vgamem[4000] = {0};
 static uint32_t vgamem_read[4000] = {0};
 
-static uint8_t ovl[640*400] = {0}; /* 256K */
+static uint8_t ovl[NATIVE_SCREEN_WIDTH*NATIVE_SCREEN_HEIGHT] = {0}; /* 256K */
 
 #define CHECK_INVERT(tl,br,n) \
 do {                                            \
@@ -165,10 +165,10 @@ void vgamem_clear(void)
 
 void vgamem_ovl_alloc(struct vgamem_overlay *n)
 {
-	n->q = &ovl[ (n->x1*8) + (n->y1 * 5120) ];
+	n->q = &ovl[ (n->x1*8) + (n->y1 * 8 * NATIVE_SCREEN_WIDTH) ];
 	n->width = 8 * ((n->x2 - n->x1) + 1);
 	n->height = 8 * ((n->y2 - n->y1) + 1);
-	n->skip = (640 - n->width);
+	n->skip = (NATIVE_SCREEN_WIDTH - n->width);
 }
 
 void vgamem_ovl_apply(struct vgamem_overlay *n)
@@ -195,7 +195,7 @@ void vgamem_ovl_clear(struct vgamem_overlay *n, int color)
 
 void vgamem_ovl_drawpixel(struct vgamem_overlay *n, int x, int y, int color)
 {
-	n->q[ (640*y) + x ] = color;
+	n->q[ (NATIVE_SCREEN_WIDTH*y) + x ] = color;
 }
 
 static inline void _draw_line_v(struct vgamem_overlay *n, int x,
@@ -205,16 +205,16 @@ static inline void _draw_line_v(struct vgamem_overlay *n, int x,
 	int y;
 
 	if (ys < ye) {
-		q += (ys * 640);
+		q += (ys * NATIVE_SCREEN_WIDTH);
 		for (y = ys; y <= ye; y++) {
 			*q = color;
-			q += 640;
+			q += NATIVE_SCREEN_WIDTH;
 		}
 	} else {
-		q += (ye * 640);
+		q += (ye * NATIVE_SCREEN_WIDTH);
 		for (y = ye; y <= ys; y++) {
 			*q = color;
-			q += 640;
+			q += NATIVE_SCREEN_WIDTH;
 		}
 	}
 }
@@ -222,7 +222,7 @@ static inline void _draw_line_v(struct vgamem_overlay *n, int x,
 static inline void _draw_line_h(struct vgamem_overlay *n, int xs,
 	int xe, int y, int color)
 {
-	unsigned char *q = n->q + (y * 640);
+	unsigned char *q = n->q + (y * NATIVE_SCREEN_WIDTH);
 	int x;
 	if (xs < xe) {
 		q += xs;
@@ -330,7 +330,7 @@ static const uint8_t uFFFD[] = {
 	{ \
 		/* constants */ \
 		const uint_fast32_t y = (ry >> 3), yl = (ry & 7); \
-		const uint8_t *q = ovl + (ry * 640); \
+		const uint8_t *q = ovl + (ry * NATIVE_SCREEN_WIDTH); \
 		const uint8_t *const itf = font_data + yl, \
 			*const bios = font_default_upper_alt + yl, \
 			*const bioslow = font_default_lower + yl, \
@@ -768,7 +768,7 @@ void draw_vu_meter(int x, int y, int width, int val, int color, int peak)
 
 /* --------------------------------------------------------------------- */
 /* sample drawing
- * 
+ *
  * output channels = number of oscis
  * input channels = number of channels in data
 */

--- a/schism/vgamem.c
+++ b/schism/vgamem.c
@@ -139,8 +139,10 @@ static inline SCHISM_ALWAYS_INLINE int vgamem_unpack_halfw(int c)
 
 /* ------------------------------------------------------------------------ */
 
-static uint32_t vgamem[4000] = {0};
-static uint32_t vgamem_read[4000] = {0};
+#define VGAMEM_CHAR_COUNT (VGAMEM_COLUMNS * VGAMEM_ROWS)
+
+static uint32_t vgamem[VGAMEM_CHAR_COUNT] = {0};
+static uint32_t vgamem_read[VGAMEM_CHAR_COUNT] = {0};
 
 static uint8_t ovl[NATIVE_SCREEN_WIDTH*NATIVE_SCREEN_HEIGHT] = {0}; /* 256K */
 
@@ -177,7 +179,7 @@ void vgamem_ovl_apply(struct vgamem_overlay *n)
 
 	for (y = n->y1; y <= n->y2; y++)
 		for (x = n->x1; x <= n->x2; x++)
-			vgamem[x + (y*80)] = VGAMEM_FONT_OVERLAY;
+			vgamem[x + (y*VGAMEM_COLUMNS)] = VGAMEM_FONT_OVERLAY;
 }
 
 void vgamem_ovl_clear(struct vgamem_overlay *n, int color)
@@ -326,7 +328,7 @@ static const uint8_t uFFFD[] = {
  * anyway. I have yet to put it to the test :) */
 #define VGAMEM_SCANNER_VARIANT(BITS) \
 	void vgamem_scan##BITS(uint32_t ry, uint##BITS##_t *out, uint32_t tc[16],\
-		uint32_t mouseline[80], uint32_t mouseline_mask[80]) \
+		uint32_t mouseline[VGAMEM_COLUMNS], uint32_t mouseline_mask[VGAMEM_COLUMNS]) \
 	{ \
 		/* constants */ \
 		const uint_fast32_t y = (ry >> 3), yl = (ry & 7); \
@@ -339,10 +341,10 @@ static const uint8_t uFFFD[] = {
 			*const extlatin = font_extended_latin + yl, \
 			*const greek = font_greek + yl, \
 			*const cp866 = font_cp866 + yl; \
-		const uint32_t *bp = &vgamem_read[y * 80]; \
+		const uint32_t *bp = &vgamem_read[y * VGAMEM_COLUMNS]; \
 	\
 		uint_fast32_t x; \
-		for (x = 0; x < 80; x++, bp++, q += 8) { \
+		for (x = 0; x < VGAMEM_COLUMNS; x++, bp++, q += 8) { \
 			uint_fast8_t fg, bg, fg2, bg2, dg; \
 	\
 			if (*bp & VGAMEM_FONT_HALFWIDTH) { \
@@ -446,9 +448,9 @@ VGAMEM_SCANNER_VARIANT(32)
 
 void draw_char_unicode(uint32_t c, int x, int y, uint32_t fg, uint32_t bg)
 {
-	SCHISM_RUNTIME_ASSERT(x >= 0 && y >= 0 && x < 80 && y < 50, "Coordinates should always be inbounds");
+	SCHISM_RUNTIME_ASSERT(x >= 0 && y >= 0 && x < VGAMEM_COLUMNS && y < VGAMEM_ROWS, "Coordinates should always be inbounds");
 
-	vgamem[x + (y*80)] = (VGAMEM_FONT_UNICODE
+	vgamem[x + (y*VGAMEM_COLUMNS)] = (VGAMEM_FONT_UNICODE
 		| (fg << VGAMEM_UNICODE_FG_BIT)
 		| (bg << VGAMEM_UNICODE_BG_BIT)
 		| c);
@@ -456,9 +458,9 @@ void draw_char_unicode(uint32_t c, int x, int y, uint32_t fg, uint32_t bg)
 
 void draw_char_bios(uint8_t c, int x, int y, uint32_t fg, uint32_t bg)
 {
-	SCHISM_RUNTIME_ASSERT(x >= 0 && y >= 0 && x < 80 && y < 50, "Coordinates should always be inbounds");
+	SCHISM_RUNTIME_ASSERT(x >= 0 && y >= 0 && x < VGAMEM_COLUMNS && y < VGAMEM_ROWS, "Coordinates should always be inbounds");
 
-	vgamem[x + (y*80)] = (VGAMEM_FONT_BIOS
+	vgamem[x + (y*VGAMEM_COLUMNS)] = (VGAMEM_FONT_BIOS
 		| (fg << VGAMEM_FG_BIT)
 		| (bg << VGAMEM_BG_BIT)
 		| c);
@@ -466,9 +468,9 @@ void draw_char_bios(uint8_t c, int x, int y, uint32_t fg, uint32_t bg)
 
 void draw_char(uint8_t c, int x, int y, uint32_t fg, uint32_t bg)
 {
-	SCHISM_RUNTIME_ASSERT(x >= 0 && y >= 0 && x < 80 && y < 50, "Coordinates should always be inbounds");
+	SCHISM_RUNTIME_ASSERT(x >= 0 && y >= 0 && x < VGAMEM_COLUMNS && y < VGAMEM_ROWS, "Coordinates should always be inbounds");
 
-	vgamem[x + (y*80)] = ((fg << VGAMEM_FG_BIT) | (bg << VGAMEM_BG_BIT) | c);
+	vgamem[x + (y*VGAMEM_COLUMNS)] = ((fg << VGAMEM_FG_BIT) | (bg << VGAMEM_BG_BIT) | c);
 }
 
 int draw_text(const char * text, int x, int y, uint32_t fg, uint32_t bg)
@@ -531,13 +533,13 @@ void draw_fill_chars(int xs, int ys, int xe, int ye, uint32_t fg, uint32_t bg)
 	uint32_t *mm;
 	int x, len;
 
-	mm = &vgamem[(ys * 80) + xs];
+	mm = &vgamem[(ys * VGAMEM_COLUMNS) + xs];
 	len = (xe - xs)+1;
 	ye -= ys;
 	do {
 		for (x = 0; x < len; x++)
 			mm[x] = (fg << VGAMEM_FG_BIT) | (bg << VGAMEM_BG_BIT);
-		mm += 80;
+		mm += VGAMEM_COLUMNS;
 		ye--;
 	} while (ye >= 0);
 }
@@ -603,10 +605,10 @@ int draw_text_utf8_len(const char * text, int len, int x, int y, uint32_t fg, ui
 void draw_half_width_chars(uint8_t c1, uint8_t c2, int x, int y,
 			   uint32_t fg1, uint32_t bg1, uint32_t fg2, uint32_t bg2)
 {
-	SCHISM_RUNTIME_ASSERT(x >= 0 && y >= 0 && x < 80 && y < 50, "Coordinates should always be inbounds");
+	SCHISM_RUNTIME_ASSERT(x >= 0 && y >= 0 && x < VGAMEM_COLUMNS && y < VGAMEM_ROWS, "Coordinates should always be inbounds");
 
 
-	vgamem[x + (y*80)] = (VGAMEM_FONT_HALFWIDTH
+	vgamem[x + (y*VGAMEM_COLUMNS)] = (VGAMEM_FONT_HALFWIDTH
 		| (fg1 << VGAMEM_HW_FG1_BIT)
 		| (fg2 << VGAMEM_HW_FG2_BIT)
 		| (bg1 << VGAMEM_HW_BG1_BIT)

--- a/schism/video.c
+++ b/schism/video.c
@@ -20,8 +20,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-#define NATIVE_SCREEN_WIDTH		640
-#define NATIVE_SCREEN_HEIGHT	400
 #define WINDOW_TITLE			"Schism Tracker"
 
 #include "headers.h"

--- a/schism/video.c
+++ b/schism/video.c
@@ -262,7 +262,7 @@ static inline void make_mouseline(unsigned int x, unsigned int v, unsigned int y
 
 	// and to the right
 	temp = swidth - scenter + 1;
-	for (i = 1; (i <= temp) && (x + i < 80); i++) {
+	for (i = 1; (i <= temp) && (x + i < VGAMEM_COLUMNS); i++) {
 		mouseline[x+i]      = z  >> (8 * (swidth - scenter + 1 - i)) & 0xff;
 		mouseline_mask[x+i] = zm >> (8 * (swidth - scenter + 1 - i)) & 0xff;
 	}

--- a/sys/sdl12/video.c
+++ b/sys/sdl12/video.c
@@ -20,8 +20,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-#define NATIVE_SCREEN_WIDTH             640
-#define NATIVE_SCREEN_HEIGHT            400
 
 /* should be the native res of the display (set once and never again)
  * assumes the user starts schism from the desktop and that the desktop
@@ -317,7 +315,7 @@ static int sdl12_video_startup(void)
 #endif
 	if (!video.surface) {
 		/* if we already got one... */
-		video.surface = sdl12_SetVideoMode(640, 400, 0, SDL_RESIZABLE);
+		video.surface = sdl12_SetVideoMode(NATIVE_SCREEN_WIDTH, NATIVE_SCREEN_HEIGHT, 0, SDL_RESIZABLE);
 		if (!video.surface) {
 			// ok
 			perror("SDL_SetVideoMode");

--- a/sys/sdl2/video.c
+++ b/sys/sdl2/video.c
@@ -23,8 +23,6 @@
 
 #include "init.h"
 
-#define NATIVE_SCREEN_WIDTH		640
-#define NATIVE_SCREEN_HEIGHT	400
 #define WINDOW_TITLE			"Schism Tracker"
 
 #include "headers.h"

--- a/sys/sdl3/video.c
+++ b/sys/sdl3/video.c
@@ -21,8 +21,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#define NATIVE_SCREEN_WIDTH		640
-#define NATIVE_SCREEN_HEIGHT	400
 #define WINDOW_TITLE			"Schism Tracker"
 
 #include "headers.h"


### PR DESCRIPTION
I noticed that `NATIVE_SCREEN_WIDTH` and `NATIVE_SCREEN_HEIGHT` were being redefined locally in a bunch of different places, always with the same values. This PR:

* Introduces macros `VGA_CHAR_WIDTH` and `VGA_CHAR_HEIGHT` that act as source of truth for the resolution of the text buffer.
* Consolidates macro definitions for `NATIVE_SCREEN_WIDTH` and `NATIVE_SCREEN_HEIGHT` into `vgamem.h` and redefines them to be based on `VGA_CHAR_WIDTH` and `VGA_CHAR_HEIGHT`.
* Updates all hardcoded 640x400 width/height references I could find to use `NATIVE_SCREEN_WIDTH` and `NATIVE_SCREEN_HEIGHT` instead.
* Updates a number of references to the text buffer's width and height to use `VGA_CHAR_WIDTH` and `VGA_CHAR_HEIGHT`. Updating everything comprehensively is a broader project that involves evaluating whether various UI elements are anchored to top/left or bottom/right.

