### PR TITLE
win32/osdefs: null-terminate argv in WIN32_EXEC_IMPL

### DIFF
--- a/sys/win32/osdefs.c
+++ b/sys/win32/osdefs.c
@@ -1585,6 +1585,8 @@ DWORD win32_create_process_wait(const WCHAR *cmd, WCHAR *arg, WCHAR *cwd)
 				return 0; \
 		} \
 	\
+		argv[i] = NULL; \
+	\
 		{ \
 			intptr_t st; \
 			CHAR_TYPE old_wdir[MAX_PATH]; \


### PR DESCRIPTION
Without this, it usually crashes. :-)