### PR TITLE
page: remove redundant code

### DIFF
--- a/schism/page.c
+++ b/schism/page.c
@@ -1521,9 +1521,7 @@ void redraw_screen(void)
 
 		draw_top_info_const();
 		redraw_top_info();
-	}
 
-	if (!ACTIVE_PAGE.draw_full) {
 		draw_vis();
 		draw_time();
 		draw_text(str_from_num(3, song_get_current_speed(), buf), 50, 4, 5, 0);

--- a/schism/page.c
+++ b/schism/page.c
@@ -1524,8 +1524,6 @@ void redraw_screen(void)
 
 		draw_vis();
 		draw_time();
-		draw_text(str_from_num(3, song_get_current_speed(), buf), 50, 4, 5, 0);
-		draw_text(str_from_num(3, song_get_current_tempo(), buf), 54, 4, 5, 0);
 
 		status_text_redraw();
 	}


### PR DESCRIPTION
Pretty sure re-checking `ACTIVE_PAGE.draw_full` isn't necessary here. I don't think it can change between the two `if` statements. And, the current speed & tempo are already drawn with identical calls inside `redraw_top_info`.