### PR TITLE
mplink: remove unused function

### DIFF
--- a/include/song.h
+++ b/include/song.h
@@ -225,7 +225,6 @@ int song_is_stereo(void);
 void song_set_stereo(void);
 void song_set_mono(void);
 void song_toggle_stereo(void);
-void song_toggle_mono(void);
 
 /* called from song_set_stereo et al - this updates the value on F12 to match the song */
 void song_vars_sync_stereo(void);

--- a/schism/mplink.c
+++ b/schism/mplink.c
@@ -383,11 +383,6 @@ void song_toggle_stereo(void)
 	current_song->flags ^= SONG_NOSTEREO;
 	song_vars_sync_stereo();
 }
-void song_toggle_mono(void)
-{
-	current_song->flags ^= SONG_NOSTEREO;
-	song_vars_sync_stereo();
-}
 void song_set_mono(void)
 {
 	current_song->flags |= SONG_NOSTEREO;


### PR DESCRIPTION
There is a function `song_toggle_stereo` that flips the `SONG_NOSTEREO` flag state. It is used in a couple of places.

There is also a function `song_toggle_mono` that flips the `SONG_NOSTEREO` flag state. It is not used anywhere. :-)