### PR TITLE
test/harness: squelch warning

### DIFF
--- a/test/harness.c
+++ b/test/harness.c
@@ -130,7 +130,7 @@ int schism_test_main(int argc, char **argv)
 		diff_time = end_time - start_time;
 
 		printf("Results: %d passed, %d failed\n", passed_tests, failed_tests);
-		printf("Elapsed: %s.%03" PRIu32 " seconds\n", str_from_num_thousands(diff_time / 1000, buf), diff_time % 1000);
+		printf("Elapsed: %s.%03" PRIu32 " seconds\n", str_from_num_thousands(diff_time / 1000, buf), (uint32_t)(diff_time % 1000));
 
 		exit_code = (failed_tests == 0) ? 0 : 1;
 	}


### PR DESCRIPTION
```
test/harness.c: In function ‘schism_test_main’:
test/harness.c:133:24: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘timer_ticks_t’ {aka ‘long unsigned int’} [-Wformat=]
  133 |                 printf("Elapsed: %s.%03" PRIu32 " seconds\n", str_from_num_thousands(diff_time / 1000, buf), diff_time % 1000);
      |                        ^~~~~~~~~~~~~~~~~                                                                     ~~~~~~~~~~~~~~~~
      |                                                                                                                        |
      |                                                                                                                        timer_ticks_t {aka long unsigned int}
In file included from ./include/headers.h:74,
                 from ./include/test.h:27,
                 from test/harness.c:24:
/usr/include/inttypes.h:104:26: note: format string is defined here
  104 | # define PRIu32         "u"
```