### PR TITLE
csndfile: fixed volume parameter range check in csf_import_mod_effect

### DIFF
--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -1504,9 +1504,7 @@ void csf_import_mod_effect(song_note_t *m, int from_xm)
 			effect = FX_VOLUME;
 		} else {
 			m->voleffect = VOLFX_VOLUME;
-			m->volparam = param;
-			if (m->voleffect > 64)
-				m->voleffect = 64;
+			m->volparam = CLAMP(param, 0, 64);
 			effect = param = 0;
 		}
 		break;


### PR DESCRIPTION
Range check was looking at the wrong field. Changed to inline `CLAMP`.