### PR TITLE
test: REQUIRE macro

### DIFF
--- a/include/test-assertions.h
+++ b/include/test-assertions.h
@@ -27,6 +27,7 @@
 #include "test.h"
 
 /* TODO prefix these with TEST_ */
+#define REQUIRE(init_cond) do { if (!(init_cond)) { test_log_printf("%s, line %d: test initialization failed: %s\n", __FILE__, __LINE__, #init_cond); return SCHISM_TESTRESULT_INCONCLUSIVE; } } while (0)
 #define ASSERT(cond) do { if (!(cond)) { test_log_printf("%s, line %d: assertion failed: %s\n", __FILE__, __LINE__, #cond); return SCHISM_TESTRESULT_FAIL; } } while (0)
 #define RETURN_PASS return SCHISM_TESTRESULT_PASS
 #define RETURN_FAIL return SCHISM_TESTRESULT_FAIL

--- a/test/cases/config-parser.c
+++ b/test/cases/config-parser.c
@@ -17,8 +17,7 @@ static const char test_config_file_content[] =
 	{ \
 		char test_config_file[TEST_TEMP_FILE_NAME_LENGTH]; \
 \
-		if (!test_temp_file(test_config_file, test_config_file_content, ARRAY_SIZE(test_config_file_content) - 1)) \
-			return SCHISM_TESTRESULT_INCONCLUSIVE; \
+		REQUIRE(test_temp_file(test_config_file, test_config_file_content, ARRAY_SIZE(test_config_file_content) - 1)); \
 \
 		int init_result = cfg_init(&cfg, test_config_file); \
 \

--- a/test/cases/slurp.c
+++ b/test/cases/slurp.c
@@ -192,7 +192,7 @@ testresult_t test_slurp_stdio(void)
 	FILE *stdfp;
 	testresult_t r;
 
-	ASSERT(test_temp_file(tmp, expected_result, ARRAY_SIZE(expected_result) - 1));
+	REQUIRE(test_temp_file(tmp, expected_result, ARRAY_SIZE(expected_result) - 1));
 
 	/* XXX we open the file, close the file, and then reopen it.
 	 * this is a source for race conditions ... */


### PR DESCRIPTION
Add `REQUIRE` macro that works like `ASSERT` but returns `SCHISM_TESTRESULT_INCONCLUSIVE` instead of `SCHISM_TESTRESULT_FAIL`. For use in test initialization, since if the initialization fails and you can't actually do the test, then you haven't actually exercised the test subject and don't _know_ if would have passed or not.