### PR TITLE
mouse semantics (mostly related to dragging)

### DIFF
--- a/include/widget.h
+++ b/include/widget.h
@@ -77,6 +77,8 @@ int widget_textentry_add_text(struct widget *widget, const char* text);
 void widget_numentry_change_value(struct widget *widget, int32_t new_value);
 int widget_numentry_handle_text(struct widget *w, const char* text_input);
 
+int widget_find_xy(int x, int y);
+
 int widget_change_focus_to_xy(int x, int y);
 void widget_change_focus_to(int new_widget_index);
 /* p_widgets should point to the group of widgets (not the actual widget that is

--- a/schism/main.c
+++ b/schism/main.c
@@ -596,10 +596,16 @@ SCHISM_NORETURN static void event_loop(void)
 							}
 						}
 					}
-					if (widget_change_focus_to_xy(kk.x, kk.y)) {
-						kk.on_target = 1;
-					} else {
-						kk.on_target = 0;
+					switch (kk.state) {
+					case KEY_PRESS:
+						if (widget_change_focus_to_xy(kk.x, kk.y)) {
+							kk.on_target = 1;
+						} else {
+							kk.on_target = 0;
+						}
+						break;
+					case KEY_DRAG:
+						kk.on_target = (widget_find_xy(kk.x, kk.y) == *selected_widget);
 					}
 					if (se.type == SCHISM_MOUSEBUTTONUP && downtrip) {
 						downtrip = 0;

--- a/schism/widget-keyhandler.c
+++ b/schism/widget-keyhandler.c
@@ -450,7 +450,7 @@ int widget_handle_key(struct key_event * k)
 			case WIDGET_TOGGLE:
 				if (!NO_MODIFIER(k->mod))
 					return 0;
-				if (k->state == KEY_RELEASE)
+				if (k->state != KEY_PRESS)
 					return 1;
 				widget->d.toggle.state = !widget->d.toggle.state;
 				if (widget->changed) widget->changed();
@@ -459,7 +459,7 @@ int widget_handle_key(struct key_event * k)
 			case WIDGET_MENUTOGGLE:
 				if (!NO_MODIFIER(k->mod))
 					return 0;
-				if (k->state == KEY_RELEASE)
+				if (k->state != KEY_PRESS)
 					return 1;
 				widget->d.menutoggle.state = (widget->d.menutoggle.state + 1)
 					% widget->d.menutoggle.num_choices;
@@ -500,7 +500,7 @@ int widget_handle_key(struct key_event * k)
 			if (status.flags & DISKWRITER_ACTIVE) return 0;
 
 			/* swallow it */
-			if (!k->on_target) return 0;
+			if (!k->on_target && (k->state != KEY_DRAG)) return 0;
 
 			fmin = widget->d.thumbbar.min;
 			fmax = widget->d.thumbbar.max;
@@ -619,11 +619,15 @@ int widget_handle_key(struct key_event * k)
 			widget->d.togglebutton.state = !widget->d.togglebutton.state;
 			SCHISM_FALLTHROUGH;
 		case WIDGET_BUTTON:
-			/* maybe buttons should ignore the changed callback, and use activate instead...
-			(but still call the changed callback for togglebuttons if they *actually* changed) */
-			if (widget->changed) widget->changed();
-			status.flags |= NEED_UPDATE;
-			return 1;
+			if (k->state == KEY_DRAG)
+				widget->depressed = k->on_target;
+			else {
+				/* maybe buttons should ignore the changed callback, and use activate instead...
+				(but still call the changed callback for togglebuttons if they *actually* changed) */
+				if (widget->changed) widget->changed();
+				status.flags |= NEED_UPDATE;
+				return 1;
+			}
 		default:
 			break;
 		}

--- a/schism/widget.c
+++ b/schism/widget.c
@@ -679,7 +679,7 @@ void widget_change_focus_to(int new_widget_index)
 	status.flags |= NEED_UPDATE;
 }
 
-static int _find_widget_xy(int x, int y)
+int widget_find_xy(int x, int y)
 {
 	struct widget *w;
 	int i, pad;
@@ -705,7 +705,7 @@ static int _find_widget_xy(int x, int y)
 
 int widget_change_focus_to_xy(int x, int y)
 {
-	int n = _find_widget_xy(x, y);
+	int n = widget_find_xy(x, y);
 	if (n >= 0) {
 		widget_change_focus_to(n);
 		return 1;


### PR DESCRIPTION
A bunch of tweaks to mouse semantics that make the UI feel better-behaved:

* Updated `event_loop` in main.c to only change focus for `KEY_PRESS` events specifically. This means that whatever widget had focus at the start of a drag operation continues to have focus for the duration of the drag, which I believe is actually normal UI behaviour. :-)
* Toggle and Menu Toggle widgets now only change state during `KEY_PRESS`. The previous code did exclude `KEY_RELEASE`, but it didn't exclude `KEY_DRAG`, so dragging over a Toggle or Menu Toggle caused it to change wildly.
* Thumb Bar and Pan Bar widgets no longer ignore events that aren't "on target". This is okay, because it ties into the change that prevents widgets from losing focus during drag events. Now, if the mouse wanders off of a Pan Bar but the user is still dragging, it continues to update the value.
* Button widgets no longer generate Changed (clicked) events during drags. Instead, their `depressed` state is updated based on whether the mouse is still on target.
