### PR TITLE
liq: unflip title and artist

### DIFF
--- a/fmt/liq.c
+++ b/fmt/liq.c
@@ -50,8 +50,8 @@ int fmt_liq_read_info(dmoz_file_t *file, slurp_t *fp)
 
 	file->description = "Liquid Tracker";
 	/*file->extension = str_dup("liq");*/
-	file->artist = strn_dup((const char *)title, sizeof(title));
-	file->title = strn_dup((const char *)artist, sizeof(artist));
+	file->title = strn_dup((const char *)title, sizeof(title));
+	file->artist = strn_dup((const char *)artist, sizeof(artist));
 	file->type = TYPE_MODULE_S3M;
 
 	return 1;


### PR DESCRIPTION
An oddity in liq.c: The marshalling of the title and artist fields into `dmoz_file_t` swaps their places. I have it on good authority that this isn't intentional. :-P