### PR TITLE
page_info: fix return value from info_page_handle_key

### DIFF
--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -1032,14 +1032,16 @@ static int info_page_handle_key(struct key_event * k)
 				set_current_channel(selected_channel);
 				order = song_get_current_order();
 
+				int currently_playing_pattern_number;
+
 				if (song_get_mode() == MODE_PLAYING) {
-					n = current_song->orderlist[order];
+					currently_playing_pattern_number = current_song->orderlist[order];
 				} else {
-					n = song_get_playing_pattern();
+					currently_playing_pattern_number = song_get_playing_pattern();
 				}
-				if (n < 200) {
+				if (currently_playing_pattern_number < 200) {
 					set_current_order(order);
-					set_current_pattern(n);
+					set_current_pattern(currently_playing_pattern_number);
 					set_current_row(song_get_current_row());
 					set_page(PAGE_PATTERN_EDITOR);
 				}


### PR DESCRIPTION
When `info_page_handle_key` in `page_info.c` receives a mouse event, it checks whether it is of type `MOUSE_CLICK` or `MOUSE_DBLCLICK`. If so, then it calls `info_handle_click`, which passes it off in turn to the info window-specific handlers. The ultimate effect this can have is to switch which channel is selected based on the click location. As is the custom, `info_handle_click` returns true (`1`) to consume a recognized mouse click event, false (`0`) otherwise, and `info_page_handle_key` takes this return value and passes it back up the call stack.

Except if the click is of type `MOUSE_DBLCLICK`, because then it runs a bit of extra code that switches to the pattern editor and jumps to the exact pattern/row that is playing at the time. But, the code that does this reuses the local variable in which `info_page_handle_key` stored the true/false return value from `info_handle_click` and stashes the pattern number in there. That becomes the return value from `info_page_handle_key`.

As far as I can ascertain, the effect of this is that if the current pattern is anything other than 0, then it is _effectively_ still returning a true value, since true is _any_ non-zero value, while if the current pattern is 0, then it switches the return value to false (`0`) and the caller isn't notified that the mouse event was consumed. I haven't checked what, if any, effect this has, but I'm pretty sure it's wrong :-)

This PR introduces a new local variable for the pattern number value in the `MOUSE_DBLCLICK` path so that `n`, propagating the return value from `info_handle_click`, is not clobbered.