### PR TITLE
everywhere: use MAX_PATTERNS instead of hardcoded constant

### DIFF
--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -900,7 +900,7 @@ void song_start_at_order(int order, int row)
 
 void song_start_at_pattern(int pattern, int row)
 {
-	if (pattern < 0 || pattern > 199)
+	if (pattern < 0 || pattern > MAX_PATTERNS - 1)
 		return;
 
 	int n = song_next_order_for_pattern(pattern);

--- a/schism/page.c
+++ b/schism/page.c
@@ -1663,7 +1663,7 @@ void main_song_changed_cb(void)
 	/* perhaps this should be in page_patedit.c? */
 	set_current_order(0);
 	n = current_song->orderlist[0];
-	if (n > 199)
+	if (n > MAX_PATTERNS - 1)
 		n = 0;
 	set_current_pattern(n);
 	set_current_row(0);
@@ -1802,7 +1802,7 @@ static void _timejump_ok(void)
 	song_get_at_time(sec, &no, &nr);
 	set_current_order(no);
 	np = current_song->orderlist[no];
-	if (np < 200) {
+	if (np < MAX_PATTERNS) {
 		set_current_pattern(np);
 		set_current_row(nr);
 		set_page(PAGE_PATTERN_EDITOR);

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -402,7 +402,7 @@ static void _draw_track_view(int base, int height, int first_channel, int num_ch
 		prev_pattern = next_pattern = cur_pattern;
 		break;
 	case MODE_PLAYING:
-		if (current_song->orderlist[current_order] >= 200) {
+		if (current_song->orderlist[current_order] >= MAX_PATTERNS) {
 			/* this does, in fact, happen. just pretend that
 			 * it's stopped :P */
 	default:
@@ -412,12 +412,12 @@ static void _draw_track_view(int base, int height, int first_channel, int num_ch
 			return;
 		}
 		cur_pattern_rows = song_get_pattern(current_song->orderlist[current_order], &cur_pattern);
-		if (current_order > 0 && current_song->orderlist[current_order - 1] < 200)
+		if (current_order > 0 && current_song->orderlist[current_order - 1] < MAX_PATTERNS)
 			prev_pattern_rows = song_get_pattern(current_song->orderlist[current_order - 1],
 								&prev_pattern);
 		else
 			prev_pattern = NULL;
-		if (current_order < 255 && current_song->orderlist[current_order + 1] < 200)
+		if (current_order < 255 && current_song->orderlist[current_order + 1] < MAX_PATTERNS)
 			next_pattern_rows = song_get_pattern(current_song->orderlist[current_order + 1],
 								&next_pattern);
 		else
@@ -1073,7 +1073,7 @@ static int info_page_handle_key(struct key_event * k)
 		} else {
 			n = song_get_playing_pattern();
 		}
-		if (n < 200) {
+		if (n < MAX_PATTERNS) {
 			set_current_order(order);
 			set_current_pattern(n);
 			set_current_row(song_get_current_row());

--- a/schism/page_orderpan.c
+++ b/schism/page_orderpan.c
@@ -98,7 +98,7 @@ void prev_order_pattern(void)
 			&& last_pattern == current_song->orderlist[new_order]
 			&& current_song->orderlist[new_order] == ORDER_SKIP);
 
-	if (current_song->orderlist[new_order] < 200) {
+	if (current_song->orderlist[new_order] < MAX_PATTERNS) {
 		current_order = new_order;
 		orderlist_reposition();
 		set_current_pattern(current_song->orderlist[new_order]);
@@ -119,7 +119,7 @@ void next_order_pattern(void)
 			&& last_pattern == current_song->orderlist[new_order]
 			&&  current_song->orderlist[new_order] == ORDER_SKIP);
 
-	if (current_song->orderlist[new_order] < 200) {
+	if (current_song->orderlist[new_order] < MAX_PATTERNS) {
 		current_order = new_order;
 		orderlist_reposition();
 		set_current_pattern(current_song->orderlist[new_order]);
@@ -138,7 +138,7 @@ static void orderlist_cheater(void)
 	}
 	cp = get_current_pattern();
 	best = first = -1;
-	for (i = 0; i < 199; i++) {
+	for (i = 0; i < MAX_PATTERNS - 1; i++) {
 		if (csf_pattern_is_empty(current_song, i)) {
 			if (first == -1) first = i;
 			if (best == -1) best = i;
@@ -242,11 +242,11 @@ static void orderlist_insert_next(void)
 {
 	int next_pattern;
 
-	if (current_order == 0 || current_song->orderlist[current_order - 1] > 199)
+	if (current_order == 0 || current_song->orderlist[current_order - 1] > MAX_PATTERNS - 1)
 		return;
 	next_pattern = current_song->orderlist[current_order - 1] + 1;
-	if (next_pattern > 199)
-		next_pattern = 199;
+	if (next_pattern > MAX_PATTERNS - 1)
+		next_pattern = MAX_PATTERNS - 1;
 	current_song->orderlist[current_order] = next_pattern;
 	if (current_order < 255)
 		current_order++;
@@ -262,10 +262,10 @@ static void orderlist_add_unused_patterns(void)
 	 * p = pattern iterator
 	 * np = number of patterns */
 	int n0, n, p, np = csf_get_num_patterns(current_song);
-	uint8_t used[200] = {0};                /* could be a bitset... */
+	uint8_t used[MAX_PATTERNS] = {0};                /* could be a bitset... */
 
 	for (n = 0; n < 255; n++)
-		if (current_song->orderlist[n] < 200)
+		if (current_song->orderlist[n] < MAX_PATTERNS)
 			used[current_song->orderlist[n]] = 1;
 
 	/* after the loop, n == 255 */
@@ -327,7 +327,7 @@ static void orderlist_reorder(void)
 		/* replace orderlist entry */
 		current_song->orderlist[i] = mapol[ current_song->orderlist[i] ];
 	}
-	for (i = 0; i < 200; i++) {
+	for (i = 0; i < MAX_PATTERNS; i++) {
 		if (!np[i]) {
 			song_pattern_install(i, NULL, 64);
 		} else {
@@ -370,7 +370,7 @@ static int orderlist_handle_char(char sym)
 
 		status.flags |= SONG_NEEDS_SAVE;
 		cur_pattern = current_song->orderlist[current_order];
-		if (cur_pattern < 200) {
+		if (cur_pattern < MAX_PATTERNS) {
 			n[0] = cur_pattern / 100;
 			n[1] = cur_pattern / 10 % 10;
 			n[2] = cur_pattern % 10;
@@ -378,7 +378,7 @@ static int orderlist_handle_char(char sym)
 
 		n[orderlist_cursor_pos] = c;
 		cur_pattern = n[0] * 100 + n[1] * 10 + n[2];
-		cur_pattern = CLAMP(cur_pattern, 0, 199);
+		cur_pattern = CLAMP(cur_pattern, 0, MAX_PATTERNS - 1);
 		song_get_pattern(cur_pattern, &tmp); /* make sure it exists */
 		current_song->orderlist[current_order] = cur_pattern;
 		break;
@@ -468,9 +468,9 @@ static int orderlist_handle_key_on_list(struct key_event * k)
 		if (k->state == KEY_PRESS)
 			return 1;
 		n = current_song->orderlist[new_order];
-		while (n >= 200 && new_order > 0)
+		while (n >= MAX_PATTERNS && new_order > 0)
 			n = current_song->orderlist[--new_order];
-		if (n < 200) {
+		if (n < MAX_PATTERNS) {
 			set_current_pattern(n);
 			set_page(PAGE_PATTERN_EDITOR);
 		}

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -422,8 +422,8 @@ void pattern_editor_length_edit(void)
 
 	widget_create_thumbbar(length_edit_widgets + 0, 34, 24, 22, 0, 1, 1, NULL, 32, 200);
 	length_edit_widgets[0].d.thumbbar.value = song_get_pattern(current_pattern, NULL );
-	widget_create_thumbbar(length_edit_widgets + 1, 34, 27, 26, 0, 2, 2, NULL, 0, 199);
-	widget_create_thumbbar(length_edit_widgets + 2, 34, 28, 26, 1, 3, 3, NULL, 0, 199);
+	widget_create_thumbbar(length_edit_widgets + 1, 34, 27, 26, 0, 2, 2, NULL, 0, MAX_PATTERNS - 1);
+	widget_create_thumbbar(length_edit_widgets + 2, 34, 28, 26, 1, 3, 3, NULL, 0, MAX_PATTERNS - 1);
 	length_edit_widgets[1].d.thumbbar.value
 		= length_edit_widgets[2].d.thumbbar.value
 		= current_pattern;
@@ -2607,7 +2607,7 @@ void set_current_pattern(int n)
 		_pattern_update_magic();
 	}
 
-	current_pattern = CLAMP(n, 0, 199);
+	current_pattern = CLAMP(n, 0, MAX_PATTERNS - 1);
 	max_row_number = song_get_max_row_number_in_pattern(current_pattern);
 
 	if (current_row > max_row_number)

--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -81,7 +81,7 @@ static int _is_magic_sample(int no)
 	sample = song_get_sample(no);
 	if (sample && ((unsigned char) sample->name[23]) == 0xFF) {
 		pn = (sample->name[24]);
-		if (pn < 200) return 1;
+		if (pn < MAX_PATTERNS) return 1;
 	}
 	return 0;
 }
@@ -187,7 +187,7 @@ static void sample_list_draw_list(void)
 
 		// wow, this is entirely horrible
 		pn = ((unsigned char)sample->name[24]);
-		if (((unsigned char)sample->name[23]) == 0xFF && pn < 200) {
+		if (((unsigned char)sample->name[23]) == 0xFF && pn < MAX_PATTERNS) {
 			nl = 23;
 			draw_text(str_from_num(3, (int)pn, buf), 32, 13 + pos, 0, 2);
 			draw_char('P', 28, 13+pos, 3, 2);

--- a/schism/page_waterfall.c
+++ b/schism/page_waterfall.c
@@ -406,7 +406,7 @@ static int waterfall_handle_key(struct key_event *k)
 			} else {
 				n = song_get_playing_pattern();
 			}
-			if (n < 200) {
+			if (n < MAX_PATTERNS) {
 				set_current_order(order);
 				set_current_pattern(n);
 				set_current_row(song_get_current_row());


### PR DESCRIPTION
I noticed that a constant `MAX_PATTERNS` exists, and it has the value 240, but there are many places in the code that clamp patterns to 200. Unless there's some reason that 200 really is an effective maximum (maybe only when `CLASSIC_MODE` is set?), I think the code should just be relying on `MAX_PATTERNS` everywhere. With the code in this branch, I tested saving and re-loading a `.it` file with patterns defined up to index 239, and it loads back into Schism Tracker just fine, and it also loads into OpenMPT just fine too. Similarly, if I create a `.it` file with OpenMPT that has patterns >200, with these changes they load and edit just fine, as far as I've seen so far.