### PR TITLE
dmoz: fix error in comment

### DIFF
--- a/schism/dmoz.c
+++ b/schism/dmoz.c
@@ -1624,7 +1624,7 @@ static int qsort_cmp_file(const void *_a, const void *_b)
 	const dmoz_file_t *b = *(const dmoz_file_t **) _b;
 
 	if ((b->type & TYPE_HIDDEN) && !(a->type & TYPE_HIDDEN))
-		return -1; /* b goes first */
+		return -1; /* a goes first */
 	if ((a->type & TYPE_HIDDEN) && !(b->type & TYPE_HIDDEN))
 		return 1; /* b goes first */
 	if (a->sort_order < b->sort_order)


### PR DESCRIPTION
The `qsort_cmp_file` function has comments explaining its return values. One of them is wrong and caused me to furrow my eyebrows and scratch my head for half a minute.