### PR TITLE
audio_loadsave: fix range check in song_load_instrument_ex

### DIFF
--- a/schism/audio_loadsave.c
+++ b/schism/audio_loadsave.c
@@ -702,7 +702,7 @@ int song_load_instrument_ex(int target, const char *file, const char *libf, int 
 		for (unsigned int j = 0; j < 128; j++) {
 			x = xl->instruments[n]->sample_map[j];
 			if (!sampmap[x]) {
-				if (x > 0 && x < MAX_INSTRUMENTS) {
+				if (x > 0 && x < MAX_SAMPLES) {
 					for (int k = 1; k < MAX_SAMPLES; k++) {
 						if (current_song->samples[k].length) continue;
 						sampmap[x] = k;


### PR DESCRIPTION
In `song_load_instrument_ex`, there's some code that retrieves a value from `sampmap` and then verifies that it is correct. It does this by performing a range check, but it compares the sample number with `MAX_INSTRUMENTS` instead of `MAX_SAMPLES`. `MAX_INSTRUMENTS` happens to have the same value as `MAX_SAMPLES`, but it's the wrong macro. It is technically incorrect -- the best kind of incorrect.