### PR TITLE
Mouse precision tweaks

### DIFF
--- a/schism/page_loadmodule.c
+++ b/schism/page_loadmodule.c
@@ -751,7 +751,9 @@ static int file_list_handle_key(struct key_event * k)
 		}
 	}
 
-	if (k->mouse != MOUSE_NONE && !(k->x >= 3 && k->x <= 51 && k->y >= 13 && k->y <= 43))
+	struct widget *w = &widgets[0];
+
+	if (k->mouse != MOUSE_NONE && !(k->x >= w->x && k->x <= w->x + w->width && k->y >= w->y && k->y <= w->y + w->height))
 		return 0;
 	switch (k->mouse) {
 	case MOUSE_CLICK:
@@ -1055,7 +1057,7 @@ void load_module_load_page(struct page *page)
 	widgets_loadmodule[0].accept_text = 1;
 	widgets_loadmodule[0].x = 3;
 	widgets_loadmodule[0].y = 13;
-	widgets_loadmodule[0].width = 44;
+	widgets_loadmodule[0].width = 45;
 	widgets_loadmodule[0].height = 30;
 	widgets_loadmodule[0].next.left = widgets_loadmodule[0].next.right = 1;
 
@@ -1127,7 +1129,7 @@ void save_module_load_page(struct page *page, int do_export)
 	widgets_exportsave[0].next.right = widgets_exportsave[0].next.tab = 1;
 	widgets_exportsave[0].x = 3;
 	widgets_exportsave[0].y = 13;
-	widgets_exportsave[0].width = 44;
+	widgets_exportsave[0].width = 45;
 	widgets_exportsave[0].height = 30;
 
 	widget_create_other(widgets_exportsave + 1, 2, dir_list_handle_key_exportsave,

--- a/schism/widget.c
+++ b/schism/widget.c
@@ -690,10 +690,8 @@ static int _find_widget_xy(int x, int y)
 		w = widgets + i;
 		switch (w->type) {
 		case WIDGET_BUTTON:
-			pad = w->d.button.padding + 1;
-			break;
 		case WIDGET_TOGGLEBUTTON:
-			pad = w->d.togglebutton.padding + 1;
+			pad = 2;
 			break;
 		default:
 			pad = 0;


### PR DESCRIPTION
I just fired up a build of Schism Tracker, and I misclicked the "Continue" button ... but it clicked anyway!

Digging into it, I found that the bounds checks for buttons is factoring in `padding`, but the `padding` is already factored in, so it gets factored in twice. Buttons respond to clicks in the blank area to the right of the button.

After fixing this, I was poking around, testing to make sure that my change hadn't broken anything, and I immediately ran into other mouse precision issues. I didn't search exhaustively for them, but for sure a number of these would have been present throughout and the fixes here corrected them globally. There were also fixes that would only have a local effect, for which there may be other similar instances elsewhere. :-)

This PR makes the following changes:

* The method which handles locating a widget to give it focus on click (`_find_widget_xy` in widget.c) and the method which processes button clicks (`widget_handle_key` in widget-keyhandler.c) no longer re-add button padding. Buttons are always 2 characters wider than their ostensible width, as part of the framing, so these two extra characters are factored in.
* In page_loadmodule.c, the handler for clicks on the file list has been updated to use the bounds stored in `widgets[0]` instead of magic numbers, which weren't quite right.
* The width stored in `widgets[0]` by `load_module_load_page` and `load_module_save_page` was also incorrect, off by one, and has been corrected.
* I also discovered that Toggle and Menu Toggle widgets respond to clicks _anywhere_ as long as they have focus. This PR adds bounds checking so that the cursor has to actually be on the widget to change its value. The implementation of this hoisted the calculation of `onw` in `widget_handle_key` up out of the button-specific path.