### PR TITLE
widget: allow spacebar to activate buttons like return does

### DIFF
--- a/schism/page_about.c
+++ b/schism/page_about.c
@@ -63,6 +63,7 @@ static int _fixup_ignore_globals(struct key_event *k)
 	case SCHISM_KEYSYM_TAB:
 	case SCHISM_KEYSYM_RETURN:
 	case SCHISM_KEYSYM_ESCAPE:
+	case SCHISM_KEYSYM_SPACE:
 		/* use default handler */
 		return 0;
 	case SCHISM_KEYSYM_F2: case SCHISM_KEYSYM_F5: case SCHISM_KEYSYM_F9: case SCHISM_KEYSYM_F10:

--- a/schism/widget-keyhandler.c
+++ b/schism/widget-keyhandler.c
@@ -484,8 +484,11 @@ int widget_handle_key(struct key_event * k)
 		}
 	}
 
+	int activate_with_return = (k->sym == SCHISM_KEYSYM_RETURN);
+	int activate_with_space = (k->sym == SCHISM_KEYSYM_SPACE) && (widget->type != WIDGET_TEXTENTRY);
+
 	if (k->mouse == MOUSE_CLICK
-	    || (k->mouse == MOUSE_NONE && k->sym == SCHISM_KEYSYM_RETURN)) {
+	    || (k->mouse == MOUSE_NONE && (activate_with_return || activate_with_space))) {
 #if 0
 		if (k->mouse && k->mouse_button == MOUSE_BUTTON_MIDDLE) {
 			if (status.flags & DISKWRITER_ACTIVE) return 0;


### PR DESCRIPTION
Allowed `SCHISM_KEYSYM_SPACE` down the same paths as `SCHISM_KEYSYM_RETURN`, except if the current widget is `WIDGET_TEXTENTRY`.

Also updated the "About" page dialog, because it uses a `pre_handle_key` to filter most stuff out, including spaces.