### PR TITLE
mtm: fix potentially incorrect pattern alloc size

### DIFF
--- a/fmt/mtm.c
+++ b/fmt/mtm.c
@@ -216,7 +216,7 @@ int fmt_mtm_load_song(song_t *song, slurp_t *fp, unsigned int lflags)
 		}
 
 		song->patterns[pat] = csf_allocate_pattern(MAX(rows, 32));
-		song->pattern_size[pat] = song->pattern_alloc_size[pat] = 64;
+		song->pattern_size[pat] = song->pattern_alloc_size[pat] = MAX(rows, 32);
 		for (chan = 0; chan < 32; chan++) {
 			slurp_read(fp, &tmp, 2);
 			tmp = bswapLE16(tmp);


### PR DESCRIPTION
This looks like a bug to me. Other loaders have this pattern of:
```
song->patterns[pat] = csf_allocate_pattern(EXPRESSION);
song->pattern_size[pat] = song->pattern_alloc_size[pat] = EXPRESSION;
```
It seems reasonable that the same expression should be used in both lines; the intent is, after all, to capture how many records were allocated in the call to `csf_allocate_pattern`, right? So, if they aren't the same, that could potentially result in some shenanigans later on when working with the data.