### PR TITLE
docs: added automated test info to building_on_*.md (straggler)

### DIFF
--- a/docs/building_on_osx.md
+++ b/docs/building_on_osx.md
@@ -67,6 +67,8 @@ The resulting `Makefile` will produce a second binary alongside
 In this build mode, if you make a change that requires corresponding changes
 to tests, you discover immediately on the next build.
 
+You should regularly run automated tests during development work.
+
 
 ## Baking Schism Tracker into an App ready to be put in /Applications
 


### PR DESCRIPTION
Last-minute copy/paste wasn't saved when I committed to `build-documentation-tests`. Oops. :stuck_out_tongue: 