### PR TITLE
opl: play first note

### DIFF
--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -534,12 +534,13 @@ static int song_keydown_ex(int samp, int ins, int note, int vol, int chan, int e
 	if (i)
 		csf_check_nna(current_song, chan_internal, ins, note, 0);
 	if (s) {
-		if (c->flags & CHN_ADLIB) {
+		if (s->flags & CHN_ADLIB) {
 			OPL_NoteOff(current_song, chan_internal);
 			OPL_Patch(current_song, chan_internal, s->adlib_bytes);
 		}
 
 		c->flags = (s->flags & CHN_SAMPLE_FLAGS) | (c->flags & CHN_MUTE);
+
 		if (c->flags & CHN_MUTE) {
 			c->flags |= CHN_NNAMUTE;
 		}

--- a/schism/audio_playback.c
+++ b/schism/audio_playback.c
@@ -534,8 +534,12 @@ static int song_keydown_ex(int samp, int ins, int note, int vol, int chan, int e
 	if (i)
 		csf_check_nna(current_song, chan_internal, ins, note, 0);
 	if (s) {
-		if (s->flags & CHN_ADLIB) {
+		if (c->flags & CHN_ADLIB) {
+			// get rid of previous OPL activity
 			OPL_NoteOff(current_song, chan_internal);
+		}
+		if (s->flags & CHN_ADLIB) {
+			// set up for OPL call if the sample needs it, regardless of where the channel is at
 			OPL_Patch(current_song, chan_internal, s->adlib_bytes);
 		}
 


### PR DESCRIPTION
The first AdLib note triggered in a channel doesn't play. The reason is that it checks the channel's flags to see if it is marked as an AdLib channel. If it isn't, it doesn't call the OPL handling. _Then_ it updates the channel's flags. This PR updates it to check the sample instead of the channel. (The sample is where the channel gets its status from in the next line anyway.)