### PR TITLE
Waveform visualization

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -480,6 +480,10 @@ else
 files_opl = player/fmopl3.c
 endif
 
+if ENABLE_WAVEFORMVIS
+CFLAGS += -DENABLE_WAVEFORMVIS
+endif
+
 ## Replacement functions for crappy systems
 files_stdlib =
 if NEED_ASPRINTF

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,15 @@ AC_ARG_ENABLE(tests,
 	BUILD_TESTS=$enableval,
 	BUILD_TESTS=no)
 
+AC_ARG_ENABLE(waveformvis,
+	AS_HELP_STRING([--enable-waveformvis], [Enable waveform visualization (uses a little bit of RAM and CPU time) @<:default=yes@:>]),
+	,
+	[enable_waveformvis=yes])
+
+AM_CONDITIONAL(
+	[ENABLE_WAVEFORMVIS],
+	[test x"$enable_waveformvis" = x"yes"])
+
 dnl These are used in the Win32 build so that we can intermix mingw32 and mingw-w64 parts.
 dnl This is really a hack, and it would be nicer if we could avoid this, but unfortunately
 dnl there is no real windows toolchain available that allows to target super old windows

--- a/helptext/info-page
+++ b/helptext/info-page
@@ -9,6 +9,8 @@
 | PgUp/PgDn         Change window type
 | Alt-Up/Down       Move window base up/down
 |
+| Alt-N             In waveform windows, toggles channel numbering
+|
 | V                 Toggle between volume/velocity bars
 | I                 Toggle between sample/instrument names
 |

--- a/include/player/sndfile.h
+++ b/include/player/sndfile.h
@@ -757,7 +757,7 @@ typedef struct song {
 	uint32_t flags;                                 // Song flags SONG_XXXX
 	uint32_t pan_separation;
 	uint32_t num_voices; // how many are currently playing. (POTENTIALLY larger than global max_voices)
-	uint32_t mix_stat; // number of channels being mixed (not really used)
+	uint32_t mix_stat; // number of channels being mixed
 	uint32_t buffer_count; // number of samples to mix per tick
 	uint32_t tick_count;
 	uint32_t frame_delay;

--- a/include/player/sndfile.h
+++ b/include/player/sndfile.h
@@ -549,6 +549,9 @@ typedef struct song_voice {
 	int32_t rofs, lofs; // ?
 	int32_t ramp_length;
 	uint32_t vu_meter; // moved this up -paper
+#ifdef ENABLE_WAVEFORMVIS
+	int oldest_recent_sample;
+#endif
 	// Information not used in the mixer
 	int32_t right_volume_new, left_volume_new; // ?
 	int32_t final_volume; // range 0-16384 (?), accounting for sample+channel+global+etc. volumes
@@ -862,6 +865,25 @@ typedef struct song {
 	// multi-write stuff -- NULL if no multi-write is in progress, else array of one struct per channel
 	struct multi_write *multi_write;
 } song_t;
+
+#ifndef NATIVE_SCREEN_WIDTH
+#define NATIVE_SCREEN_WIDTH 640
+#endif
+#ifndef NATIVE_SCREEN_HEIGHT
+#define NATIVE_SCREEN_HEIGHT 400
+#endif
+
+#ifdef ENABLE_WAVEFORMVIS
+#define RECENT_SAMPLE_BUFFER_SIZE NATIVE_SCREEN_WIDTH
+
+/* one for each voice, plus one for each output channel */
+extern int8_t recent_sample_buffer[(MAX_VOICES + 2) * RECENT_SAMPLE_BUFFER_SIZE];
+
+#define RECENT_SAMPLE_BUFFER(voice) (&recent_sample_buffer[(voice) * RECENT_SAMPLE_BUFFER_SIZE])
+
+int csf_get_oldest_recent_sample_output(void);
+void csf_set_oldest_recent_sample_output(int new_value);
+#endif
 
 song_note_t *csf_allocate_pattern(uint32_t rows);
 void csf_free_pattern(void *pat);

--- a/include/player/sndfile.h
+++ b/include/player/sndfile.h
@@ -776,7 +776,8 @@ typedef struct song {
 	uint32_t freq_factor; // not used -- for tweaking the song speed LP-style (interesting!)
 	uint32_t tempo_factor; // ditto
 	int32_t repeat_count; // 0 = first playback, etc. (note: set to -1 to stop instead of looping)
-	int8_t *recent_sample_buffer; // one buffer per voice, stored outside of song_voice_t because we regularly obliterate that
+	int8_t *recent_sample_buffer; // one buffer per voice, stored outside of song_voice_t because we regularly obliterate that, plus two for output LR
+	int oldest_recent_output_sample; // pointer into the ringbuffer for the output buffers
 
 	uint8_t row_highlight_major;
 	uint8_t row_highlight_minor;
@@ -882,9 +883,6 @@ typedef struct song {
 #define RECENT_SAMPLE_BUFFER_SIZE NATIVE_SCREEN_WIDTH
 
 #define RECENT_SAMPLE_BUFFER(csf, voice) (&csf->recent_sample_buffer[(voice) * RECENT_SAMPLE_BUFFER_SIZE])
-
-int csf_get_oldest_recent_sample_output(void);
-void csf_set_oldest_recent_sample_output(int new_value);
 #endif
 
 song_note_t *csf_allocate_pattern(uint32_t rows);

--- a/include/player/sndfile.h
+++ b/include/player/sndfile.h
@@ -821,6 +821,10 @@ typedef struct song {
 
 	int32_t opl_to_chan[OPL_CHANNELS];
 	int32_t opl_from_chan[MAX_VOICES];
+
+	// up to MIXBUFFERSIZE stereo samples on each of OPL_CHANNELS channels
+	// allocated on-demand in snd_fm.c
+	int32_t *opl_buffer_data; // up to MIXBUFFERSIZE samples on each of OPL_CHANNELS channels
 	// -----------------------------------------------------------------------
 
 	// MIDI stuff ------------------------------------------------------------

--- a/include/player/sndfile.h
+++ b/include/player/sndfile.h
@@ -776,6 +776,7 @@ typedef struct song {
 	uint32_t freq_factor; // not used -- for tweaking the song speed LP-style (interesting!)
 	uint32_t tempo_factor; // ditto
 	int32_t repeat_count; // 0 = first playback, etc. (note: set to -1 to stop instead of looping)
+	int8_t *recent_sample_buffer; // one buffer per voice, stored outside of song_voice_t because we regularly obliterate that
 
 	uint8_t row_highlight_major;
 	uint8_t row_highlight_minor;
@@ -876,10 +877,7 @@ typedef struct song {
 #ifdef ENABLE_WAVEFORMVIS
 #define RECENT_SAMPLE_BUFFER_SIZE NATIVE_SCREEN_WIDTH
 
-/* one for each voice, plus one for each output channel */
-extern int8_t recent_sample_buffer[(MAX_VOICES + 2) * RECENT_SAMPLE_BUFFER_SIZE];
-
-#define RECENT_SAMPLE_BUFFER(voice) (&recent_sample_buffer[(voice) * RECENT_SAMPLE_BUFFER_SIZE])
+#define RECENT_SAMPLE_BUFFER(csf, voice) (&csf->recent_sample_buffer[(voice) * RECENT_SAMPLE_BUFFER_SIZE])
 
 int csf_get_oldest_recent_sample_output(void);
 void csf_set_oldest_recent_sample_output(int new_value);

--- a/include/vgamem.h
+++ b/include/vgamem.h
@@ -64,6 +64,7 @@ void vgamem_ovl_apply(struct vgamem_overlay *n);
 void vgamem_ovl_clear(struct vgamem_overlay *n, int color);
 void vgamem_ovl_drawpixel(struct vgamem_overlay *n, int x, int y, int color);
 void vgamem_ovl_drawline(struct vgamem_overlay *n, int xs, int ys, int xe, int ye, int color);
+void vgamem_ovl_drawtext_halfwidth(struct vgamem_overlay *n, char *text, int x, int y, int color);
 
 /* --------------------------------------------------------------------- */
 /* character drawing routines */

--- a/include/vgamem.h
+++ b/include/vgamem.h
@@ -133,6 +133,32 @@ void draw_box(int xs, int ys, int xe, int ye, uint32_t flags);
 struct song_sample;
 void draw_sample_data(struct vgamem_overlay *r, struct song_sample *sample);
 
+typedef enum {
+  SAMPLE_DRAW_STYLE_DOTS,
+	SAMPLE_DRAW_STYLE_LINE,
+	SAMPLE_DRAW_STYLE_FILLED,
+} sample_draw_style_t;
+
+/* when you need all of the control :-) most notably, the sample doesn't need
+ * to fill the overlay.
+ * - advances by advance samples in the buffer for every pixel drawn
+ * - advance is fixed-point, scaled by 256
+ * - samples are stride indices apart (to allow for interleaved stereo)
+ * - if the offset passes length, it wraps around (ringbuffer semantics)
+ * - (x1, y1)-(x2, y2) are pixel coordinates relative to the top/left of the
+ *   overlay
+ * - assumes you've already cleared the background
+ */
+void draw_sample_data_ex_32(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
+	int32_t *data, int offset, int stride, int advance, int length,
+	int32_t min_value, int32_t max_value, int colour, sample_draw_style_t draw_style);
+void draw_sample_data_ex_16(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
+	int16_t *data, int offset, int stride, int advance, int length,
+	int16_t min_value, int16_t max_value, int colour, sample_draw_style_t draw_style);
+void draw_sample_data_ex_8(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
+	int8_t *data, int offset, int stride, int advance, int length, int signed_data,
+	int8_t min_value, int8_t max_value, int colour, sample_draw_style_t draw_style);
+
 /* this works like draw_sample_data, just without having to allocate a
  * song_sample structure, and without caching the waveform.
  * mostly it's just for the oscilloscope view. */

--- a/include/vgamem.h
+++ b/include/vgamem.h
@@ -150,23 +150,23 @@ typedef enum {
  * - assumes you've already cleared the background
  */
 void draw_sample_data_ex_32(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
-	int32_t *data, int offset, int stride, int advance, int length,
+	int32_t *data, uint32_t offset, uint32_t stride, uint32_t advance, uint32_t length,
 	int32_t min_value, int32_t max_value, int colour, sample_draw_style_t draw_style);
 void draw_sample_data_ex_16(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
-	int16_t *data, int offset, int stride, int advance, int length,
+	int16_t *data, uint32_t offset, uint32_t stride, uint32_t advance, uint32_t length,
 	int16_t min_value, int16_t max_value, int colour, sample_draw_style_t draw_style);
 void draw_sample_data_ex_8(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
-	int8_t *data, int offset, int stride, int advance, int length, int signed_data,
+	int8_t *data, uint32_t offset, uint32_t stride, uint32_t advance, uint32_t length, int signed_data,
 	int8_t min_value, int8_t max_value, int colour, sample_draw_style_t draw_style);
 
 /* this works like draw_sample_data, just without having to allocate a
  * song_sample structure, and without caching the waveform.
  * mostly it's just for the oscilloscope view. */
-void draw_sample_data_rect_32(struct vgamem_overlay *r, int32_t *data,
-	int length, unsigned int inputchans, unsigned int outputchans);
-void draw_sample_data_rect_16(struct vgamem_overlay *r, int16_t *data, int length,
+void draw_sample_data_rect_32(struct vgamem_overlay *r, int32_t *data, uint32_t length,
 	unsigned int inputchans, unsigned int outputchans);
-void draw_sample_data_rect_8(struct vgamem_overlay *r, int8_t *data, int length,
+void draw_sample_data_rect_16(struct vgamem_overlay *r, int16_t *data, uint32_t length,
+	unsigned int inputchans, unsigned int outputchans);
+void draw_sample_data_rect_8(struct vgamem_overlay *r, int8_t *data, uint32_t length,
 	unsigned int inputchans, unsigned int outputchans);
 
 /* ------------------------------------------------------------ */

--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -34,6 +34,20 @@
 #include "fmt.h" // for it_decompress8 / it_decompress16
 #include "mem.h"
 
+#ifdef ENABLE_WAVEFORMVIS
+int8_t recent_sample_buffer[(MAX_VOICES + 2) * RECENT_SAMPLE_BUFFER_SIZE];
+static int oldest_recent_output_sample = 0;
+
+int csf_get_oldest_recent_sample_output(void)
+{
+	return oldest_recent_output_sample;
+}
+
+void csf_set_oldest_recent_sample_output(int new_value)
+{
+	oldest_recent_output_sample = new_value;
+}
+#endif
 
 static void _csf_reset(song_t *csf)
 {

--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -136,6 +136,7 @@ song_t *csf_allocate(void)
 {
 	song_t *csf = mem_calloc(1, sizeof(song_t));
 	_csf_reset(csf);
+	csf->recent_sample_buffer = mem_calloc(MAX_VOICES + 2, NATIVE_SCREEN_WIDTH);
 	return csf;
 }
 
@@ -212,6 +213,8 @@ void csf_destroy(song_t *csf)
 			csf->instruments[i] = NULL;
 		}
 	}
+
+	free(csf->recent_sample_buffer);
 
 	_csf_reset(csf);
 }
@@ -829,7 +832,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		SCHISM_FALLTHROUGH;
 	case SF(8,M,LE,PCMS):
 	case SF(8,M,LE,PCMU):
-	case SF(8,M,LE,PCMD): 
+	case SF(8,M,LE,PCMD):
 	case SF(8,M,BE,PCMS):
 	case SF(8,M,BE,PCMU):
 	case SF(8,M,BE,PCMD): {
@@ -856,7 +859,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	// 8-bit stereo samples
 	case SF(8,SS,LE,PCMS):
 	case SF(8,SS,LE,PCMU):
-	case SF(8,SS,LE,PCMD): 
+	case SF(8,SS,LE,PCMD):
 	case SF(8,SS,BE,PCMS):
 	case SF(8,SS,BE,PCMU):
 	case SF(8,SS,BE,PCMD): {

--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -114,9 +114,12 @@ static void _csf_reset(song_t *csf)
 	OPL_Close(csf);
 	GM_Reset(csf, 1);
 
+
 	/* all zeroes should be the default playing configuration,
 	 * anything else increases complexity unfortunately */
 	BITARRAY_FILL(csf->quirks);
+
+	csf->opl_buffer_data = NULL;
 
 	memset(csf->midi_note_tracker, 0, sizeof(csf->midi_note_tracker));
 	memset(csf->midi_vol_tracker, 0, sizeof(csf->midi_vol_tracker));
@@ -215,6 +218,7 @@ void csf_destroy(song_t *csf)
 	}
 
 	free(csf->recent_sample_buffer);
+	free(csf->opl_buffer_data);
 
 	_csf_reset(csf);
 }

--- a/player/fmopl2.c
+++ b/player/fmopl2.c
@@ -2060,7 +2060,7 @@ do { \
 	vu_max[CHN] = MAX(vu_max[CHN], ab); \
 \
 	if (buffers[CHN]) { \
-		int32_t sample = OPL->output[0] * OPL_VOLUME; \
+		int32_t sample = OPL->output[0]; \
 		buffers[CHN][i*2+0] += sample; \
 		buffers[CHN][i*2+1] += sample; \
 	} \

--- a/player/fmopl3.c
+++ b/player/fmopl3.c
@@ -2539,8 +2539,8 @@ void ymf262_update_multi(void *_chip, int32_t **buffers, int length, uint32_t vu
 		/* accumulator register set #1 */
 		for (j = 0, k = 0; j < 18; j++) {
 			if (buffers[j]) {
-				buffers[j][i*2+0] += (chanout[j] & chip->pan[k++]) * OPL_VOLUME;
-				buffers[j][i*2+1] += (chanout[j] & chip->pan[k++]) * OPL_VOLUME;
+				buffers[j][i*2+0] += chanout[j] & chip->pan[k++];
+				buffers[j][i*2+1] += chanout[j] & chip->pan[k++];
 				k += 2; // skip next two pans
 			} else {
 				k += 4;

--- a/player/mixer.c
+++ b/player/mixer.c
@@ -793,7 +793,8 @@ uint32_t csf_create_stereo_mix(song_t *csf, uint32_t count)
 			memset(csf->multi_write[nchan].buffer, 0, sizeof(csf->multi_write[nchan].buffer));
 
 	for (uint32_t nchan = 0; nchan < csf->num_voices; nchan++) {
-		song_voice_t *const channel = &csf->voices[csf->voice_mix[nchan]];
+		int real_voice = csf->voice_mix[nchan];
+		song_voice_t *const channel = &csf->voices[real_voice];
 		uint32_t flags;
 		uint32_t nrampsamples;
 		int32_t smpcount;
@@ -832,8 +833,8 @@ uint32_t csf_create_stereo_mix(song_t *csf, uint32_t count)
 		nsamples = count;
 
 		if (csf->multi_write) {
-			int32_t master = (csf->voice_mix[nchan] < MAX_CHANNELS)
-				? csf->voice_mix[nchan]
+			int32_t master = (real_voice < MAX_CHANNELS)
+				? real_voice
 				: (channel->master_channel - 1);
 			pbuffer = csf->multi_write[master].buffer;
 			csf->multi_write[master].used = 1;
@@ -902,7 +903,7 @@ uint32_t csf_create_stereo_mix(song_t *csf, uint32_t count)
 				channel->lofs = -*(pbufmax - 1);
 
 #ifdef ENABLE_WAVEFORMVIS
-				mix_func(channel, pbuffer, pbufmax, RECENT_SAMPLE_BUFFER(csf, nchan));
+				mix_func(channel, pbuffer, pbufmax, RECENT_SAMPLE_BUFFER(csf, real_voice));
 #else
 				mix_func(channel, pbuffer, pbufmax);
 #endif

--- a/player/mixer.c
+++ b/player/mixer.c
@@ -30,8 +30,6 @@
 #include "bits.h"
 #include "util.h"   // for CLAMP
 
-#define NATIVE_SCREEN_WIDTH 640
-
 // For pingpong loops that work like most of Impulse Tracker's drivers
 // (including SB16, SBPro, and the disk writer) -- as well as XMPlay, use 1
 // To make them sound like the GUS driver, use 0.
@@ -251,7 +249,7 @@
 # define MERGE_SAMPLE(l, r) ((l >> 1) + (r >> 1))
 # define CONVERT_SAMPLE(s) ((int8_t)(((s) >> 18)) ^ 128);
 # define CAPTURE_RECENT_SAMPLE \
-	if (oldest_recent_sample >= NATIVE_SCREEN_WIDTH) \
+	if (oldest_recent_sample >= RECENT_SAMPLE_BUFFER_SIZE) \
 		oldest_recent_sample = 0; \
 	recent[oldest_recent_sample++] = CONVERT_SAMPLE(MERGE_SAMPLE(vol_lx, vol_rx));
 #else

--- a/player/mixer.c
+++ b/player/mixer.c
@@ -911,7 +911,7 @@ uint32_t csf_create_stereo_mix(song_t *csf, uint32_t count)
 				channel->lofs += *(pbufmax - 1);
 
 #ifdef ENABLE_WAVEFORMVIS
-				int oldest_recent_output_sample = csf_get_oldest_recent_sample_output();
+				int oldest_recent_output_sample = csf->oldest_recent_output_sample;
 				int8_t *recent_sample_buffer_l = RECENT_SAMPLE_BUFFER(csf, MAX_VOICES);
 				int8_t *recent_sample_buffer_r = RECENT_SAMPLE_BUFFER(csf, MAX_VOICES + 1);
 
@@ -926,7 +926,7 @@ uint32_t csf_create_stereo_mix(song_t *csf, uint32_t count)
 					oldest_recent_output_sample++;
 				}
 
-				csf_set_oldest_recent_sample_output(oldest_recent_output_sample);
+				csf->oldest_recent_output_sample = oldest_recent_output_sample;
 #else
 				pbuffer = pbufmax;
 #endif

--- a/player/mixer.c
+++ b/player/mixer.c
@@ -29,7 +29,6 @@
 #include "player/cmixer.h"
 #include "bits.h"
 #include "util.h"   // for CLAMP
-#include "sndfile.h"
 
 #define NATIVE_SCREEN_WIDTH 640
 

--- a/player/snd_fm.c
+++ b/player/snd_fm.c
@@ -53,18 +53,6 @@
 # error "The current value of OPLSOURCE isn't supported! Check build-config.h."
 #endif
 
-/* This just forwards to OPLUpdateMulti now */
-static inline void OPLUpdateOne(void *chip, int32_t *buffer, int length, uint32_t vu_max[OPL_CHANNELS])
-{
-	int32_t *buffers[OPL_CHANNELS];
-	int i;
-
-	for (i = 0; i < OPL_CHANNELS; i++)
-		buffers[i] = buffer;
-
-	OPLUpdateMulti(chip, buffers, length, vu_max);
-}
-
 /* Schismtracker output buffer works in 27bits: [MIXING_CLIPMIN..MIXING_CLIPMAX]
 fmopl works in 16bits, although tested output used to range +-10000 instead of
 	+-20000 from adlibtracker/screamtracker in dosbox. So we need 11 bits + 1 extra bit.
@@ -239,7 +227,8 @@ void Fmdrv_Mix(song_t *csf, uint32_t count)
 {
 	uint32_t sz;
 	uint32_t vu_max[OPL_CHANNELS];
-	uint32_t i;
+	uint32_t i, j;
+	int32_t *buffers[OPL_CHANNELS] = {0};
 
 	if (!csf->opl_fm_active)
 		return;
@@ -264,47 +253,100 @@ void Fmdrv_Mix(song_t *csf, uint32_t count)
 
 	// IF we wanted to do the stereo mix in software, we could setup the voices always in mono
 	// and do the panning here.
-	{
-		uint32_t j;
-		int32_t *buffers[OPL_CHANNELS] = {0};
+	SCHISM_VLA_ALLOC(int32_t, buf, OPL_CHANNELS * sz);
 
-		if (csf->multi_write) {
-			for (i = 0; i < OPL_CHANNELS; i++) {
-				int32_t opl_v = csf->opl_to_chan[i];
-				if (opl_v < 0 || opl_v >= MAX_VOICES /* this is a bug */)
-					continue;
+	if (csf->multi_write) {
+		for (i = 0; i < OPL_CHANNELS; i++) {
+			int32_t opl_v = csf->opl_to_chan[i];
+			if (opl_v < 0 || opl_v >= MAX_VOICES /* this is a bug */)
+				continue;
 
-				buffers[i] = csf->multi_write[opl_v].buffer;
-			}
-		} else {
-			/* updated this to be able to work with the mixing buffer
-			* directly  --paper */
-			for (i = 0; i < ARRAY_SIZE(buffers); i++) {
-				int32_t opl_v = csf->opl_to_chan[i];
-				if (opl_v < 0 || opl_v >= MAX_VOICES /* this is a bug */)
-					continue;
-
-				buffers[i] = (csf->voices[opl_v].flags & CHN_MUTE) ? NULL : csf->mix_buffer;
-			}
+			buffers[i] = csf->multi_write[opl_v].buffer;
 		}
+	}
+	else {
+		memset(buf, 0, OPL_CHANNELS * sz * sizeof(int32_t));
 
-		OPLUpdateMulti(csf->opl, buffers, count, vu_max);
+		for (i = 0; i < OPL_CHANNELS; i++)
+			buffers[i] = &buf[i * sz];
+	}
 
-		for (i = 0; i < ARRAY_SIZE(buffers); i++) {
-			if (!buffers[i]) continue;
+	OPLUpdateMulti(csf->opl, buffers, count, vu_max);
 
-			for (j = 0; j < sz; j++)
-				buffers[i][j] *= OPL_VOLUME;
-		}
+	for (i = 0; i < OPL_CHANNELS; i++) {
+		if (!buffers[i]) continue;
+
+		for (uint32_t j = 0; j < sz; j++)
+			buffers[i][j] *= OPL_VOLUME;
 	}
 
 	for (i = 0; i < OPL_CHANNELS; i++) {
 		int32_t opl_v = csf->opl_to_chan[i];
+		int32_t *buf;
+		song_voice_t *voice;
+		int8_t *recent_sample_buffer;
+		int oldest_recent_sample;
+
 		if (opl_v < 0 || opl_v >= MAX_VOICES /* this is a bug */)
 			continue;
 
-		csf->voices[opl_v].vu_meter = (vu_max[i] * OPL_VOLUME) >> 16;
+		voice = &csf->voices[opl_v];
+
+		voice->vu_meter = (vu_max[i] * OPL_VOLUME) >> 16;
+
+		recent_sample_buffer = RECENT_SAMPLE_BUFFER(csf, opl_v);
+
+		oldest_recent_sample = voice->oldest_recent_sample;
+
+#define MERGE_SAMPLE(l, r) ((l >> 1) + (r >> 1))
+#define CONVERT_SAMPLE(x) ((x) >> 17)
+
+		buf = buffers[i];
+
+		if (csf->multi_write) {
+			for (int j = 0; j < sz; j += 2) {
+				if (oldest_recent_sample > RECENT_SAMPLE_BUFFER_SIZE)
+					oldest_recent_sample = 0;
+
+				recent_sample_buffer[oldest_recent_sample] = CONVERT_SAMPLE(MERGE_SAMPLE(buf[j], buf[j + 1])) ^ 0x80;
+
+				oldest_recent_sample++;
+			}
+		} else {
+			/* we need the sample data to be a part of the common mixing buffer */
+			for (int j = 0; j < sz; j += 2) {
+				if (oldest_recent_sample > RECENT_SAMPLE_BUFFER_SIZE)
+					oldest_recent_sample = 0;
+
+				recent_sample_buffer[oldest_recent_sample] = CONVERT_SAMPLE(MERGE_SAMPLE(buf[j], buf[j + 1])) ^ 0x80;
+
+				csf->mix_buffer[j] += buf[j];
+				csf->mix_buffer[j + 1] += buf[j + 1];
+
+				oldest_recent_sample++;
+			}
+		}
+
+		voice->oldest_recent_sample = oldest_recent_sample;
 	}
+
+	SCHISM_VLA_FREE(buf);
+
+	/* main output recent samples */
+	int oldest_recent_output_sample = csf_get_oldest_recent_sample_output();
+	int8_t *recent_sample_buffer_l = RECENT_SAMPLE_BUFFER(csf, MAX_VOICES);
+	int8_t *recent_sample_buffer_r = RECENT_SAMPLE_BUFFER(csf, MAX_VOICES + 1);
+
+	for (int i = 0, l = sz * 2; i < sz; i += 2) {
+		if (oldest_recent_output_sample >= RECENT_SAMPLE_BUFFER_SIZE) {
+			oldest_recent_output_sample = 0;
+		}
+		recent_sample_buffer_l[oldest_recent_output_sample] = CONVERT_SAMPLE(csf->mix_buffer[i]) ^ 0x80;
+		recent_sample_buffer_r[oldest_recent_output_sample] = CONVERT_SAMPLE(csf->mix_buffer[i + 1]) ^ 0x80;
+		oldest_recent_output_sample++;
+	}
+
+	csf_set_oldest_recent_sample_output(oldest_recent_output_sample);
 }
 
 

--- a/player/snd_fm.c
+++ b/player/snd_fm.c
@@ -265,11 +265,8 @@ void Fmdrv_Mix(song_t *csf, uint32_t count)
 		}
 	}
 	else {
-		if (!csf->opl_buffer_data) {
-			SCHISM_RUNTIME_ASSERT(sz <= MIXBUFFERSIZE * 2, "Fmdrv_Mix can only process up to MIXBUFFERSIZE samples at a time, caller requested more");
-			csf->opl_buffer_data = mem_calloc(OPL_CHANNELS, MIXBUFFERSIZE * 2 * sizeof(int32_t));
-		}
-
+		SCHISM_RUNTIME_ASSERT(sz <= MIXBUFFERSIZE * 2, "Fmdrv_Mix can only process up to MIXBUFFERSIZE samples at a time, caller requested more");
+\
 		memset(csf->opl_buffer_data, 0, OPL_CHANNELS * sz * sizeof(int32_t));
 
 		for (i = 0; i < OPL_CHANNELS; i++)
@@ -336,7 +333,7 @@ void Fmdrv_Mix(song_t *csf, uint32_t count)
 	}
 
 	/* main output recent samples */
-	int oldest_recent_output_sample = csf_get_oldest_recent_sample_output();
+	int oldest_recent_output_sample = csf->oldest_recent_output_sample;
 	int8_t *recent_sample_buffer_l = RECENT_SAMPLE_BUFFER(csf, MAX_VOICES);
 	int8_t *recent_sample_buffer_r = RECENT_SAMPLE_BUFFER(csf, MAX_VOICES + 1);
 
@@ -349,7 +346,7 @@ void Fmdrv_Mix(song_t *csf, uint32_t count)
 		oldest_recent_output_sample++;
 	}
 
-	csf_set_oldest_recent_sample_output(oldest_recent_output_sample);
+	csf->oldest_recent_output_sample = oldest_recent_output_sample;
 }
 
 

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -33,7 +33,7 @@
 #include "config-parser.h"
 #include "keyboard.h"
 #include "str.h"
-#include "sndfile.h"
+#include "player/sndfile.h"
 
 /* --------------------------------------------------------------------- */
 

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -823,7 +823,8 @@ static void info_draw_waveform(struct info_window *window, int base, int height,
 		for (int x = x1 | 1; x <= x2; x += 2)
 			vgamem_ovl_drawpixel(&window->overlay, x, y2, WAVEFORM_BOX_OUTLINE_COLOUR);
 
-		if ((chan >= MAX_VOICES) || current_song->voices[chan].current_sample_data) {
+		if ((chan >= MAX_VOICES)
+		 || (voice->current_sample_data && (voice->left_volume || voice->right_volume)))
 			recent_samples = RECENT_SAMPLE_BUFFER(current_song, chan);
 			idx = (chan >= MAX_VOICES) ? csf_get_oldest_recent_sample_output() : current_song->voices[chan].oldest_recent_sample;
 

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -834,7 +834,7 @@ static void info_draw_waveform(struct info_window *window, int base, int height,
 			for (int x = x1, h = y2 - y1; x < x2; x++) {
 				int y;
 
-				if (idx >= NATIVE_SCREEN_WIDTH)
+				if (idx >= RECENT_SAMPLE_BUFFER_SIZE)
 					idx = 0;
 
 				y = y1 + (255 - recent_samples[idx]) * h / 255;

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -33,6 +33,7 @@
 #include "config-parser.h"
 #include "keyboard.h"
 #include "str.h"
+#include "sndfile.h"
 
 /* --------------------------------------------------------------------- */
 
@@ -47,11 +48,14 @@ static int instrument_names = 0;
 /* --------------------------------------------------------------------- */
 /* window setup */
 
+struct info_window;
+
 struct info_window_type {
 	const char *id;
 
-	void (*draw) (int base, int height, int active, int first_channel);
-	void (*click) (int x, int y, int num_vis_channel, int first_channel);
+	void (*recalculate) (struct info_window *window);
+	void (*draw) (struct info_window *window, int base, int height, int active, int first_channel);
+	void (*click) (struct info_window *window, int x, int y, int fx, int fy, int num_vis_channel, int first_channel);
 
 	/* if this is set, the first row contains actual text (not just the top part of a box) */
 	int first_row;
@@ -67,8 +71,10 @@ struct info_window_type {
 
 struct info_window {
 	int type;
-	int height;
+	int first_row, height;
+	const struct info_window_type *type_def;
 	int first_channel;
+	struct vgamem_overlay overlay;
 };
 
 static int selected_window = 0;
@@ -86,7 +92,7 @@ static struct info_window windows[MAX_WINDOWS] = {
 /* --------------------------------------------------------------------- */
 /* the various stuff that can be drawn... */
 
-static void info_draw_technical(int base, int height, int active, int first_channel)
+static void info_draw_technical(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int smp, pos, fg, c = first_channel;
 	char buf[64];
@@ -218,7 +224,7 @@ static void info_draw_technical(int base, int height, int active, int first_chan
 	}
 }
 
-static void info_draw_samples(int base, int height, int active, int first_channel)
+static void info_draw_samples(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int vu, smp, ins, n, pos, fg, fg2, c;
 	char buf[11];
@@ -509,7 +515,7 @@ static void _draw_track_view(int base, int height, int first_channel, int num_ch
 	}
 }
 
-static void info_draw_track_5(int base, int height, int active, int first_channel)
+static void info_draw_track_5(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int chan, chan_pos, fg;
 
@@ -524,7 +530,7 @@ static void info_draw_track_5(int base, int height, int active, int first_channe
 	_draw_track_view(base, height, first_channel, 5, 13, 1, draw_note_13);
 }
 
-static void info_draw_track_8(int base, int height, int active, int first_channel)
+static void info_draw_track_8(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int chan, chan_pos, fg;
 	char buf[11];
@@ -544,7 +550,7 @@ static void info_draw_track_8(int base, int height, int active, int first_channe
 	_draw_track_view(base, height, first_channel, 8, 8, 1, draw_note_8);
 }
 
-static void info_draw_track_10(int base, int height, int active, int first_channel)
+static void info_draw_track_10(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int chan, chan_pos, fg;
 	char buf[11];
@@ -564,7 +570,7 @@ static void info_draw_track_10(int base, int height, int active, int first_chann
 	_draw_track_view(base, height, first_channel, 10, 7, 0, draw_note_7);
 }
 
-static void info_draw_track_12(int base, int height, int active, int first_channel)
+static void info_draw_track_12(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int chan, chan_pos, fg;
 	char buf[11];
@@ -584,7 +590,7 @@ static void info_draw_track_12(int base, int height, int active, int first_chann
 	_draw_track_view(base, height, first_channel, 12, 6, 0, draw_note_6);
 }
 
-static void info_draw_track_18(int base, int height, int active, int first_channel)
+static void info_draw_track_18(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int chan, chan_pos, fg;
 	char buf[11];
@@ -600,7 +606,7 @@ static void info_draw_track_18(int base, int height, int active, int first_chann
 	_draw_track_view(base, height, first_channel, 18, 3, 1, draw_note_3);
 }
 
-static void info_draw_track_24(int base, int height, int active, int first_channel)
+static void info_draw_track_24(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int chan, chan_pos, fg;
 	char buf[11];
@@ -616,7 +622,7 @@ static void info_draw_track_24(int base, int height, int active, int first_chann
 	_draw_track_view(base, height, first_channel, 24, 3, 0, draw_note_3);
 }
 
-static void info_draw_track_36(int base, int height, int active, int first_channel)
+static void info_draw_track_36(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int chan, chan_pos, fg;
 	char buf[11];
@@ -632,7 +638,7 @@ static void info_draw_track_36(int base, int height, int active, int first_chann
 	_draw_track_view(base, height, first_channel, 36, 2, 0, draw_note_2);
 }
 
-static void info_draw_track_64(int base, int height, int active, int first_channel)
+static void info_draw_track_64(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int chan, chan_pos, fg;
 	/* IT draws nine more blank "channels" on the right */
@@ -654,7 +660,7 @@ static void info_draw_track_64(int base, int height, int active, int first_chann
 	_draw_track_view(base, height, first_channel, nchan, 1, 0, draw_note_1);
 }
 
-static void info_draw_channels(int base, SCHISM_UNUSED int height, int active, SCHISM_UNUSED int first_channel)
+static void info_draw_channels(SCHISM_UNUSED struct info_window *window, int base, SCHISM_UNUSED int height, int active, SCHISM_UNUSED int first_channel)
 {
 	char buf[32];
 	int fg = (active ? 3 : 0);
@@ -668,7 +674,7 @@ static void info_draw_channels(int base, SCHISM_UNUSED int height, int active, S
 
 
 /* Yay it works, only took me forever and a day to get it right. */
-static void info_draw_note_dots(int base, int height, int active, int first_channel)
+static void info_draw_note_dots(SCHISM_UNUSED struct info_window *window, int base, int height, int active, int first_channel)
 {
 	int fg, v;
 	int c, pos;
@@ -729,10 +735,133 @@ static void info_draw_note_dots(int base, int height, int active, int first_chan
 	}
 }
 
+#ifdef ENABLE_WAVEFORMVIS
+static void _calculate_channel_layout(int num_channels, int width, int height, int *num_rows, int *num_columns)
+{
+	for (*num_rows = 1; *num_rows < 8; (*num_rows)++)
+	{
+		int channel_width, channel_height;
+		int aspect; // scaled up by 100
+
+		*num_columns = (num_channels + *num_rows - 1) / *num_rows;
+
+		channel_width = width / *num_columns;
+		channel_height = height / *num_rows;
+
+		aspect = channel_height * 100 / channel_width;
+
+		if (aspect < 180)
+			break;
+	}
+}
+
+static void info_draw_waveform_recalculate(struct info_window *window)
+{
+	window->overlay.x1 = 3;
+	window->overlay.x2 = 77;
+	window->overlay.y1 = window->first_row + 1;
+	window->overlay.y2 = window->first_row + window->height - 2;
+
+	vgamem_ovl_alloc(&window->overlay);
+}
+
+#define WAVEFORM_BOX_OUTLINE_COLOUR 1
+#define WAVEFORM_COLOUR 5
+
+static void info_draw_waveform(struct info_window *window, int base, int height, int active, int first_channel)
+{
+	int num_channels = window->type_def->channels;
+
+	if (num_channels == 0) {
+		// mix output
+		first_channel = MAX_VOICES + 1;
+		num_channels = current_song->flags & SONG_NOSTEREO ? 1 : 2;
+	}
+
+	int num_rows, num_columns;
+	int chan, chan_pos;
+
+	if ((window->overlay.width <= 0) || (window->overlay.height <= 0))
+		return;
+
+	_calculate_channel_layout(num_channels, window->overlay.width, window->overlay.height, &num_rows, &num_columns);
+
+	vgamem_ovl_clear(&window->overlay, 0);
+
+	for (chan = MAX(0, first_channel - 1), chan_pos = 0; chan_pos < num_channels; chan++, chan_pos++) {
+		int row = chan_pos / num_columns;
+		int col = chan_pos % num_columns;
+
+		int x1 = col * window->overlay.width / num_columns;
+		int y1 = row * window->overlay.height / num_rows;
+		int x2 = (col + 1) * window->overlay.width / num_columns - 1;
+		int y2 = (row + 1) * window->overlay.height / num_rows - 1;
+
+		uint8_t *recent_samples;
+		int idx;
+
+		for (int y = y1 | 1; y <= y2; y += 2)
+			vgamem_ovl_drawpixel(&window->overlay, x2, y, WAVEFORM_BOX_OUTLINE_COLOUR);
+		for (int x = x1 | 1; x <= x2; x += 2)
+			vgamem_ovl_drawpixel(&window->overlay, x, y2, WAVEFORM_BOX_OUTLINE_COLOUR);
+
+		if ((chan >= MAX_VOICES) || current_song->voices[chan].current_sample_data) {
+			recent_samples = RECENT_SAMPLE_BUFFER(chan);
+			idx = (chan >= MAX_VOICES) ? csf_get_oldest_recent_sample_output() : current_song->voices[chan].oldest_recent_sample;
+
+#ifdef WAVEFORMVIS_JOINED
+			int ly = -1;
+#endif
+
+			for (int x = x1, h = y2 - y1; x < x2; x++) {
+				int y;
+
+				if (idx >= NATIVE_SCREEN_WIDTH)
+					idx = 0;
+
+				y = y1 + (255 - recent_samples[idx]) * h / 255;
+
+#ifndef WAVEFORMVIS_JOINED
+				vgamem_ovl_drawpixel(&window->overlay, x, y, WAVEFORM_COLOUR);
+#else
+				if (ly < 0) {
+					vgamem_ovl_drawpixel(&window->overlay, x, y, WAVEFORM_COLOUR);
+					ly = y;
+				}
+				else {
+					vgamem_ovl_drawline(&window->overlay, x, ly + (y > ly ? 1 : 0), x, y, WAVEFORM_COLOUR);
+					ly = y;
+				}
+#endif
+
+				idx = idx + 1;
+			}
+		}
+	}
+
+	draw_box(2, window->first_row, 78, window->first_row + window->height - 1, BOX_THICK | BOX_INNER | BOX_INSET);
+	vgamem_ovl_apply(&window->overlay);
+}
+
+static void waveform_channels_click(struct info_window *window, int x, int y, int fx, int fy, int nc, int fc)
+{
+	int num_rows, num_columns;
+	int row, col;
+
+	if ((window->overlay.width <= 0) || (window->overlay.height <= 0))
+		return;
+
+	col = (fx - 8 * window->overlay.x1) * num_columns / window->overlay.width;
+	row = (fy - 8 * window->overlay.y1) * num_rows / window->overlay.height;
+
+	selected_channel = 1 + CLAMP(row * num_columns + col, 0, 63);
+}
+#endif /* ENABLE_WAVEFORMVIS */
+
 /* --------------------------------------------------------------------- */
 /* click receivers */
 
-static void click_chn_x(int x, int w, int skip, int fc)
+static void click_chn_x(struct info_window *window, int x, int w, SCHISM_UNUSED int fx, SCHISM_UNUSED int fy, int skip, int fc)
 {
 	while (x > 0 && fc <= 64) {
 		if (x < w) {
@@ -745,47 +874,47 @@ static void click_chn_x(int x, int w, int skip, int fc)
 	}
 }
 
-static void click_chn_is_x(int x, SCHISM_UNUSED int y, int nc, int fc)
+static void click_chn_is_x(struct info_window *window, int x, SCHISM_UNUSED int y, SCHISM_UNUSED int fx, SCHISM_UNUSED int fy, int nc, int fc)
 {
 	if (x < 5) return;
 	x -= 4;
 	switch (nc) {
 	case 5:
-		click_chn_x(x, 13, 1, fc);
+		click_chn_x(window, x, 13, 0, 0, 1, fc);
 		break;
 	case 10:
-		click_chn_x(x, 7, 0, fc);
+		click_chn_x(window, x, 7, 0, 0, 0, fc);
 		break;
 	case 12:
-		click_chn_x(x, 6, 0, fc);
+		click_chn_x(window, x, 6, 0, 0, 0, fc);
 		break;
 	case 18:
-		click_chn_x(x, 3, 1, fc);
+		click_chn_x(window, x, 3, 0, 0, 1, fc);
 		break;
 	case 24:
-		click_chn_x(x, 3, 0, fc);
+		click_chn_x(window, x, 3, 0, 0, 0, fc);
 		break;
 	case 36:
-		click_chn_x(x, 2, 0, fc);
+		click_chn_x(window, x, 2, 0, 0, 0, fc);
 		break;
 	case 64:
-		click_chn_x(x, 1, 0, fc);
+		click_chn_x(window, x, 1, 0, 0, 0, fc);
 		break;
 	};
 }
 
-static void click_chn_is_y_nohead(SCHISM_UNUSED int x, int y, SCHISM_UNUSED int nc, int fc)
+static void click_chn_is_y_nohead(SCHISM_UNUSED struct info_window *window, SCHISM_UNUSED int x, int y, SCHISM_UNUSED int fx, SCHISM_UNUSED int fy, SCHISM_UNUSED int nc, int fc)
 {
 	selected_channel = CLAMP(y+fc, 1, 64);
 }
 
-static void click_chn_is_y(SCHISM_UNUSED int x, int y, SCHISM_UNUSED int nc, int fc)
+static void click_chn_is_y(SCHISM_UNUSED struct info_window *window, SCHISM_UNUSED int x, int y, SCHISM_UNUSED int fx, SCHISM_UNUSED int fy, SCHISM_UNUSED int nc, int fc)
 {
 	if (!y) return;
 	selected_channel = CLAMP((y+fc)-1, 1, 64);
 }
 
-static void click_chn_nil(SCHISM_UNUSED int x, SCHISM_UNUSED int y, SCHISM_UNUSED int nc, SCHISM_UNUSED int fc)
+static void click_chn_nil(SCHISM_UNUSED struct info_window *window, SCHISM_UNUSED int x, SCHISM_UNUSED int y, SCHISM_UNUSED int fx, SCHISM_UNUSED int fy, SCHISM_UNUSED int nc, SCHISM_UNUSED int fc)
 {
 	/* do nothing */
 }
@@ -793,9 +922,9 @@ static void click_chn_nil(SCHISM_UNUSED int x, SCHISM_UNUSED int y, SCHISM_UNUSE
 /* --------------------------------------------------------------------- */
 /* declarations of the window types */
 
-#define TRACK_VIEW(n) {"track" # n, info_draw_track_##n, click_chn_is_x, 1, n}
+#define TRACK_VIEW(n) {"track" # n, NULL, info_draw_track_##n, click_chn_is_x, 1, n}
 static const struct info_window_type window_types[] = {
-	{"samples", info_draw_samples, click_chn_is_y_nohead, 0, -2},
+	{"samples", NULL, info_draw_samples, click_chn_is_y_nohead, 0, -2},
 	TRACK_VIEW(5),
 	TRACK_VIEW(8),
 	TRACK_VIEW(10),
@@ -804,9 +933,17 @@ static const struct info_window_type window_types[] = {
 	TRACK_VIEW(24),
 	TRACK_VIEW(36),
 	TRACK_VIEW(64),
-	{"global", info_draw_channels, click_chn_nil, 1, 0},
-	{"dots", info_draw_note_dots, click_chn_is_y_nohead, 0, -2},
-	{"tech", info_draw_technical, click_chn_is_y, 1, -2},
+	{"global", NULL, info_draw_channels, click_chn_nil, 1, 0},
+	{"dots", NULL, info_draw_note_dots, click_chn_is_y_nohead, 0, -2},
+	{"tech", NULL, info_draw_technical, click_chn_is_y, 1, -2},
+#ifdef ENABLE_WAVEFORMVIS
+	{"waveform-channels-4", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 4},
+	{"waveform-channels-8", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 8},
+	{"waveform-channels-16", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 16},
+	{"waveform-channels-32", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 32},
+	{"waveform-channels-64", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 64},
+	{"waveform-output", info_draw_waveform_recalculate, info_draw_waveform, click_chn_nil, 0, 0},
+#endif /* ENABLE_WAVEFORMVIS */
 };
 #undef TRACK_VIEW
 
@@ -836,7 +973,7 @@ static void _fix_channels(int n)
 	w->first_channel = CLAMP(w->first_channel, 1, MAX_CHANNELS - channels + 1);
 }
 
-static int info_handle_click(int x, int y)
+static int info_handle_click(int x, int y, int fx, int fy)
 {
 	int n;
 	if (y < 13) return 0; /* NA */
@@ -844,7 +981,10 @@ static int info_handle_click(int x, int y)
 	for (n = 0; n < num_windows; n++) {
 		if (y < windows[n].height) {
 			window_types[windows[n].type].click(
+				&windows[n],
+
 				x, y,
+				fx, fy,
 
 				window_types[windows[n].type].channels,
 				windows[n].first_channel);
@@ -862,11 +1002,14 @@ static void recalculate_windows(void)
 	pos = 13;
 	for (n = 0; n < num_windows - 1; n++) {
 		_fix_channels(n);
+		windows[n].first_row = pos;
 		pos += windows[n].height;
 		if (pos > 50) {
 			/* Too big? Throw out the rest of the windows. */
 			num_windows = n;
 		}
+		if (windows[n].type_def->recalculate)
+			windows[n].type_def->recalculate(&windows[n]);
 	}
 	SCHISM_RUNTIME_ASSERT(num_windows > 0, "Should always have at least one window.");
 	windows[n].height = 50 - pos;
@@ -900,6 +1043,21 @@ void cfg_save_info(cfg_file_t *cfg)
 	cfg_set_string(cfg, "Info Page", "layout", buf + 1);
 }
 
+static void reset_window_layout(void)
+{
+	/* Fall back to defaults */
+	num_windows = 3;
+	windows[0].type = 0;    /* samples */
+	windows[0].type_def = &window_types[windows[0].type];
+	windows[0].height = 19;
+	windows[1].type = 9;    /* active channels */
+	windows[1].type_def = &window_types[windows[1].type];
+	windows[1].height = 3;
+	windows[2].type = 6;    /* 24chn track view */
+	windows[2].type_def = &window_types[windows[2].type];
+	windows[2].height = 15;
+}
+
 static void cfg_load_info_old(cfg_file_t *cfg)
 {
 	char key[] = "windowX";
@@ -927,20 +1085,15 @@ static void cfg_load_info_old(cfg_file_t *cfg)
 		if (windows[i].type < 0 || windows[i].type >= NUM_WINDOW_TYPES || windows[i].height < 3) {
 			/* Broken window? */
 			num_windows = -1;
+			windows[i].type_def = NULL;
 			break;
 		}
+		windows[num_windows].type_def = &window_types[windows[num_windows].type];
 	}
 	/* last window's size < 3 lines? */
 
 	if (num_windows == -1) {
-		/* Fall back to defaults */
-		num_windows = 3;
-		windows[0].type = 0;    /* samples */
-		windows[0].height = 19;
-		windows[1].type = 9;    /* active channels */
-		windows[1].height = 3;
-		windows[2].type = 6;    /* 24chn track view */
-		windows[2].height = 15;
+		reset_window_layout();
 	}
 
 	for (i = 0; i < num_windows; i++) {
@@ -979,6 +1132,7 @@ void cfg_load_info(cfg_file_t *cfg)
 		for (n = 0; n < NUM_WINDOW_TYPES; n++) {
 			if (strcasecmp(window_types[n].id, left) == 0) {
 				windows[num_windows].type = n;
+				windows[num_windows].type_def = &window_types[windows[num_windows].type];
 				break;
 			}
 		}
@@ -993,8 +1147,14 @@ void cfg_load_info(cfg_file_t *cfg)
 			// failed to parse any digits, or number is too small
 			break;
 		}
-		windows[num_windows++].height = n;
+		windows[num_windows].height = n;
+
+		num_windows++;
 	} while (num_windows < MAX_WINDOWS - 1);
+
+	if (num_windows <= 0) {
+		reset_window_layout();
+	}
 
 	recalculate_windows();
 	if (status.current_page == PAGE_INFO)
@@ -1011,12 +1171,12 @@ static void info_page_redraw(void)
 		height = windows[n].height;
 		if (pos == 12)
 			height++;
-		window_types[windows[n].type].draw(pos, height, (n == selected_window),
+		window_types[windows[n].type].draw(&windows[n], pos, height, (n == selected_window),
 						   windows[n].first_channel);
 		pos += height;
 	}
 	/* the last window takes up all the rest of the screen */
-	window_types[windows[n].type].draw(pos, 50 - pos, (n == selected_window), windows[n].first_channel);
+	window_types[windows[n].type].draw(&windows[n], pos, 50 - pos, (n == selected_window), windows[n].first_channel);
 }
 
 /* --------------------------------------------------------------------- */
@@ -1027,7 +1187,7 @@ static int info_page_handle_key(struct key_event * k)
 
 	if (k->mouse == MOUSE_CLICK || k->mouse == MOUSE_DBLCLICK) {
 		p = selected_channel;
-		n = info_handle_click(k->x, k->y);
+		n = info_handle_click(k->x, k->y, k->fx, k->fy);
 		if (k->mouse == MOUSE_DBLCLICK) {
 			/* TODO: should this only be handled if info_handle_click
 			 * actually returns 1 ? */
@@ -1283,6 +1443,7 @@ static int info_page_handle_key(struct key_event * k)
 			n = NUM_WINDOW_TYPES;
 		n--;
 		windows[selected_window].type = n;
+		windows[selected_window].type_def = &window_types[windows[selected_window].type];
 		break;
 	case SCHISM_KEYSYM_PAGEDOWN:
 		if (!NO_MODIFIER(k->mod))
@@ -1290,6 +1451,7 @@ static int info_page_handle_key(struct key_event * k)
 		if (k->state == KEY_RELEASE)
 			return 1;
 		windows[selected_window].type = (windows[selected_window].type + 1) % NUM_WINDOW_TYPES;
+		windows[selected_window].type_def = &window_types[windows[selected_window].type];
 		break;
 	case SCHISM_KEYSYM_TAB:
 		if (k->state == KEY_RELEASE)

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -830,9 +830,9 @@ static void info_draw_waveform(struct info_window *window, int base, int height,
 		if ((chan >= MAX_VOICES)
 			? current_song->mix_stat /* main mixer output -- is anything playing? */
 			: ((voice->current_sample_data && (voice->left_volume || voice->right_volume)) /* PCM */
-		 || (current_song->opl_from_chan[chan] >= 0))) /* FM */ {
+			|| ((voice->flags & CHN_ADLIB) && (current_song->opl_from_chan[chan] >= 0)))) /* FM */ {
 			recent_samples = RECENT_SAMPLE_BUFFER(current_song, chan);
-			idx = (chan >= MAX_VOICES) ? csf_get_oldest_recent_sample_output() : voice->oldest_recent_sample;
+			idx = (chan >= MAX_VOICES) ? current_song->oldest_recent_output_sample : voice->oldest_recent_sample;
 
 			draw_sample_data_ex_8(
 				&window->overlay,

--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -67,6 +67,9 @@ struct info_window_type {
 	uses -2.) confusing, almost to the point of being painful, but it works. (ok, i admit, it's not
 	the most brilliant idea i ever had ;) */
 	int channels;
+
+	/* if this is true, then this window is visualizing voices, not channels */
+	int shows_voices;
 };
 
 struct info_window {
@@ -74,12 +77,14 @@ struct info_window {
 	int first_row, height;
 	const struct info_window_type *type_def;
 	int first_channel;
+	int hide_waveform_label; // for waveform windows, should the channel number be overlaid in the top-left?
 	struct vgamem_overlay overlay;
 };
 
 static int selected_window = 0;
 static int num_windows = 3;
 static int selected_channel = 1;
+static int selected_voice = 1;
 
 /* five, because that's Impulse Tracker's maximum */
 #define MAX_WINDOWS 5
@@ -767,6 +772,7 @@ static void info_draw_waveform_recalculate(struct info_window *window)
 
 #define WAVEFORM_BOX_OUTLINE_COLOUR 1
 #define WAVEFORM_COLOUR 5
+#define LABEL_COLOUR 6
 
 static void info_draw_waveform(struct info_window *window, int base, int height, int active, int first_channel)
 {
@@ -777,6 +783,9 @@ static void info_draw_waveform(struct info_window *window, int base, int height,
 		first_channel = MAX_VOICES + 1;
 		num_channels = current_song->flags & SONG_NOSTEREO ? 1 : 2;
 	}
+	else {
+		first_channel = selected_voice; // we're not a list view
+	}
 
 	int num_rows, num_columns;
 	int chan, chan_pos;
@@ -785,6 +794,15 @@ static void info_draw_waveform(struct info_window *window, int base, int height,
 		return;
 
 	_calculate_channel_layout(num_channels, window->overlay.width, window->overlay.height, &num_rows, &num_columns);
+
+	if (num_rows * num_columns > num_channels) {
+		num_channels = MIN(num_rows * num_columns, MAX_VOICES);
+
+		if (first_channel + num_channels > MAX_VOICES) {
+			selected_voice = MAX(MAX_VOICES - num_channels + 1, 0);
+			first_channel = selected_voice;
+		}
+	}
 
 	vgamem_ovl_clear(&window->overlay, 0);
 
@@ -806,7 +824,7 @@ static void info_draw_waveform(struct info_window *window, int base, int height,
 			vgamem_ovl_drawpixel(&window->overlay, x, y2, WAVEFORM_BOX_OUTLINE_COLOUR);
 
 		if ((chan >= MAX_VOICES) || current_song->voices[chan].current_sample_data) {
-			recent_samples = RECENT_SAMPLE_BUFFER(chan);
+			recent_samples = RECENT_SAMPLE_BUFFER(current_song, chan);
 			idx = (chan >= MAX_VOICES) ? csf_get_oldest_recent_sample_output() : current_song->voices[chan].oldest_recent_sample;
 
 #ifdef WAVEFORMVIS_JOINED
@@ -836,6 +854,21 @@ static void info_draw_waveform(struct info_window *window, int base, int height,
 
 				idx = idx + 1;
 			}
+		}
+
+		if (!window->hide_waveform_label) {
+			char buf[10];
+
+			if (chan < MAX_VOICES) {
+				str_from_num(0, chan + 1, buf);
+			} else if (num_channels == 1) {
+				strcpy(buf, "LR");
+			} else {
+				buf[0] = "LR"[chan - MAX_VOICES];
+				buf[1] = 0;
+			}
+
+			vgamem_ovl_drawtext_halfwidth(&window->overlay, buf, x1 + 2, y1 + 2, LABEL_COLOUR);
 		}
 	}
 
@@ -937,11 +970,11 @@ static const struct info_window_type window_types[] = {
 	{"dots", NULL, info_draw_note_dots, click_chn_is_y_nohead, 0, -2},
 	{"tech", NULL, info_draw_technical, click_chn_is_y, 1, -2},
 #ifdef ENABLE_WAVEFORMVIS
-	{"waveform-channels-4", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 4},
-	{"waveform-channels-8", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 8},
-	{"waveform-channels-16", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 16},
-	{"waveform-channels-32", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 32},
-	{"waveform-channels-64", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 64},
+	{"waveform-channels-4", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 4, 1},
+	{"waveform-channels-8", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 8, 1},
+	{"waveform-channels-16", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 16, 1},
+	{"waveform-channels-32", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 32, 1},
+	{"waveform-channels-64", info_draw_waveform_recalculate, info_draw_waveform, waveform_channels_click, 0, 64, 1},
 	{"waveform-output", info_draw_waveform_recalculate, info_draw_waveform, click_chn_nil, 0, 0},
 #endif /* ENABLE_WAVEFORMVIS */
 };
@@ -1267,6 +1300,10 @@ static int info_page_handle_key(struct key_event * k)
 			return 1;
 		}
 		return 0;
+	case SCHISM_KEYSYM_n:
+		if ((k->mod & SCHISM_KEYMOD_ALT) && (k->state == KEY_PRESS)) {
+			windows[selected_window].hide_waveform_label = !windows[selected_window].hide_waveform_label;
+		}
 	case SCHISM_KEYSYM_EQUALS:
 		if (!(k->mod & SCHISM_KEYMOD_SHIFT))
 			return 0;
@@ -1339,8 +1376,17 @@ static int info_page_handle_key(struct key_event * k)
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (selected_channel > 1)
-			selected_channel--;
+
+		if (windows[selected_window].type_def->shows_voices) {
+			if (selected_voice > 1)
+				selected_voice--;
+			selected_channel = CLAMP(selected_voice, 1, MAX_CHANNELS);
+		}
+		else {
+			if (selected_channel > 1)
+				selected_channel--;
+			selected_voice = selected_channel;
+		}
 		break;
 	case SCHISM_KEYSYM_DOWN:
 		if (k->state == KEY_RELEASE)
@@ -1367,14 +1413,16 @@ static int info_page_handle_key(struct key_event * k)
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
-		if (selected_channel < MAX_CHANNELS)
-			selected_channel++;
+		if (selected_voice < MAX_VOICES)
+			selected_voice++;
+		selected_channel = CLAMP(selected_voice, 1, MAX_CHANNELS);
 		break;
 	case SCHISM_KEYSYM_HOME:
 		if (!NO_MODIFIER(k->mod))
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
+		selected_voice = 0;
 		selected_channel = 1;
 		break;
 	case SCHISM_KEYSYM_END:
@@ -1382,6 +1430,7 @@ static int info_page_handle_key(struct key_event * k)
 			return 0;
 		if (k->state == KEY_RELEASE)
 			return 1;
+		selected_voice = MAX_VOICES;
 		selected_channel = song_find_last_channel() + 1;
 		break;
 	case SCHISM_KEYSYM_INSERT:

--- a/schism/vgamem.c
+++ b/schism/vgamem.c
@@ -299,6 +299,37 @@ void vgamem_ovl_drawline(struct vgamem_overlay *n, int xs,
 	}
 }
 
+void vgamem_ovl_drawtext_halfwidth(struct vgamem_overlay *n, char *text, int x, int y, int colour)
+{
+	while (text[0]) {
+		uint8_t c0 = text[0] ? text[0] : 32;
+		uint8_t c1 = text[1] ? text[1] : 32;
+
+		int o0 = c0 * 4;
+		int o1 = c1 * 4;
+
+		for (int yy = 0; yy < 8; yy++) {
+			int b = yy / 2;
+			int s = 4 - (yy & 1) * 4;
+
+			const uint_fast8_t dg1 = 0xF & (font_half_data[o0 + b] >> s);
+			const uint_fast8_t dg2 = 0xF & (font_half_data[o1 + b] >> s);
+
+			const uint_fast8_t dg = dg1 << 4 | dg2;
+
+			for (int xx = 0, xb = 128; xx < 8; xx++, xb >>= 1)
+				if (dg & xb)
+					vgamem_ovl_drawpixel(n, x + xx, y + yy, colour);
+		}
+
+		if (!text[1])
+			break;
+
+		text += 2;
+		x += 8;
+	}
+}
+
 /* unknown character (basically an inverted '?') */
 static const uint8_t uFFFD[] = {
 	0x42, /* .X....X. */
@@ -768,7 +799,7 @@ void draw_vu_meter(int x, int y, int width, int val, int color, int peak)
 
 /* --------------------------------------------------------------------- */
 /* sample drawing
- * 
+ *
  * output channels = number of oscis
  * input channels = number of channels in data
 */

--- a/schism/vgamem.c
+++ b/schism/vgamem.c
@@ -1264,74 +1264,34 @@ void draw_sample_data(struct vgamem_overlay *r, song_sample_t *sample)
 	vgamem_ovl_apply(r);
 }
 
-void draw_sample_data_rect_32(struct vgamem_overlay *r, int32_t *data,
-	int length, unsigned int inputchans, unsigned int outputchans)
-{
-	int advance = _muldiv(length, 256, r->width);
-	int chn;
-
-	vgamem_ovl_clear(r, 0);
-
-	for (chn = 0; chn < outputchans; chn++)
-	{
-		int y1 = chn * r->height / outputchans;
-		int y2 = (chn + 1) * r->height / outputchans - 1;
-
-		draw_sample_data_ex_32(
-			r,
-			0, y1, r->width, y2,
-			data, chn, outputchans, advance, length,
-			INT32_MIN, INT32_MAX,
-			SAMPLE_DATA_COLOR, SAMPLE_DRAW_STYLE_FILLED);
+#define DRAW_SAMPLE_DATA_RECT_VARIANT(BITS, SIGNARG) \
+	void draw_sample_data_rect_##BITS(struct vgamem_overlay *r, int##BITS##_t *data, \
+		int length, unsigned int inputchans, unsigned int outputchans) \
+	{ \
+		int advance = _muldiv(length, 256, r->width); \
+		int chn; \
+\
+		vgamem_ovl_clear(r, 0); \
+\
+		for (chn = 0; chn < outputchans; chn++) \
+		{ \
+			int y1 = chn * r->height / outputchans; \
+			int y2 = (chn + 1) * r->height / outputchans - 1; \
+\
+			draw_sample_data_ex_##BITS( \
+				r, \
+				0, y1, r->width, y2, \
+				data, chn, outputchans, advance, length, SIGNARG \
+				INT##BITS##_MIN, INT##BITS##_MAX, \
+				SAMPLE_DATA_COLOR, SAMPLE_DRAW_STYLE_FILLED); \
+		} \
+\
+		vgamem_ovl_apply(r); \
 	}
 
-	vgamem_ovl_apply(r);
-}
+#define SIGNARG_8B 1,
+#define SIGNARG_NONE
 
-void draw_sample_data_rect_16(struct vgamem_overlay *r, int16_t *data,
-	int length, unsigned int inputchans, unsigned int outputchans)
-{
-	int advance = _muldiv(length, 256, r->width);
-	int chn;
-
-	vgamem_ovl_clear(r, 0);
-
-	for (chn = 0; chn < outputchans; chn++)
-	{
-		int y1 = chn * r->height / outputchans;
-		int y2 = (chn + 1) * r->height / outputchans - 1;
-
-		draw_sample_data_ex_16(
-			r,
-			0, y1, r->width, y2,
-			data, chn, outputchans, advance, length,
-			INT16_MIN, INT16_MAX,
-			SAMPLE_DATA_COLOR, SAMPLE_DRAW_STYLE_FILLED);
-	}
-
-	vgamem_ovl_apply(r);
-}
-
-void draw_sample_data_rect_8(struct vgamem_overlay *r, int8_t *data,
-	int length, unsigned int inputchans, unsigned int outputchans)
-{
-	int advance = _muldiv(length, 256, r->width);
-	int chn;
-
-	vgamem_ovl_clear(r, 0);
-
-	for (chn = 0; chn < outputchans; chn++)
-	{
-		int y1 = chn * r->height / outputchans;
-		int y2 = (chn + 1) * r->height / outputchans - 1;
-
-		draw_sample_data_ex_8(
-			r,
-			0, y1, r->width, y2,
-			data, chn, outputchans, advance, length, 1,
-			INT8_MIN, INT8_MAX,
-			SAMPLE_DATA_COLOR, SAMPLE_DRAW_STYLE_FILLED);
-	}
-
-	vgamem_ovl_apply(r);
-}
+DRAW_SAMPLE_DATA_RECT_VARIANT(32, SIGNARG_NONE)
+DRAW_SAMPLE_DATA_RECT_VARIANT(16, SIGNARG_NONE)
+DRAW_SAMPLE_DATA_RECT_VARIANT(8, SIGNARG_8B)

--- a/schism/vgamem.c
+++ b/schism/vgamem.c
@@ -806,7 +806,7 @@ void draw_vu_meter(int x, int y, int width, int val, int color, int peak)
 
 #define DRAW_SAMPLE_DATA_EX_VARIANT(BITS, SCALE, SIGNARG_DEF, SIGN_FLIP_DEF, SIGN_FLIP_DO) \
 	void draw_sample_data_ex_##BITS(struct vgamem_overlay *r, int x1, int y1, int x2, int y2, \
-		int##BITS##_t *data, int offset, int stride, int advance, int length, SIGNARG_DEF \
+		int##BITS##_t *data, uint32_t offset, uint32_t stride, uint32_t advance, uint32_t length, SIGNARG_DEF \
 		int##BITS##_t min_value, int##BITS##_t max_value, int colour, sample_draw_style_t draw_style) \
 	{ \
 		int32_t mid = ((min_value >> (SCALE / 2)) + (max_value >> (SCALE / 2))) >> (1 + SCALE / 2); \
@@ -821,7 +821,7 @@ void draw_vu_meter(int x, int y, int width, int val, int color, int peak)
 		int ly = -1; \
 		int yy; \
 \
-		int walk = 0; \
+		uint32_t walk = 0; \
 \
 		for (int x = x1, h = y2 - y1 + 1; x < x2; x++) { \
 			int y; \
@@ -1050,9 +1050,9 @@ void draw_sample_data(struct vgamem_overlay *r, song_sample_t *sample)
 
 	/* do the actual drawing */
 	int chans = sample->flags & CHN_STEREO ? 2 : 1;
-	int stride = chans;
+	uint32_t stride = chans;
 
-	int samples_per_pixel = sample->length / r->width;
+	int32_t samples_per_pixel = sample->length / r->width;
 
 	if (samples_per_pixel > MAX_SAMPLES_PER_PIXEL) {
 		stride *= (1 + samples_per_pixel / MAX_SAMPLES_PER_PIXEL);
@@ -1062,7 +1062,7 @@ void draw_sample_data(struct vgamem_overlay *r, song_sample_t *sample)
 	{
 		int fy1 = chan * r->height / chans;
 		int fy2 = (chan + 1) * r->height / chans - 1;
-		int advance = _muldiv(sample->length * chans, 256, r->width * stride);
+		uint32_t advance = _muldiv(sample->length * chans, 256, r->width * stride);
 
 		if (sample->flags & CHN_16BIT)
 			draw_sample_data_ex_16(
@@ -1089,9 +1089,9 @@ void draw_sample_data(struct vgamem_overlay *r, song_sample_t *sample)
 
 #define DRAW_SAMPLE_DATA_RECT_VARIANT(BITS, SIGNARG) \
 	void draw_sample_data_rect_##BITS(struct vgamem_overlay *r, int##BITS##_t *data, \
-		int length, unsigned int inputchans, unsigned int outputchans) \
+		uint32_t length, unsigned int inputchans, uint32_t outputchans) \
 	{ \
-		int advance = _muldiv(length, 256, r->width); \
+		uint32_t advance = _muldiv(length, 256, r->width); \
 		int chn; \
 \
 		vgamem_ovl_clear(r, 0); \

--- a/schism/vgamem.c
+++ b/schism/vgamem.c
@@ -819,6 +819,7 @@ void draw_vu_meter(int x, int y, int width, int val, int color, int peak)
 		SIGN_FLIP_DEF \
 \
 		int ly = -1; \
+		int yy; \
 \
 		int walk = 0; \
 \
@@ -897,7 +898,7 @@ void draw_vu_meter(int x, int y, int width, int val, int color, int peak)
 				} \
 				break; \
 			case SAMPLE_DRAW_STYLE_FILLED: \
-				int yy = (int)min - min_value; \
+				yy = (int)min - min_value; \
 				yy = y1 + (range - yy) * h / range; \
 				vgamem_ovl_drawline(r, x, y, x, yy, colour); \
 				break; \

--- a/schism/vgamem.c
+++ b/schism/vgamem.c
@@ -802,7 +802,295 @@ void draw_vu_meter(int x, int y, int width, int val, int color, int peak)
  *
  * output channels = number of oscis
  * input channels = number of channels in data
-*/
+ */
+
+void draw_sample_data_ex_32(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
+	int32_t *data, int offset, int stride, int advance, int length,
+	int32_t min_value, int32_t max_value, int colour, sample_draw_style_t draw_style)
+{
+	// To avoid needing a 64-bit intermediate, all samples are scaled
+	// and the 16-bit values are then processed.
+
+	int32_t mid = ((min_value >> 8) + (max_value >> 8)) >> 9;
+
+	max_value >>= 16;
+	min_value >>= 16;
+
+	int32_t range = (int)max_value - min_value;
+
+	int ly = -1;
+
+	int walk = 0;
+
+	for (int x = x1, h = y2 - y1 + 1; x < x2; x++) {
+		int y;
+
+		int32_t min, max, max_mag = 0;
+
+		if (draw_style == SAMPLE_DRAW_STYLE_FILLED) {
+			min = INT32_MAX;
+			max = INT32_MIN;
+
+			while (walk < advance) {
+				int scaled, magnitude;
+
+				if (offset >= length)
+					offset -= length;
+
+				scaled = data[offset] >> 16;
+
+				if (scaled < min)
+					min = scaled;
+				if (scaled > max)
+					max = scaled;
+
+				offset += stride;
+
+				walk += 256;
+			}
+
+			walk -= advance;
+		}
+		else {
+			max = 0;
+
+			for (int i = 0; i < advance; i++) {
+				int scaled, magnitude;
+
+				if (offset >= length)
+					offset -= length;
+
+				scaled = data[offset] >> 16;
+				magnitude = scaled - mid;
+
+				if (magnitude < 0)
+					magnitude = -magnitude;
+
+				if (magnitude > max_mag) {
+					max = scaled;
+					max_mag = magnitude;
+				}
+
+				offset += stride;
+			}
+		}
+
+		y = (int)max - min_value;
+		y = y1 + (range - y) * h / range;
+
+		switch (draw_style) {
+		case SAMPLE_DRAW_STYLE_DOTS:
+			vgamem_ovl_drawpixel(r, x, y, colour);
+			break;
+		case SAMPLE_DRAW_STYLE_LINE:
+			if (ly < 0) {
+				vgamem_ovl_drawpixel(r, x, y, colour);
+				ly = y;
+			}
+			else {
+				vgamem_ovl_drawline(r, x, ly + (y > ly ? 1 : 0), x, y, colour);
+				ly = y;
+			}
+			break;
+		case SAMPLE_DRAW_STYLE_FILLED:
+			int yy = (int)min - min_value;
+			yy = y1 + (range - yy) * h / range;
+			vgamem_ovl_drawline(r, x, y, x, yy, colour);
+			break;
+		}
+	}
+}
+
+void draw_sample_data_ex_16(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
+	int16_t *data, int offset, int stride, int advance, int length,
+	int16_t min_value, int16_t max_value, int colour, sample_draw_style_t draw_style)
+{
+	int32_t mid = (min_value + max_value) >> 1;
+	int32_t range = (int)max_value - min_value;
+
+	int ly = -1;
+
+	int walk = 0;
+
+	for (int x = x1, h = y2 - y1 + 1; x < x2; x++) {
+		int y;
+
+		int32_t min, max, max_mag = 0;
+
+		if (draw_style == SAMPLE_DRAW_STYLE_FILLED) {
+			min = INT32_MAX;
+			max = INT32_MIN;
+
+			while (walk < advance) {
+				int value;
+
+				if (offset >= length)
+					offset -= length;
+
+				value = data[offset];
+
+				if (value < min)
+					min = value;
+				if (value > max)
+					max = value;
+
+				offset += stride;
+
+				walk += 256;
+			}
+
+			walk -= advance;
+		}
+		else {
+			max = 0;
+
+			while (walk < advance) {
+				int magnitude;
+
+				if (offset >= length)
+					offset -= length;
+
+				magnitude = data[offset] - mid;
+
+				if (magnitude < 0)
+					magnitude = -magnitude;
+
+				if (magnitude > max_mag) {
+					max = data[offset];
+					max_mag = magnitude;
+				}
+
+				offset += stride;
+
+				walk += 256;
+			}
+
+			walk -= advance;
+		}
+
+		y = (int)max - min_value;
+		y = y1 + (range - y) * h / range;
+
+		switch (draw_style) {
+		case SAMPLE_DRAW_STYLE_DOTS:
+			vgamem_ovl_drawpixel(r, x, y, colour);
+			break;
+		case SAMPLE_DRAW_STYLE_LINE:
+			if (ly < 0) {
+				vgamem_ovl_drawpixel(r, x, y, colour);
+				ly = y;
+			}
+			else {
+				vgamem_ovl_drawline(r, x, ly + (y > ly ? 1 : 0), x, y, colour);
+				ly = y;
+			}
+			break;
+		case SAMPLE_DRAW_STYLE_FILLED:
+			int yy = (int)min - min_value;
+			yy = y1 + (range - yy) * h / range;
+			vgamem_ovl_drawline(r, x, y, x, yy, colour);
+			break;
+		}
+	}
+}
+
+void draw_sample_data_ex_8(struct vgamem_overlay *r, int x1, int y1, int x2, int y2,
+	int8_t *data, int offset, int stride, int advance, int length, int signed_data,
+	int8_t min_value, int8_t max_value, int colour, sample_draw_style_t draw_style)
+{
+	int32_t mid = (min_value + max_value) >> 1;
+	int32_t range = (int)max_value - min_value;
+	int8_t sign_flip;
+
+	sign_flip = signed_data ? 0 : 0x80;
+
+	int ly = -1;
+
+	int walk = 0;
+
+	for (int x = x1, h = y2 - y1 + 1; x < x2; x++) {
+		int y;
+
+		int32_t min, max, max_mag = 0;
+
+		if (draw_style == SAMPLE_DRAW_STYLE_FILLED) {
+			min = INT32_MAX;
+			max = INT32_MIN;
+
+			while (walk < advance) {
+				int value;
+
+				if (offset >= length)
+					offset -= length;
+
+				value = (data[offset] ^ sign_flip) - mid;
+
+				if (value < min)
+					min = value;
+				if (value > max)
+					max = value;
+
+				offset += stride;
+
+				walk += 256;
+			}
+
+			walk -= advance;
+		}
+		else {
+			max = 0;
+
+			while (walk < advance) {
+				int value;
+				int magnitude;
+
+				if (offset >= length)
+					offset -= length;
+
+				value = data[offset] ^ sign_flip;
+				magnitude = value - mid;
+
+				if (magnitude < 0)
+					magnitude = -magnitude;
+
+				if (magnitude > max_mag) {
+					max = value;
+					max_mag = magnitude;
+				}
+
+				offset += stride;
+
+				walk += 256;
+			}
+
+			walk -= advance;
+		}
+
+		y = (int)max - min_value;
+		y = y1 + (range - y) * h / range;
+
+		switch (draw_style) {
+		case SAMPLE_DRAW_STYLE_DOTS:
+			vgamem_ovl_drawpixel(r, x, y, colour);
+			break;
+		case SAMPLE_DRAW_STYLE_LINE:
+			if (ly < 0) {
+				vgamem_ovl_drawpixel(r, x, y, colour);
+				ly = y;
+			}
+			else {
+				vgamem_ovl_drawline(r, x, ly + (y > ly ? 1 : 0), x, y, colour);
+				ly = y;
+			}
+			break;
+		case SAMPLE_DRAW_STYLE_FILLED:
+			int yy = (int)min - min_value;
+			yy = y1 + (range - yy) * h / range;
+			vgamem_ovl_drawline(r, x, y, x, yy, colour);
+			break;
+		}
+	}
+}
 
 /* somewhat heavily based on CViewSample::DrawSampleData2 in modplug
  *
@@ -953,6 +1241,9 @@ static void _draw_sample_play_marks(struct vgamem_overlay *r, song_sample_t * sa
 /* --------------------------------------------------------------------- */
 /* meat! */
 
+// limit CPU usage on hugemongous samples
+#define MAX_SAMPLES_PER_PIXEL 100
+
 void draw_sample_data(struct vgamem_overlay *r, song_sample_t *sample)
 {
 	vgamem_ovl_clear(r, 0);
@@ -996,14 +1287,35 @@ void draw_sample_data(struct vgamem_overlay *r, song_sample_t *sample)
 
 	/* do the actual drawing */
 	int chans = sample->flags & CHN_STEREO ? 2 : 1;
-	if (sample->flags & CHN_16BIT)
-		_draw_sample_data_16(r, (signed short *) sample->data,
-				sample->length * chans,
-				chans, chans);
-	else
-		_draw_sample_data_8(r, sample->data,
-				sample->length * chans,
-				chans, chans);
+	int stride = chans;
+
+	int samples_per_pixel = sample->length / r->width;
+
+	if (samples_per_pixel > MAX_SAMPLES_PER_PIXEL) {
+		stride *= (1 + samples_per_pixel / MAX_SAMPLES_PER_PIXEL);
+	}
+
+	for (int chan = 0; chan < chans; chan++)
+	{
+		int fy1 = chan * r->height / chans;
+		int fy2 = (chan + 1) * r->height / chans - 1;
+		int advance = _muldiv(sample->length * chans, 256, r->width * stride);
+
+		if (sample->flags & CHN_16BIT)
+			draw_sample_data_ex_16(
+				r,
+				0, fy1, r->width, fy2,
+				(int16_t *)sample->data, chan, stride, advance, sample->length,
+				INT16_MIN, INT16_MAX,
+				SAMPLE_DATA_COLOR, SAMPLE_DRAW_STYLE_FILLED);
+		else
+			draw_sample_data_ex_8(
+				r,
+				0, fy1, r->width, fy2,
+				(int8_t *)sample->data, chan, stride, advance, sample->length, 1,
+				INT8_MIN, INT8_MAX,
+				SAMPLE_DATA_COLOR, SAMPLE_DRAW_STYLE_FILLED);
+	}
 
 	if ((status.flags & CLASSIC_MODE) == 0)
 		_draw_sample_play_marks(r, sample);


### PR DESCRIPTION
This PR adds waveform visualization to the Info page.

In order to do this, the mixer code had to be updated to gather recent sample data. This needed to be as performant as possible, as I'm sure this is the hottest hot path in the codebase :slightly_smiling_face: I did my best in that regard. The buffers are statically-allocated, and the calculation and assignment of the values fits into the same spot as the VU calculation.

Also, in recognition of the possibility that some of the target architectures might yet have difficulty with the added CPU load (maybe? I don't know :slightly_smiling_face:), the feature can be turned off with `./configure --disable-waveformvis`. It is enabled by default as presently written.

I also tried making it join the waveform lines, but I actually like it more unjoined. I left that experiment in but `#ifdef`ed out, you can find it inside `page_info.c` under `#ifdef WAVEFORMVIS_JOINED`.

<img width="770" height="566" alt="image" src="https://github.com/user-attachments/assets/5396ee21-a919-4395-a343-217ca08d183a" />