### PR TITLE
effects: fix assignment of volume to midi_vol_tracker

### DIFF
--- a/player/effects.c
+++ b/player/effects.c
@@ -927,7 +927,7 @@ printf("channel = %d note=%d starting_note=%p\n",chan,m_note,starting_note);
 		if (m->voleffect != VOLFX_VOLUME) {
 			csf->midi_vol_tracker[chan] = 64;
 		} else {
-			csf->midi_vol_tracker[chan] = m->voleffect;
+			csf->midi_vol_tracker[chan] = m->volparam;
 		}
 	} else if (!m->note && m->voleffect == VOLFX_VOLUME) {
 		csf->midi_vol_tracker[chan] = m->volparam;


### PR DESCRIPTION
Looks like an autocomplete error. The `midi_vol_tracker` tracks volumes, not effect types. Just three lines down there's a correct-looking assignment.