### PR TITLE
headers: enable gcc analyzer to grok CLAMP (suppresses warnings)

### DIFF
--- a/fmt/d00.c
+++ b/fmt/d00.c
@@ -154,12 +154,10 @@ static void hz_to_speed_tempo(uint32_t hz, uint32_t *pspeed, uint32_t *ptempo)
 
 static int uint16_compare(const void *a, const void *b)
 {
-	int32_t aa = *(uint16_t *)a;
-	int32_t bb = *(uint16_t *)b;
+	uint16_t aa = *(uint16_t *)a;
+	uint16_t bb = *(uint16_t *)b;
 
-	int32_t r = (aa - bb);
-
-	return CLAMP(r, INT_MIN, INT_MAX);
+	return (aa < bb) ? -1 : (aa > bb) ? +1 : 0;
 }
 
 #define D00_PATTERN_ROWS 64

--- a/include/headers.h
+++ b/include/headers.h
@@ -285,7 +285,13 @@ struct stat {
 # define MIN(X,Y) (((X)<(Y))?(X):(Y))
 #endif
 #ifndef CLAMP
-# define CLAMP(N,L,H) (((N)>(H))?(H):(((N)<(L))?(L):(N)))
+# define CLAMP_IMPL(N,L,H) (((N)>(H))?(H):(((N)<(L))?(L):(N)))
+
+// GCC's analysis that feeds into -Wformat-truncation can't tell that CLAMP
+// constrains the range of the expression, except if L is 0. So, we slide
+// the range over to 0, and then slide it back after the CLAMP. Surprisingly,
+// this works and supresses warnings.
+# define CLAMP(N,L,H) (CLAMP_IMPL((N)-(L),0,(H)-(L))+(L))
 #endif
 #ifndef ABS
 # define ABS(x) ((x) < 0 ? -(x) : x)


### PR DESCRIPTION
This warning from version.c had been bugging me on rebuilds:
```
  168 |                 snprintf(buf, 11, "%04lu-%02lu-%02lu",
      |                                          ^~~~~
schism/version.c:168:35: note: directive argument in the range [1, 12]
  168 |                 snprintf(buf, 11, "%04lu-%02lu-%02lu",
      |                                   ^~~~~~~~~~~~~~~~~~~
schism/version.c:168:35: note: directive argument in the range [0, 4294967295]
schism/version.c:168:17: note: ‘snprintf’ output between 11 and 25 bytes into a destination of size 11
  168 |                 snprintf(buf, 11, "%04lu-%02lu-%02lu",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  169 |                         (unsigned long)CLAMP(y, EPOCH_YEAR, 9999),
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  170 |                         (unsigned long)(CLAMP(m, 0, 11) + 1),
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  171 |                         (unsigned long)CLAMP(d, 1, 31));
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The cause seems to be that the compiler isn't always smart enough to tell that `CLAMP` constrains the range of the expressions, so it assumes that the first and the third could potentially be as large as `UINT_MAX`, or 4294967295. Thus, it thinks we might be formatting the string `"4294967295-12-4294967295"`, of length 25 (incl. NUL), into a buffer we've constrained to length 11.

Now, curiously, I noticed that _does_ see that the second one will be in the range [1, 12], and after some experimentation, I determined that if the value of L is 0, then something about the structure of the ternary expressions is then comprehensible to gcc's analyzer. For instance, it thinks `CLAMP(y, EPOCH_YEAR, 9999)` has potential range `0 .. 4294967295`, but it thinks `CLAMP(y - EPOCH_YEAR, 0, 9999 - EPOCH_YEAR) + EPOCH_YEAR` has potential range `EPOCH_YEAR .. 9999`.

After some testing, I have arrived at the following solution: Rewrite `CLAMP` so that, behind the scenes, it is processed as another `CLAMP` whose `L` is always 0.

```
# define CLAMP_IMPL(N,L,H) (((N)>(H))?(H):(((N)<(L))?(L):(N)))
# define CLAMP(N,L,H) (CLAMP_IMPL((N)-(L),0,(H)-(L))+(L))
```

I have done testing to verify that this won't cause problems:

* I have fuzz tested it with both signed and unsigned arguments. Numerically, the value is unchanged.
* To be certain it won't affect any hot paths, I inspected the assembler code produced by the use of this macro. My test case used the `CLAMP` call from the FIR filter processing: `CLAMP(i, -65536, 65534)`. With both GCC and clang, the resulting assembler for the old and new macros is 100% identical. In fact, with GCC, it's identical even without optimization (I wasn't expecting that :slightly_smiling_face:).

It occurs to me that `CLAMP_IMPL` could be rewritten to not _have_ an `L` argument at all. I'm not sure I see the point, though; in its current form, the ternary expressions are visibly recognizable as a min() and a max(), and in its current form, it does the right thing. :slightly_smiling_face: 