### PR TITLE
*_run_hook: only if exists

### DIFF
--- a/sys/posix/osdefs.c
+++ b/sys/posix/osdefs.c
@@ -111,6 +111,11 @@ int posix_run_hook(const char *dir, const char *name, const char *maybe_arg)
 	int st;
 	char *bat_name;
 
+	if (access(name, X_OK) != 0) {
+		// file does not exist or cannot be executed, go no further
+		return 0;
+	}
+
 	if (asprintf(&bat_name, "./%s", name) < 0)
 		return 0;
 


### PR DESCRIPTION
```
Dadu@ALTERNATOR MINGW64 /c/code/schismtracker
$ ./schismtracker.exe
'startup-hook.bat' is not recognized as an internal or external command,
operable program or batch file.
'exit-hook.bat' is not recognized as an internal or external command,
operable program or batch file.

Dadu@ALTERNATOR MINGW64 /c/code/schismtracker
$
```

On Windows, the `.bat` file is not itself directly executable. Instead, you run `CMD.EXE /C filename.bat`. `CMD.EXE` does exist and does run even if `filename.bat` doesn't exist.