### PR TITLE
config.h: removed import of non-existent and unreferenced symbol cfg_palette

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -44,7 +44,6 @@ extern int cfg_kbd_repeat_rate;
 extern char cfg_dir_modules[SCHISM_PATH_MAX + 1], cfg_dir_samples[SCHISM_PATH_MAX + 1], cfg_dir_instruments[SCHISM_PATH_MAX + 1];
 extern char *cfg_dir_dotschism; /* the full path to ~/.schism */
 extern char *cfg_font;
-extern int cfg_palette;
 
 extern int cfg_str_date_format;
 extern int cfg_str_time_format;


### PR DESCRIPTION
At one point, there was presumably a symbol called `cfg_palette`. Including `config.h` creates an import for it. But, no such symbol is defined or used anywhere.