### PR TITLE
OPL3: full channel support

### DIFF
--- a/include/player/fmopl.h
+++ b/include/player/fmopl.h
@@ -5,6 +5,16 @@
 
 #define logerror(...) /**/
 
+#define OPL_BANK_SIZE 9
+
+#if OPLSOURCE == 2
+# define OPL_CHANNELS 9
+#elif OPLSOURCE == 3
+# define OPL_CHANNELS 18
+#else
+# error "The current value of OPLSOURCE isn't supported! Check build-config.h."
+#endif
+
 typedef int16_t OPLSAMPLE;
 
 typedef void (*OPL_TIMERHANDLER)(void *param,int timer,double period);
@@ -20,7 +30,7 @@ void ym3812_reset_chip(void *chip);
 int  ym3812_write(void *chip, int a, int v);
 unsigned char ym3812_read(void *chip, int a);
 int  ym3812_timer_over(void *chip, int c);
-void ym3812_update_multi(void *chip, int32_t **buffers, int length, uint32_t vu_max[18]);
+void ym3812_update_multi(void *chip, int32_t **buffers, int length, uint32_t vu_max[OPL_CHANNELS]);
 
 void ym3812_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, void *param);
 void ym3812_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, void *param);
@@ -33,7 +43,7 @@ void ymf262_reset_chip(void *chip);
 int  ymf262_write(void *chip, int a, int v);
 unsigned char ymf262_read(void *chip, int a);
 int  ymf262_timer_over(void *chip, int c);
-void ymf262_update_multi(void *chip, int32_t **buffers, int length, uint32_t vu_max[18]);
+void ymf262_update_multi(void *chip, int32_t **buffers, int length, uint32_t vu_max[OPL_CHANNELS]);
 
 void ymf262_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, void *param);
 void ymf262_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, void *param);
@@ -41,7 +51,7 @@ void ymf262_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, void
 
 /* moved this constant from snd_fm.c, because now the OPL update funcs need it */
 /* Schismtracker output buffer works in 27bits: [MIXING_CLIPMIN..MIXING_CLIPMAX]
-fmopl works in 16bits, although tested output used to range +-10000 instead of 
+fmopl works in 16bits, although tested output used to range +-10000 instead of
     +-20000 from adlibtracker/screamtracker in dosbox. So we need 11 bits + 1 extra bit.
 Also note when comparing volumes, that Screamtracker output on mono with PCM samples is not reduced by half.
 */

--- a/include/player/sndfile.h
+++ b/include/player/sndfile.h
@@ -16,7 +16,7 @@
 #include "tables.h"
 
 #include "timer.h" // timer_ticks_t
-
+#include "fmopl.h" // OPL_CHANNELS
 
 #define MOD_AMIGAC2             0x1AB
 #define MAX_SAMPLE_LENGTH       0x10000000 /* borrowed from OpenMPT; originally 16000000 */
@@ -811,11 +811,11 @@ typedef struct song {
 	uint32_t oplregno;
 	uint32_t opl_fm_active;
 
-	const unsigned char *opl_dtab[9];
-	unsigned char opl_keyontab[9];
+	const unsigned char *opl_dtab[OPL_CHANNELS];
+	unsigned char opl_keyontab[OPL_CHANNELS];
 	int32_t opl_pans[MAX_VOICES];
 
-	int32_t opl_to_chan[9];
+	int32_t opl_to_chan[OPL_CHANNELS];
 	int32_t opl_from_chan[MAX_VOICES];
 	// -----------------------------------------------------------------------
 


### PR DESCRIPTION
I noticed that if you ask Schism Tracker to play more than 9 AdLib notes concurrently, it doesn't work, even when built against the OPL3 chip with 18 channel support. I did some digging and uncovered why:

- `struct song` only tracks channel mappings for a hardcoded 9 OPL channels.
- `snd_fm.c` has explicit support for the second bank of channels (`OPL_Byte_RightSide`), but it never actually calls it.

This PR fixes this:

- `fmopl.h` now defines macros that capture the size of an OPL channel bank and how many channels there are (can be more than one bank).
- `struct song` now tracks channel mappings for `OPL_CHANNELS` channels, whether that's 9 or 18.
- `OPLUpdateOne` now only bothers mapping as many `buffers` as there are `OPL_CHANNELS`.
- `Fmdrv_Mix` now processes & mixes `OPL_CHANNELS` channels.
- All of the various OPL control methods use `OPL_Byte_RightSide` for channels outside of the first bank.
- `OPL_Detect` sends the same timer controls to both sides. When built against OPL2, the address for the second bank is simply ignored. I don't know if this is actually necessary or not.

Tested working with OPL2 (limited, of course to 9 channels) and OPL3 (full 18 channels supported). Now we just need a file format that isn't limited to 9 channels :-P Experimentally, I found that if you write FM notes in more than 9 channels with an S3M file, it actually does save all of your notes, but it marks channels that use FM notes past the 9th one as disabled. You can re-enable them when reloading the file.