### PR TITLE
midi-core: improve maintainability and resiliency

### DIFF
--- a/include/midi.h
+++ b/include/midi.h
@@ -120,6 +120,7 @@ int midi_need_flush(void);
 union schism_event;
 int midi_engine_handle_event(union schism_event *ev);
 
+/* index != midi_port.num */
 struct midi_port *midi_engine_port(uint32_t n, const char **name);
 uint32_t midi_engine_port_count(void);
 void midi_engine_port_lock(void);

--- a/schism/midi-core.c
+++ b/schism/midi-core.c
@@ -391,6 +391,7 @@ uint32_t midi_engine_port_count(void)
 	if (!midi_port_mutex) return 0;
 
 	mt_mutex_lock(midi_port_mutex);
+	// if ports have been unregistered, some array entries might be NULL
 	for (i = 0, pc = 0; i < port_alloc; i++)
 		if (port_top[i])
 			pc++;


### PR DESCRIPTION
This PR polishes the fixes in c87fca5:

* Comments are added so that future programmers understand how the sparse array structure is being used.
* `midi_engine_port` is updated to leverage `midi_port_foreach` instead of reimplementing the sparse array traversal.
* `midi_port_register` is updated to acquire and hold the `midi_port_mutex` lock for the duration of its interaction with the structure, instead of only during the update phase
* `midi_port_unregister` is made resilient to callers accidentally passing in `num` values that aren't allocated (and are thus `NULL`)
* `midi_port_unregister` is updated to walk back `port_count` when the tail is `NULL` pointers.

This PR doesn't do it but `midi_port_unregister` could be updated in the future to, after an appropriate threshold is reached, reallocate the array to make it smaller. Probably not really necessary, because even if the array increases to thousands of elements, it's sharing a heap with samples that have potentially megabyte-sized allocations :-) But it _could_ be done.