### PR TITLE
page_loadinst: fix status flag checked in _common_set_page

### DIFF
--- a/schism/page_loadinst.c
+++ b/schism/page_loadinst.c
@@ -169,7 +169,7 @@ static void _common_set_page(void)
 
 	/* if we have a list, the directory didn't change, and the mtime is the same, we're set */
 	if (flist.num_files > 0
-	    && (status.flags & DIR_SAMPLES_CHANGED) == 0
+	    && (status.flags & DIR_INSTRUMENTS_CHANGED) == 0
 		&& os_stat(inst_cwd, &st) == 0
 	    && st.st_mtime == directory_mtime) {
 		return;


### PR DESCRIPTION
In `page_loadsample`, the `_common_set_page` function checks for `DIR_SAMPLES_CHANGED`, and then clears `DIR_SAMPLES_CHANGED` before returning.

In `page_loadinst`, which is a very similar page to `loadsample`, the `_common_set_page` function looks like it was copy/pasted from `page_loadsample` and then updated to work with instruments instead -- except that the flag check wasn't changed, so even though before returning it clears the flag `DIR_INSTRUMENTS_CHANGED`, it's still checking for `DIR_SAMPLES_CHANGED` to determine whether an update is needed.

This PR fixes it.