### PR TITLE
key handling: avoid latching modifier keys themselves when tracking last key

### DIFF
--- a/include/it.h
+++ b/include/it.h
@@ -151,6 +151,7 @@ struct tracker_status {
 	enum tracker_time_display time_display;
 	enum tracker_vis_style vis_style;
 	schism_keysym_t last_keysym;
+	schism_keymod_t last_keymod;
 
 	schism_keymod_t keymod;
 
@@ -166,6 +167,8 @@ struct tracker_status {
 
 	int fix_numlock_setting;
 };
+
+#define LAST_KEY_IS(sym, mod) (((mod == 0) ? !status.last_keymod : (status.last_keymod & mod)) && (status.last_keysym == sym))
 
 /* numlock hackery */
 enum {

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -599,6 +599,8 @@ int kbd_get_alnum(struct key_event *k);
 
 void kbd_key_translate(struct key_event *k);
 
+int kbd_is_modifier_key(struct key_event *k);
+
 /* -------------------------------------------- */
 /* key repeat */
 

--- a/schism/keyboard.c
+++ b/schism/keyboard.c
@@ -252,6 +252,23 @@ void kbd_key_translate(struct key_event *k)
 	// do nothing
 }
 
+int kbd_is_modifier_key(struct key_event *k)
+{
+	switch (k->sym) {
+	case SCHISM_KEYSYM_LCTRL:
+	case SCHISM_KEYSYM_LSHIFT:
+	case SCHISM_KEYSYM_LALT:
+	case SCHISM_KEYSYM_LGUI:
+	case SCHISM_KEYSYM_RCTRL:
+	case SCHISM_KEYSYM_RSHIFT:
+	case SCHISM_KEYSYM_RALT:
+	case SCHISM_KEYSYM_RGUI:
+		return 1;
+	default:
+		return 0;
+	}
+}
+
 int numeric_key_event(struct key_event *k, int kponly)
 {
 	if (kponly) {
@@ -366,7 +383,7 @@ char *get_note_string(int note, char *buf)
 		note--;
 		buf[0] = note_names[note % 12][0];
 		buf[1] = note_names[note % 12][1];
-		buf[2] = note / 12 + '0'; 
+		buf[2] = note / 12 + '0';
 	}
 	buf[3] = 0;
 	return buf;

--- a/schism/main.c
+++ b/schism/main.c
@@ -374,23 +374,6 @@ static void key_event_reset(struct key_event *kk, int start_x, int start_y)
 
 /* -------------------------------------------- */
 
-static int is_modifier_key(schism_keysym_t sym)
-{
-	switch (sym) {
-	case SCHISM_KEYSYM_LCTRL:
-	case SCHISM_KEYSYM_LSHIFT:
-	case SCHISM_KEYSYM_LALT:
-	case SCHISM_KEYSYM_LGUI:
-	case SCHISM_KEYSYM_RCTRL:
-	case SCHISM_KEYSYM_RSHIFT:
-	case SCHISM_KEYSYM_RALT:
-	case SCHISM_KEYSYM_RGUI:
-		return 1;
-	default:
-		return 0;
-	}
-}
-
 SCHISM_NORETURN static void event_loop(void)
 {
 	unsigned int lx = 0, ly = 0; /* last x and y position (character) */
@@ -520,7 +503,7 @@ SCHISM_NORETURN static void event_loop(void)
 				} else {
 					kbd_cache_key_repeat(&kk);
 
-					if (!is_modifier_key(kk.sym)) {
+					if (!kbd_is_modifier_key(&kk)) {
 						status.last_keysym = kk.sym;
 						status.last_keymod = kk.mod;
 					}

--- a/schism/main.c
+++ b/schism/main.c
@@ -374,6 +374,23 @@ static void key_event_reset(struct key_event *kk, int start_x, int start_y)
 
 /* -------------------------------------------- */
 
+static int is_modifier_key(schism_keysym_t sym)
+{
+	switch (sym) {
+	case SCHISM_KEYSYM_LCTRL:
+	case SCHISM_KEYSYM_LSHIFT:
+	case SCHISM_KEYSYM_LALT:
+	case SCHISM_KEYSYM_LGUI:
+	case SCHISM_KEYSYM_RCTRL:
+	case SCHISM_KEYSYM_RSHIFT:
+	case SCHISM_KEYSYM_RALT:
+	case SCHISM_KEYSYM_RGUI:
+		return 1;
+	default:
+		return 0;
+	}
+}
+
 SCHISM_NORETURN static void event_loop(void)
 {
 	unsigned int lx = 0, ly = 0; /* last x and y position (character) */
@@ -503,8 +520,10 @@ SCHISM_NORETURN static void event_loop(void)
 				} else {
 					kbd_cache_key_repeat(&kk);
 
-					status.last_keysym = last_key;
-					last_key = kk.sym;
+					if (!is_modifier_key(kk.sym)) {
+						status.last_keysym = kk.sym;
+						status.last_keymod = kk.mod;
+					}
 				}
 				break;
 			case SCHISM_MOUSEMOTION:
@@ -829,7 +848,7 @@ SCHISM_NORETURN static void event_loop(void)
 		if (!events_have_event())
 			timer_msleep(5);
 	}
-	
+
 	schism_exit(0);
 }
 

--- a/schism/page_instruments.c
+++ b/schism/page_instruments.c
@@ -506,7 +506,7 @@ static int instrument_list_handle_key_on_list(struct key_event * k)
 			if (k->mod & SCHISM_KEYMOD_ALT) {
 				// restrict position to the "old" value of _last_vis_inst()
 				// (this is entirely for aesthetic reasons)
-				if (status.last_keysym != SCHISM_KEYSYM_DOWN && !k->is_repeat)
+				if (!LAST_KEY_IS(SCHISM_KEYSYM_DOWN, SCHISM_KEYMOD_ALT) && !k->is_repeat)
 					_altswap_lastvis = _last_vis_inst();
 				if (current_instrument < _altswap_lastvis) {
 					new_ins = current_instrument + 1;

--- a/schism/page_patedit.c
+++ b/schism/page_patedit.c
@@ -3669,7 +3669,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	case SCHISM_KEYSYM_d:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_d) {
+		if (LAST_KEY_IS(SCHISM_KEYSYM_d, SCHISM_KEYMOD_ALT)) {
 			if (max_row_number - (current_row - 1) > block_double_size)
 				block_double_size <<= 1;
 		} else {
@@ -3686,7 +3686,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	case SCHISM_KEYSYM_l:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_l) {
+		if (LAST_KEY_IS(SCHISM_KEYSYM_l, SCHISM_KEYMOD_ALT)) {
 			/* 3x alt-l re-selects the current channel */
 			if (selection.first_channel == selection.last_channel) {
 				selection.first_channel = 1;
@@ -3734,7 +3734,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	case SCHISM_KEYSYM_o:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_o) {
+		if (LAST_KEY_IS(SCHISM_KEYSYM_o, SCHISM_KEYMOD_ALT)) {
 			pattern_copyin_behavior = PATTERN_COPYIN_OVERWRITE_GROW;
 		} else {
 			pattern_copyin_behavior = PATTERN_COPYIN_OVERWRITE;
@@ -3750,7 +3750,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	case SCHISM_KEYSYM_m:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_m) {
+		if (LAST_KEY_IS(SCHISM_KEYSYM_m, SCHISM_KEYMOD_ALT)) {
 			pattern_copyin_behavior = PATTERN_COPYIN_MIX_FIELDS;
 		} else {
 			pattern_copyin_behavior = PATTERN_COPYIN_MIX_NOTES;
@@ -3783,7 +3783,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 			}
 		}
 
-		if (status.last_keysym == SCHISM_KEYSYM_n) {
+		if (LAST_KEY_IS(SCHISM_KEYSYM_n, SCHISM_KEYMOD_ALT)) {
 			pattern_editor_display_multichannel();
 		}
 		break;
@@ -3811,7 +3811,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	case SCHISM_KEYSYM_k:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_k) {
+		if (LAST_KEY_IS(SCHISM_KEYSYM_k, SCHISM_KEYMOD_ALT)) {
 			selection_wipe_volume(1);
 		} else {
 			selection_slide_volume();
@@ -3820,7 +3820,7 @@ static int pattern_editor_handle_alt_key(struct key_event * k)
 	case SCHISM_KEYSYM_x:
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (status.last_keysym == SCHISM_KEYSYM_x) {
+		if (LAST_KEY_IS(SCHISM_KEYSYM_x, SCHISM_KEYMOD_ALT)) {
 			selection_wipe_effect();
 		} else {
 			selection_slide_effect();

--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -503,7 +503,7 @@ static int sample_list_handle_key_on_list(struct key_event * k)
 			if (k->mod & SCHISM_KEYMOD_ALT) {
 				// restrict position to the "old" value of _last_vis_sample()
 				// (this is entirely for aesthetic reasons)
-				if (status.last_keysym != SCHISM_KEYSYM_DOWN && !k->is_repeat)
+				if (!LAST_KEY_IS(SCHISM_KEYSYM_DOWN, SCHISM_KEYMOD_ALT) && !k->is_repeat)
 					_altswap_lastvis = _last_vis_sample();
 				if (current_sample < _altswap_lastvis) {
 					new_sample = current_sample + 1;


### PR DESCRIPTION
This PR resolves an issue I ran into with the repeated keypress detection used in a few screens.

As an example, pressing Alt-N in the Pattern Editor toggles the Multichannel state of the current channel. Immediately pressing Alt-N again is supposed to pop up the Multichannel Dialog that allows rapidly updating the Multichannel state of all channels. But, in HEAD, it doesn't work this way. The reason is:

https://github.com/schismtracker/schismtracker/blob/75b87f980ceb310359025a5df37a53e01f363669/schism/main.c#L506-L507

An intermediate variable `last_key` is used, resulting in `status.last_keysym` being delayed and representing the press that occurred _two_ keypresses ago.

Because of this, to get the Multichannel Dialog, you need to press Alt-N _three_ times. Unless you release Alt and then press it again, in which case the second press of Alt fills that intermediate slot. This is inconsistent and undesirable, in my opinion. :-)

The issue is resolved here by updating the code in `main.c` that latches the last key event to only latch non-modifier keys. Then, the last key latched will always be e.g. the N in Alt-N.

There's another issue with the existing code. It doesn't have any provision for checking whether that last keysym was actually part of a modifier combo. For instance, if you go to the Pattern Editor and then you press N followed by Alt-N, the Alt-N handler will see that previous _unmodified_ N and think that you have pressed Alt-N twice.

This PR addresses this by also latching the value of `kk.mod`, which it places into new field `last_keymod` added alongside `last_keysym` in `struct tracker_status`. This makes it possible to tell whether that preceding N was in fact an Alt-N.

This test requires inspecting both `last_keysym` and `last_keymod` simultaneously, which is a bit of an unwieldy expression, so a macro `LAST_KEY_IS` is added that does the right check given `SCHISM_KEYSYM_` and `SCHISM_KEYMOD_` values.

All sites that were doing a naive check on `last_keysym` have been updated to use this new macro.

With these changes:

* Alt-N twice in the Pattern Editor reliably always brings up the Multichannel Dialog, regardless of whether Alt was released in the middle.
* N, Alt-N does not bring up the Multichannel Dialog.

These semantics apply to all double keypress detections.