### PR TITLE
page_loadsample: fix volumes

### DIFF
--- a/schism/page_loadsample.c
+++ b/schism/page_loadsample.c
@@ -159,7 +159,7 @@ static void file_list_reposition(void)
 
 		widgets_loadsample[7].d.numentry.value = f ? f->smp_sustain_start : 0;
 		widgets_loadsample[8].d.numentry.value = f ? f->smp_sustain_end : 0;
-		widgets_loadsample[9].d.thumbbar.value = f ? f->smp_defvol : 64;
+		widgets_loadsample[9].d.thumbbar.value = f ? CLAMP(f->smp_defvol >> 2, 0, 64) : 64;
 		widgets_loadsample[10].d.thumbbar.value = f ? f->smp_gblvol : 64;
 		widgets_loadsample[11].d.thumbbar.value = f ? f->smp_vibrato_speed : 0;
 		widgets_loadsample[12].d.thumbbar.value = f ? f->smp_vibrato_depth : 0;
@@ -853,11 +853,15 @@ static void handle_load_copy(song_sample_t *s)
 	handle_load_copy_uint(widgets_loadsample[5].d.numentry.value, &s->loop_end);
 	handle_load_copy_uint(widgets_loadsample[7].d.numentry.value, &s->sustain_start);
 	handle_load_copy_uint(widgets_loadsample[8].d.numentry.value, &s->sustain_end);
-	handle_load_copy_uint(widgets_loadsample[9].d.thumbbar.value, &s->volume);
-	if ((unsigned int)widgets_loadsample[9].d.thumbbar.value == (s->volume>>2)) {
+
+	// s->volume is 0..256, Impulse Tracker's UI is 0..64
+	// we only push the value back to the song_sample_t if
+	// it's not what the existing value would convert to
+	if ((s->volume >> 2) != widgets_loadsample[9].d.numentry.value) {
 		s->volume = (widgets_loadsample[9].d.thumbbar.value << 2);
 		fake_slot_changed=1;
 	}
+
 	handle_load_copy_uint(widgets_loadsample[10].d.thumbbar.value, &s->global_volume);
 	handle_load_copy_uint(widgets_loadsample[11].d.thumbbar.value, &s->vib_rate);
 	handle_load_copy_uint(widgets_loadsample[12].d.thumbbar.value, &s->vib_depth);


### PR DESCRIPTION
The code that handles both Load Sample and Sample Library, `page_loadsample`, preloads samples by temporarily hijacking a "fake" sample slot in the current song. In the code that translates between this "fake slot" sample and the UI, the volume isn't translated correctly. The OpenMPT-universe volume value of 0..256 is copied directly into the UI that is set up for the Impulse Tracker range of 0..64.

This PR fixes translation on both ends:

* In `file_list_reposition`, it is scaled to 0..64 (and clamped, just in case).
* In `handle_load_copy`, the existing code that @sagamusix identified as having the right intentions but a bug in the condition is made into the way that 0..64 value gets scaled back to 0..256 for assignment into the `song_sample_t`. (It was just calling the generic `handle_load_copy_uint` helper function, and while it also had code to translate properly, that code wasn't active because the `if` condition was accidentally inverted.)