### PR TITLE
midi-ip: rework win32 implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -443,12 +443,16 @@ cygwin*|mingw*)
 	WIN32_LIBS="-lwinmm"
 
 	AC_CHECK_HEADERS([winsock.h winsock2.h])
-	if test "x$ac_cv_header_winsock_h" = "xyes"; then
-		AC_SUBST([NETWORK_LIBS], [-lwsock32])
-		use_network=yes
-	elif test "x$ac_cv_header_winsock2_h" = "xyes"; then
+	AC_CHECK_LIB(ws2_32, WSAEventSelect, [use_network_ws2=yes], [use_network_ws2=no])
+	if test "x$use_network_ws2" = "xyes"; then
 		AC_SUBST([NETWORK_LIBS], [-lws2_32])
 		use_network=yes
+		AC_DEFINE([USE_NETWORK], [1], [Networking])
+		AC_DEFINE([USE_NETWORK_WS2], [1], [Win32 WinSock2 networking])
+	elif test "x$ac_cv_header_winsock_h" = "xyes"; then
+		AC_SUBST([NETWORK_LIBS], [-lwsock32])
+		use_network=yes
+		AC_DEFINE([USE_NETWORK], [1], [Networking])
 	else
 		AC_MSG_ERROR([*** Couldn't find winsock (how)])
 	fi
@@ -627,6 +631,7 @@ AM_CONDITIONAL([USE_MACOS], [test "x$use_macos" = "xyes"])
 AM_CONDITIONAL([USE_OS2], [test "x$use_os2" = "xyes"])
 AM_CONDITIONAL([am__fastdepOBJC], [test "x$use_macosx" = "xyes"])
 AM_CONDITIONAL([USE_NETWORK], [test "x$use_network" = "xyes"])
+AM_CONDITIONAL([USE_NETWORK_WS2], [test "x$use_network_ws2" = "xyes"])
 AM_CONDITIONAL([USE_XBOX], [test "x$use_xbox" = "xyes"])
 AM_CONDITIONAL([USE_ASIO], [test "x$use_asio" = "xyes"])
 

--- a/include/midi.h
+++ b/include/midi.h
@@ -32,6 +32,7 @@ struct midi_driver {
 	uint32_t flags;
 
 	void (*poll)(struct midi_provider *m);
+	void (*wake)(struct midi_provider *m);
 	int (*thread)(struct midi_provider *m);
 
 	/* return: 1 on success, 0 on failure */
@@ -49,6 +50,8 @@ struct mt_thread;
 struct midi_provider {
 	char *name;
 	void (*poll)(struct midi_provider *);
+	void (*wake)(struct midi_provider *);
+
 	struct mt_thread *thread;
 	volatile int cancelled;
 
@@ -134,6 +137,8 @@ uint32_t midi_port_register(struct midi_provider *p,
 
 int midi_port_foreach(struct midi_provider *p, struct midi_port **cursor);
 void midi_port_unregister(uint32_t num);
+
+void midi_port_wake_thread(struct midi_provider* p);
 
 /* ------------------------------------------------------------------------ */
 /* MIDI hotplug support */

--- a/schism/midi-ip.c
+++ b/schism/midi-ip.c
@@ -31,30 +31,39 @@
 
 #ifdef USE_NETWORK
 
+#ifndef SCHISM_WIN32
+// Windows uses something weird like UINT_PTR
+typedef int SOCKET;
+#endif
+
+
 #ifdef SCHISM_WIN32
-#include <windows.h>
-#include <ws2tcpip.h>
+# // must precede <windows.h>
+# include <ws2tcpip.h>
+# include <windows.h>
 #else
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <sys/select.h>
-#include <fcntl.h>
-#include <arpa/inet.h>
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netinet/in.h>
+# include <sys/select.h>
+# include <fcntl.h>
+# include <arpa/inet.h>
 #endif
 
 #define DEFAULT_IP_PORT_COUNT   5
 #define MIDI_IP_BASE    21928
 #define MAX_DGRAM_SIZE  1280
 
-#ifndef SCHISM_WIN32
-static int wakeup[2];
+#ifdef USE_NETWORK_WS2
+static HANDLE hWakeUp;
+#else
+static SOCKET wakeup[2];
 #endif
 static int real_num_ports = 0;
 static int num_ports = 0;
-static int out_fd = -1;
-static int *port_fd = NULL;
-static int *state = NULL;
+static SOCKET out_fd = -1;
+static SOCKET *port_fd = NULL;
+static SOCKET *state = NULL; /* not really sockets, but shares the same allocation as port_fd */
 static mt_mutex_t *blocker = NULL;
 
 static void do_wake_main(void)
@@ -68,7 +77,14 @@ static void do_wake_main(void)
 static void do_wake_midi(void)
 {
 #ifdef SCHISM_WIN32
-	/* anyone want to suggest how this is done? XXX */
+# ifdef USE_NETWORK_WS2
+	SetEvent(hWakeUp);
+# else
+	if ((wakeup[1] != INVALID_SOCKET)
+	 && (send(wakeup[1], "\x1", 1, 0) == 1)) {
+		/* */
+	}
+#endif
 #else
 	if (write(wakeup[1], "\x1", 1) == 1) {
 		/* fortify is stupid */
@@ -76,12 +92,13 @@ static void do_wake_midi(void)
 #endif
 }
 
-static int _get_fd(int pb, int isout)
+static SOCKET _get_fd(int pb, int isout)
 {
 	struct ip_mreq mreq = {0};
 	struct sockaddr_in asin = {0};
 	unsigned char *ipcopy;
-	int fd, opt;
+	SOCKET fd;
+	int opt;
 
 #if !defined(PF_INET) && defined(AF_INET)
 #define PF_INET AF_INET
@@ -99,6 +116,7 @@ static int _get_fd(int pb, int isout)
 #else
 		close(fd);
 #endif
+
 		return -1;
 	}
 
@@ -112,8 +130,7 @@ static int _get_fd(int pb, int isout)
 		return -1;
 	}
 
-	ipcopy = (unsigned char *)&mreq.imr_multiaddr;
-	ipcopy[0] = 225; ipcopy[1] = ipcopy[2] = 0; ipcopy[3] = 37;
+	mreq.imr_multiaddr.s_addr = inet_addr("225.0.0.37");
 	if (setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (void*)&mreq, sizeof(mreq)) < 0) {
 #ifdef SCHISM_WIN32
 		closesocket(fd);
@@ -136,14 +153,7 @@ static int _get_fd(int pb, int isout)
 	asin.sin_family = AF_INET;
 	ipcopy = (unsigned char *)&asin.sin_addr;
 	if (!isout) {
-		/* all 0s is inaddr_any; but this is for listening */
-#ifdef SCHISM_WIN32
-		//JosepMa:On my machine, using the 225.0.0.37 address caused bind to fail.
-		//Didn't look too much to find why.
-		ipcopy[0] = ipcopy[1] = ipcopy[2] = ipcopy[3] = 0;
-#else
-		ipcopy[0] = 225; ipcopy[1] = ipcopy[2] = 0; ipcopy[3] = 37;
-#endif
+		asin.sin_addr.s_addr = htonl(INADDR_ANY);
 		asin.sin_port = htons(MIDI_IP_BASE+pb);
 	}
 	if (bind(fd, (struct sockaddr *)&asin, sizeof(asin)) < 0) {
@@ -170,6 +180,15 @@ static int _get_fd(int pb, int isout)
 #endif
 		return -1;
 	}
+
+#ifdef USE_NETWORK_WS2
+		// Translate socket events into the hWakeUp event object being set.
+	if (0 != WSAEventSelect(fd, hWakeUp, FD_READ)) {
+		closesocket(fd);
+		return -1;
+	}
+#endif
+
 
 	return fd;
 }
@@ -206,11 +225,11 @@ static int _ip_thread(struct midi_provider *p)
 {
 #ifdef SCHISM_WIN32
 	struct timeval tv;
-#else
-	static unsigned char buffer[4096];
 #endif
+	struct timeval *tv_ptr = NULL;
+	static unsigned char buffer[4096];
 	fd_set rfds;
-	int *tmp2, *tmp;
+	SOCKET *tmp2, *tmp;
 	int i, m;
 
 	while (!p->cancelled) {
@@ -219,7 +238,7 @@ static int _ip_thread(struct midi_provider *p)
 		//If no ports, wait and try again
 		if (m > real_num_ports) {
 			/* need more ports */
-			tmp = malloc(2 * (m * sizeof(int)));
+			tmp = malloc(2 * (m * sizeof(SOCKET)));
 			if (tmp) {
 				tmp2 = tmp + m;
 				for (i = 0; i < real_num_ports; i++) {
@@ -265,6 +284,7 @@ static int _ip_thread(struct midi_provider *p)
 			}
 		}
 
+#ifndef USE_NETWORK_WS2
 		FD_ZERO(&rfds);
 		m = 0;
 		for (i = 0; i < real_num_ports; i++) {
@@ -272,51 +292,73 @@ static int _ip_thread(struct midi_provider *p)
 			if (port_fd[i] > m) m = port_fd[i];
 		}
 
-#ifdef SCHISM_WIN32
-		tv.tv_sec = 1;
-		tv.tv_usec = 0;
-#else
 		FD_SET(wakeup[0], &rfds);
 		if (wakeup[0] > m) m = wakeup[0];
 #endif
+
 		do {
-			i = select(m+1, &rfds, NULL, NULL,
-#ifdef SCHISM_WIN32
-				&tv
+#ifdef USE_NETWORK_WS2
+			// We have bound all of the sockets to this event object, so that waiting on
+			// the event object is equivalent to the select() call.
+			//
+			// By coincidence, WaitForSingleObject and select both return the same value
+			// on failure. WaitForSingleObject returns it as an unsigned (DWORD)0xFFFFFFFF,
+			// while select returns it as a signed (int)-1. On Win32, we can assume that
+			// int and DWORD are both 32-bit integers and we can just reinterpret it.
+			i = (int)WaitForSingleObject(hWakeUp, INFINITE);
 #else
-				NULL
-#endif
-				);
-#ifdef SCHISM_WIN32
-			if (i == SOCKET_ERROR ) {
-				perror("selectError:");
-				int asdf = WSAGetLastError();
-				switch(asdf) {
-					case WSANOTINITIALISED: perror("WSANOTINITIALISED");break;
-					case WSAEFAULT: perror("WSAEFAULT");break;
-					case WSAENETDOWN: perror("WSAENETDOWN");break;
-					case WSAEINVAL: perror("WSAEINVAL");break;
-					case WSAEINTR: perror("WSAEINTR");break;
-					case WSAEINPROGRESS: perror("WSAEINPROGRESS");break;
-					case WSAENOTSOCK: perror("WSAENOTSOCK");break;
-					default: perror("default");break;
-				}
+# ifdef SCHISM_WIN32
+			if (wakeup[0] == INVALID_SOCKET) {
+				tv.tv_sec = 1;
+				tv.tv_usec = 0;
+
+				tv_ptr = &tv;
 			}
+# endif
+
+			i = select(m+1, &rfds, NULL, NULL, tv_ptr);
 #endif
+			if (p->cancelled) {
+				return 0;
+			}
 		} while (i == -1 && errno == EINTR);
 
-#ifndef SCHISM_WIN32
+#ifdef SCHISM_WIN32
+# ifdef USE_NETWORK_WS2
+		for (i = 0; i < real_num_ports; i++) {
+			u_long avail;
+
+			if ((0 == ioctlsocket(port_fd[i], FIONREAD, &avail))
+			 && (avail != 0))
+				_readin(p, i, port_fd[i]);
+		}
+# else
+		if (wakeup[0] == INVALID_SOCKET) {
+			/* if we didn't get a socket, then we can't poll on it */
+		}
+		else /* fall through */
+ #endif
+#endif
+
+#ifndef USE_NETWORK_WS2
 		if (FD_ISSET(wakeup[0], &rfds)) {
+# ifdef SCHISM_WIN32
+			if (recv(wakeup[0], buffer, sizeof(buffer), 0) == -1) {
+				/* */
+			}
+# else
 			if (read(wakeup[0], buffer, sizeof(buffer)) == -1) {
 				/* fortify is stupid */
 			}
+# endif
 		}
-#endif
 		for (i = 0; i < real_num_ports; i++) {
 			if (FD_ISSET(port_fd[i], &rfds)) {
 				if (state[i] & 1) _readin(p, i, port_fd[i]);
 			}
 		}
+#endif
+
 	}
 	return 0;
 }
@@ -414,6 +456,11 @@ static void _ip_poll(struct midi_provider *p)
 	mt_mutex_unlock(blocker);
 }
 
+static void _ip_wake(struct midi_provider* p)
+{
+	do_wake_midi();
+}
+
 int ip_midi_setup(void)
 {
 	static struct midi_driver driver;
@@ -424,7 +471,96 @@ int ip_midi_setup(void)
 	if (!blocker)
 		return 0;
 
-#ifndef SCHISM_WIN32
+#ifdef SCHISM_WIN32
+# ifdef USE_NETWORK_WS2
+	// Create an object:
+	// - NULL: Do not specify the attributes needed for this to be inheritable.
+	// - FALSE: The object is not manual-reset (waiting on it clears signals as they are received).
+	// - FALSE: The object's initial state is not signalled.
+	// - NULL: The object is not assigned a name, and thus cannot be accessed by other processes.
+
+	hWakeUp = CreateEventA(NULL, FALSE, FALSE, NULL);
+# else
+	// Work-around for pre-WinSock 2 Windows: Make a loopback TCP connection. In the UNIX
+	// implementation, we just call pipe() and use that. Win32, though, doesn't use file
+	// descriptors and is just playing pretend for network sockets specifically. Its pipes
+	// don't integrate into sockets and select(). So, use an actual socket.
+	//
+	// If we can't establish a connection, fall back on the old polling behaviour.
+
+	wakeup[0] = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	wakeup[1] = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+	if ((wakeup[0] == INVALID_SOCKET) || (wakeup[1] == INVALID_SOCKET)) {
+		if (wakeup[0] != INVALID_SOCKET) {
+			closesocket(wakeup[0]);
+				wakeup[0] = INVALID_SOCKET;
+		}
+		if (wakeup[1] != INVALID_SOCKET) {
+			closesocket(wakeup[1]);
+			wakeup[1] = INVALID_SOCKET;
+		}
+	}
+	else {
+		int good = 0;
+		struct sockaddr_in sin;
+		u_long mode;
+
+		sin.sin_family = AF_INET;
+		sin.sin_addr.s_addr = inet_addr("127.0.0.1");
+		sin.sin_port = 0;
+
+		mode = 1;
+		ioctlsocket(wakeup[1], FIONBIO, &mode);
+
+		socklen_t sin_len = sizeof(sin);
+
+		if ((bind(wakeup[0], (struct sockaddr *)&sin, sizeof(sin)) == 0)
+		 && (listen(wakeup[0], 1) == 0)
+		 && (getsockname(wakeup[0], (struct sockaddr *)&sin, &sin_len) == 0)
+		 && (sin.sin_family == AF_INET)) {
+			int result = connect(wakeup[1], (struct sockaddr *)&sin, sizeof(sin));
+
+			if ((result == SOCKET_ERROR) && (WSAGetLastError() == WSAEWOULDBLOCK)) {
+				// This is okay :-)
+
+				SOCKET client_fd;
+
+				sin_len = sizeof(sin);
+
+				client_fd = accept(wakeup[0], (struct sockaddr *)&sin, &sin_len);
+
+				closesocket(wakeup[0]);
+				wakeup[0] = client_fd;
+
+				mode = 1;
+				ioctlsocket(wakeup[0], FIONBIO, &mode);
+
+				// wakeup[0] is all good to go, make sure wakeup[1] got the message too
+				{
+					struct fd_set fds;
+					struct timeval timeout;
+
+					FD_ZERO(&fds);
+					FD_SET(wakeup[1], &fds);
+
+					timeout.tv_sec = 1;
+					timeout.tv_usec = 0;
+
+					good = select(1, NULL, &fds, NULL, &timeout);
+				}
+			}
+		}
+
+		if (!good) {
+			closesocket(wakeup[0]);
+			closesocket(wakeup[1]);
+			wakeup[0] = INVALID_SOCKET;
+			wakeup[1] = INVALID_SOCKET;
+		}
+	}
+# endif
+#else
 	if (pipe(wakeup) == -1) {
 		return 0;
 	}
@@ -439,6 +575,7 @@ int ip_midi_setup(void)
 
 	driver.flags = 0;
 	driver.poll = _ip_poll;
+	driver.wake = _ip_wake;
 	driver.thread = _ip_thread;
 	driver.send = _ip_send;
 	driver.enable = _ip_start;

--- a/sys/alsa/midi-alsa.c
+++ b/sys/alsa/midi-alsa.c
@@ -439,6 +439,7 @@ int alsa_midi_setup(void)
 {
 	static const struct midi_driver alsa_driver = {
 		.poll = _alsa_poll,
+		.wake = NULL,
 		.thread = _alsa_thread,
 		.enable = _alsa_start,
 		.disable = _alsa_stop,

--- a/sys/jack/midi-jack.c
+++ b/sys/jack/midi-jack.c
@@ -424,6 +424,7 @@ int jack_midi_setup(void)
 {
 	static const struct midi_driver jack_driver = {
 		.poll = _jack_poll,
+		.wake = NULL,
 		.flags = 0, // jack is realtime
 		.thread = _jack_thread,
 		.enable = _jack_start,

--- a/sys/macosx/midi-macosx.c
+++ b/sys/macosx/midi-macosx.c
@@ -194,6 +194,7 @@ int macosx_midi_setup(void)
 	static const struct midi_driver driver = {
 		.flags = MIDI_PORT_CAN_SCHEDULE,
 		.poll = _macosx_poll,
+		.wake = NULL,
 		.thread = NULL,
 		.enable = _macosx_start,
 		.disable = _macosx_stop,

--- a/sys/oss/midi-oss.c
+++ b/sys/oss/midi-oss.c
@@ -161,6 +161,7 @@ int oss_midi_setup(void)
 	static const struct midi_driver driver = {
 		.flags = 0,
 		.poll = _oss_poll,
+		.wake = NULL,
 		.thread = _oss_thread,
 		.enable = _oss_start_stop,
 		.disable = _oss_start_stop,

--- a/sys/win32/midi-win32mm.c
+++ b/sys/win32/midi-win32mm.c
@@ -292,6 +292,7 @@ int win32mm_midi_setup(void)
 	static const struct midi_driver driver = {
 		.flags = 0,
 		.poll = _win32mm_poll,
+		.wake = NULL,
 		.thread = NULL,
 		.enable = _win32mm_start,
 		.disable = _win32mm_stop,


### PR DESCRIPTION
This PR makes a few changes:

(0: On Windows, sockets aren't technically `int` values. It uses something weird under the hood like `UINT_PTR` or something. Anyway, all WinSock functions use a typedef called `SOCKET`. Of course, this doesn't exist on non-Windows systems. I updated the code to use `SOCKET` instead of `int`, and to `typedef int SOCKET` on non-Windows builds.)

1. A new Win32 WinSock2 implementation using `WSAEventSelect` is added. The principle behind this is that Windows has this kernel object called an "event" that is essentially a condition variable. They can be autoreset, in which case each time they're waited upon, the signalled state is "consumed" automatically, or manual reset, in which case once they're signalled they stay signalled until you explicitly clear the signal. Either way, WinSock2 can link sockets to these events, so that whenever a kind of activity that you'd otherwise detect using `select()` happens, it sets a specified event. This makes it really easy to wake a thread that is waiting: since it's just waiting on an event object, you can just set the event object yourself. So, this is what it does. I've tested it and it works. :-)

2. This can only be done with WinSock2, which isn't available in baseline Windows 95 installations. Since that seems to be one of the target platforms of Schism Tracker presently, I made a fallback implementation. It basically does what the POSIX implementation does. The catch is that on POSIX, sockets are just a kind of fd, and so are pipes, so we can just make a pipe and add it to the list of fds we're `select`ing on, but on Windows, sockets are their own unique kind of entity. There is no concept of a pipe fitting into the same universe that you could `select` upon. But, you _can_ just use (drumroll) sockets! :-) I wrote some code to create a loopback connection between two sockets, and that fits into the same model as the `pipe` fds. Writing has to be done with `send` and reading has to be done with `recv`, but it's basically the same. It detects whether it needs to go this route using a new `./configure` test. If it _can_ use `WSAEventSelect`, it does. If it can't, it tries the loopback socket connection. I've tested it and it works. :-)

4. This same code needs to compile & run on Linux as well. I've tested it and it works. :-)

5. If it can't establish the sockets, it falls back on the existing (Win32) implementation, with the 1 second poll. I .. haven't tested this specifically.

6. I found that with the ipMIDI thread actually running, Schism Tracker would hang on shutdown. I tracked this down to the fact that it sets `midi_provider.cancelled` to 1 and then just waits, assuming that the very act of setting it to `1` will cause the provider to shut down. Since with the previous changes, we now have an effective means of waking up the thread, I added some plumbing to expose this, so that before waiting, it wakes the thread. Only the ipMIDI provider actually provides a `wake` implementation presently, but if there are other providers that have a persistent thread that needs to shut down, they could potentially tie into this as well. 