### PR TITLE
compression: fix return values for error cases in it_decompress[8,16]

### DIFF
--- a/fmt/compression.c
+++ b/fmt/compression.c
@@ -98,7 +98,7 @@ uint32_t it_decompress8(void *dest, uint32_t len, slurp_t *fp, int it215, int ch
 			if (width > 9) {
 				// illegal width, abort
 				printf("Illegal bit width %d for 8-bit sample\n", width);
-				return slurp_tell(fp);
+				return slurp_tell(fp) - startpos;
 			}
 			value = it_readbits(width, &bitbuf, &bitnum, fp);
 
@@ -187,7 +187,7 @@ uint32_t it_decompress16(void *dest, uint32_t len, slurp_t *fp, int it215, int c
 
 			if (c1 == EOF || c2 == EOF
 				|| pos + (c1 | (c2 << 8)) > (int64_t)filelen)
-				return pos;
+				return pos - startpos;
 		}
 
 		bitbuf = bitnum = 0;
@@ -203,7 +203,7 @@ uint32_t it_decompress16(void *dest, uint32_t len, slurp_t *fp, int it215, int c
 			if (width > 17) {
 				// illegal width, abort
 				printf("Illegal bit width %d for 16-bit sample\n", width);
-				return slurp_tell(fp);
+				return slurp_tell(fp) - startpos;
 			}
 			value = it_readbits(width, &bitbuf, &bitnum, fp);
 


### PR DESCRIPTION
The "good" path return values return the _relative_ file position at the end of decompression, as compared to the file pointer at the start of decompression. That is to say, the number of bytes that were processed. Some of the "bad" paths do this, but some of them just return the raw file pointer, which will only be correct when the start position is 0. I'm reasonably sure these should consistently factor in `startpos`. Only makes a difference when reading corrupt data.