### PR TITLE
page_loadmodule: remove unnecessary calls to dmoz

### DIFF
--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -151,15 +151,11 @@ idea for return codes:
 
 static void handle_file_entered_L(const char *ptr)
 {
-	dmoz_filelist_t tmp = {0};
 	struct stat sb;
 
 	/* these shenanigans force the file to take another trip... */
 	if (os_stat(ptr, &sb) == -1)
 		return;
-
-	dmoz_add_file(&tmp, str_dup(ptr), str_dup(ptr), &sb, 0);
-	dmoz_free(&tmp, NULL);
 
 	song_load(ptr);
 }


### PR DESCRIPTION
The `handle_file_entered_L` function in `page_loadmodule.c` takes a path and passes it off to `song_load`. Before it does this, it does some basic sanity checking. Originally, this sanity checking included firing up DMOZ and ensuring that a basic scan of the file's attributes passed. But, back in 2009, this check got removed (3b3d361), as, according to the commit message, there were otherwise-valid files whose titles couldn't be read, and this prevented them from being loaded.

But, when the line checking the return value of `dmoz_add_file` against `modgrep` was removed, the code actually calling into DMOZ was not also removed. So now, every time a module is selected to be loaded, DMOZ is used to scan the file and read its extended attributes, and then that information is summary thrown away because as long as the file passes a basic `stat` check, it is _always_ passed on to `song_load`.

This PR removes the redundant code.