### PR TITLE
page_samples: fix status text for unreachable sample directory

### DIFF
--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -1081,7 +1081,7 @@ static void sample_save(const char *filename, const char *format)
 	}
 
 	if (os_stat(cfg_dir_samples, &buf) == -1) {
-		status_text_flash("Sample directory \"%s\" unreachable", filename);
+		status_text_flash("Sample directory \"%s\" unreachable", cfg_dir_samples);
 		return;
 	}
 


### PR DESCRIPTION
The status text displayed if `cfg_dir_samples` isn't reachable uses the sample file's base name, which is misleading and inaccurate.