### PR TITLE
csf_read_sample: factor in stream offset

### DIFF
--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -732,7 +732,7 @@ uint32_t csf_write_sample(disko_t *fp, song_sample_t *sample, uint32_t flags, ui
 
 uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 {
-	const uint64_t memsize = slurp_length(fp);
+	const uint64_t memsize = slurp_length(fp) - slurp_tell(fp);
 	uint32_t len = 0, mem;
 
 	if (sample->flags & CHN_ADLIB) return 0; // no sample data


### PR DESCRIPTION
This function is called to extract sample data from all sorts of files, including within modules, where multiple samples start at different offsets. It computes a value, `memsize`, which is the largest number of bytes that could potentially be read. It is used for various limiting/bounds checking. But, it doesn't take into account the fact that, in many instances, the file pointer won't be at the start of the file.