### PR TITLE
iti: fix copy/paste error in save_iti_envelopes

### DIFF
--- a/fmt/iti.c
+++ b/fmt/iti.c
@@ -422,11 +422,11 @@ static int save_iti_envelopes(disko_t *fp, song_instrument_t *ins)
 		| ((ins->flags & ENV_PITCHSUSTAIN) ? 0x04 : 0)
 		| ((ins->flags & ENV_PITCHCARRY) ? 0x08 : 0)
 		| ((ins->flags & ENV_FILTER) ? 0x80 : 0);
-	pitch.num = ins->pan_env.nodes;
-	pitch.lpb = ins->pan_env.loop_start;
-	pitch.lpe = ins->pan_env.loop_end;
-	pitch.slb = ins->pan_env.sustain_start;
-	pitch.sle = ins->pan_env.sustain_end;
+	pitch.num = ins->pitch_env.nodes;
+	pitch.lpb = ins->pitch_env.loop_start;
+	pitch.lpe = ins->pitch_env.loop_end;
+	pitch.slb = ins->pitch_env.sustain_start;
+	pitch.sle = ins->pitch_env.sustain_end;
 
 	for (int j = 0; j < 25; j++) {
 		vol.nodes[j].value = ins->vol_env.values[j];


### PR DESCRIPTION
In iti.c, there is a function `save_iti_envelopes` that serializes all 3 instrument envelopes as part of the structure of a saved Impulse Tracker instrument. It contains a repeated structure that propagates flags & loop settings from each `song_envelope_t` in the `song_instrument_t` into an `it_envelope` structure in preparation for writing. But, it accidentally copies the _panning_ envelope's node count and loop settings into the structure for the _pitch_ envelope.

Apart from the obvious loop offsets being copied from one envelope to the other, the impact of this bug is that when an instrument is saved where the panning envelope has fewer nodes than the pitch envelope, then when the resulting file is loaded, the pitch envelope will be truncated. Conversely, when an instrument is saved where the panning envelope has more nodes than the pitch envelope, then when the resulting file is loaded, additional nodes will be synthesized. The values of these nodes will be whatever the nodes in memory had at the time of the save, which could be old node data that was deleted prior to saving.

I verified this bug by creating an instrument with a pitch envelope using all 25 nodes, saving that, then deleting those nodes and setting up a panning envelope using all 25 nodes and saving that. I then compared the two files.

The file where the panning envelope was the default 2 nodes and the pitch envelope had 25 nodes:

<img width="1526" height="493" alt="image" src="https://github.com/user-attachments/assets/2b8a9e84-bf1c-4f64-90c3-d5dead6c0225" />
<img width="1526" height="493" alt="image" src="https://github.com/user-attachments/assets/a01009f5-e4cd-41a2-91dd-7d0e7283d639" />

The file where the panning envelope had 25 nodes and the pitch envelope should only have had 2 nodes:

<img width="1526" height="493" alt="image" src="https://github.com/user-attachments/assets/3b5f0450-2699-485e-bd73-53e76acecb4e" />
<img width="1526" height="493" alt="image" src="https://github.com/user-attachments/assets/4f78e9e0-0284-45b8-988e-33475b257d3c" />
