### PR TITLE
page_samples: crossfade sample dialog initialization

### DIFF
--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -1365,7 +1365,7 @@ static void crossfade_sample_draw_const(void)
 	draw_box(44, 26, 52, 28, BOX_THICK | BOX_INNER | BOX_INSET);
 }
 
-// regenerate the sample loop widget based on loop/susloop data
+// update the sample loop widget range based on loop/susloop data
 static void crossfade_sample_loop_changed(void)
 {
 	song_sample_t *smp = song_get_sample(current_sample);
@@ -1377,7 +1377,7 @@ static void crossfade_sample_loop_changed(void)
 
 	const uint32_t max = MIN(loop_end - loop_start, loop_start);
 
-	widget_create_numentry(crossfade_sample_widgets + 2, 45, 27, 7, 0, 3, 3, NULL, 0, max, &crossfade_sample_length_cursor);
+	crossfade_sample_widgets[2].d.numentry.max = max;
 	crossfade_sample_widgets[2].d.numentry.value = max;
 }
 
@@ -1396,6 +1396,8 @@ static void crossfade_sample_dialog(void)
 
 	// Samples To Fade; handled in other function to account for differences between
 	// sample loop and sustain loop
+	widget_create_numentry(crossfade_sample_widgets + 2, 45, 27, 7, 0, 3, 3, NULL, 0, 1, &crossfade_sample_length_cursor);
+
 	crossfade_sample_loop_changed();
 
 	// Priority


### PR DESCRIPTION
The Crossfade Sample dialog has a Number Entry widget where it collects the number of samples to fade. This widget's max value needs to be calculated based on which loop is selected for performing the crossfade; if you switch loops, the max value changes. The code currently handles this by calling `widget_create_numentry` in the event handler for the loop changing -- which means it is recreating the widget every time it changes. This works, because the widget data is static, and because `crossfade_sample_dialog` calls the event handler explicitly once during initialization as well, but it is a significant deviation from the pattern of dialog code, and the max can be updated simply by assigning to the max field in the numentry data for the widget. I guarantee that this is confusing for anybody who doesn't already know what's going on, because that was me 10 minutes ago. :-)

This PR changes the dialog initialization to follow conventions, placing the `widget_create_numentry` call alongside all the other widget creation calls for the dialog in `crossfade_sample_dialog`.