### PR TITLE
sndmix: fix initialization of current_tempo in csf_read_note

### DIFF
--- a/player/sndmix.c
+++ b/player/sndmix.c
@@ -1034,7 +1034,7 @@ int32_t csf_read_note(song_t *csf)
 		if (!csf->current_speed)
 			csf->current_speed = csf->initial_speed ? csf->initial_speed : 6;
 		if (!csf->current_tempo)
-			csf->current_tempo = csf->initial_tempo ? csf->initial_speed : 125;
+			csf->current_tempo = csf->initial_tempo ? csf->initial_tempo : 125;
 
 		csf->flags &= ~SONG_FIRSTTICK;
 


### PR DESCRIPTION
I can't think of a scenario where this wouldn't be wrong. :-P