### PR TITLE
test: filtering of test batches

### DIFF
--- a/test/harness.c
+++ b/test/harness.c
@@ -89,12 +89,41 @@ static testresult_t run_test_child(const char *self, test_index_entry *entry)
 
 int schism_test_main(int argc, char **argv)
 {
+	int run_batch = 1;
+	char *filter_prefix = NULL;
+	int filter_prefix_length = 0;
 	int exit_code;
 
 	SCHISM_RUNTIME_ASSERT(mt_init(), "need multithreading");
 	SCHISM_RUNTIME_ASSERT(timer_init(), "need timers");
 
-	if (argc <= 1) {
+	if (argc > 1) {
+		char *test_case_name = argv[1];
+		int len = strlen(test_case_name);
+
+		if (test_case_name[len - 1] == '*') {
+			filter_prefix_length = len - 1;
+			filter_prefix = strndup(test_case_name, filter_prefix_length);
+		}
+		else {
+			// run individual test case -- used internally as part of batch processing
+			run_batch = 0;
+
+			test_index_entry *test_case = test_get_case(test_case_name);
+			testresult_t result;
+
+			if (!test_case) {
+				fprintf(stderr, "%s (test build): no such test was found: %s\n", argv[0], argv[1]);
+				return 3;
+			}
+
+			result = run_test(test_case);
+
+			exit_code = result_to_exit_code(result);
+		}
+	}
+
+	if (run_batch) {
 		timer_ticks_t start_time, end_time, diff_time;
 
 		int passed_tests = 0;
@@ -106,6 +135,9 @@ int schism_test_main(int argc, char **argv)
 		start_time = timer_ticks();
 
 		for (i = 0; automated_tests[i].name; i++) {
+			if (filter_prefix && strncmp(automated_tests[i].name, filter_prefix, filter_prefix_length) != 0)
+				continue;
+
 			testresult_t result = run_test_child(argv[0], &automated_tests[i]);
 
 			if (result == SCHISM_TESTRESULT_PASS) {
@@ -137,21 +169,10 @@ int schism_test_main(int argc, char **argv)
 
 		exit_code = (failed_tests == 0) ? 0 : 1;
 	}
-	else {
-		test_index_entry *test_case = test_get_case(argv[1]);
-		testresult_t result;
-
-		if (!test_case) {
-			fprintf(stderr, "%s (test build): no such test was found: %s\n", argv[0], argv[1]);
-			return 3;
-		}
-
-		result = run_test(test_case);
-
-		exit_code = result_to_exit_code(result);
-	}
 
 	test_temp_files_cleanup();
+
+	free(filter_prefix);
 
 	timer_quit();
 	mt_quit();


### PR DESCRIPTION
```
logiclrd@visor:/code/schismtracker$ ./schismtrackertest 'test_song_*'
TEST: test_song_get_pattern_offset_0 ............................. PASS (0 ms)
TEST: test_song_get_pattern_offset_same_pattern_1 ................ PASS (0 ms)
TEST: test_song_get_pattern_offset_same_pattern_n ................ PASS (1 ms)
TEST: test_song_get_pattern_offset_same_pattern_LAST ............. PASS (0 ms)
TEST: test_song_get_pattern_offset_next_pattern_FIRST ............ PASS (0 ms)
TEST: test_song_get_pattern_offset_next_pattern_n ................ PASS (0 ms)
TEST: test_song_get_pattern_offset_next_pattern_LAST ............. PASS (1 ms)
TEST: test_song_get_pattern_offset_more_than_two_patterns ........ PASS (0 ms)
TEST: test_song_get_pattern_offset_from_middle_same_pattern ...... PASS (1 ms)
TEST: test_song_get_pattern_offset_from_middle_next_pattern ...... PASS (0 ms)
TEST: test_song_get_pattern_offset_from_middle_more_than_two_patterns  PASS (1 ms)
TEST: test_song_get_pattern_offset_song_LAST ..................... PASS (0 ms)
TEST: test_song_get_pattern_offset_past_end_of_song .............. PASS (0 ms)
Results: 13 passed, 0 failed
Elapsed: 0.074 seconds
logiclrd@visor:/code/schismtracker$ 
```