### PR TITLE
fm_opl2: fixed CALC_CHANNEL

### DIFF
--- a/player/fmopl2.c
+++ b/player/fmopl2.c
@@ -2057,9 +2057,10 @@ do { \
 \
 	vu_max[CHN] = MAX(vu_max[CHN], ab); \
 \
-	if (buffers[j]) { \
-		buffers[j][i*2+0] += OPL->output[0] * OPL_VOLUME; \
-		buffers[j][i*2+1] += OPL->output[0] * OPL_VOLUME; \
+	if (buffers[CHN]) { \
+		int32_t sample = OPL->output[0] * OPL_VOLUME; \
+		buffers[CHN][i*2+0] += sample; \
+		buffers[CHN][i*2+1] += sample; \
 	} \
 } while (0)
 


### PR DESCRIPTION
When the code was refactored into the macro `CALC_CHANNEL` inside `ym3812_update_multi`, some of the references to the loop iterator `j` as the channel number were overlooked. When the macro is used for rhythm mode, `j` will not have the correct value `0`. Instead, it'll be the value 6 left over from the `for` loop that handles the first 6 channels.

Maybe this is actually correct and the rhythm output is supposed to be written to specifically `buffers[6]`. If that's the case, then the code needs to call it out explicitly, because it looks like a bug presently. :-)