### PR TITLE
page_samples: clarifying comment in crossfade_sample_dialog

### DIFF
--- a/schism/page_samples.c
+++ b/schism/page_samples.c
@@ -1392,6 +1392,7 @@ static void crossfade_sample_dialog(void)
 	widget_create_togglebutton(crossfade_sample_widgets + 1, 41, 24, 7, 2, 2, 0, 0, 2, crossfade_sample_loop_changed, "Sustain", 1, crossfade_sample_loop_group);
 
 	// Default to sustain loop if there is a sustain loop but no regular loop, or the regular loop is not valid
+	// (Note that a loop that starts at 0 is not valid, because crossfading requires data before the loop.)
 	crossfade_sample_widgets[((smp->flags & CHN_SUSTAINLOOP) && !((smp->flags & CHN_LOOP) && smp->loop_start && smp->loop_end)) ? 1 : 0].d.togglebutton.state = 1;
 
 	// Samples To Fade; handled in other function to account for differences between


### PR DESCRIPTION
I thought I'd found a bug, because in checking for the presence of a loop, it requires loop_start to be non-zero. Further investigation revealed that this is intentional, because crossfading requires data before the loop to work with. So, instead of fixing a bug, this PR adds a comment to ensure that nobody else looks at this and thinks they've spotted a bug.