### PR TITLE
video: fix read past end of buffer due to accidental bias in interpolation

### DIFF
--- a/schism/video.c
+++ b/schism/video.c
@@ -429,8 +429,7 @@ void video_blitNN(unsigned int bpp, unsigned char *pixels, unsigned int pitch, u
 		uint32_t x;
 		uint64_t fixedx;
 
-		/* add (1ul << 31) to round to nearest */
-		const uint32_t scaled_y = ((fixedy + (1ul << 31)) >> 32);
+		const uint32_t scaled_y = fixedy >> 32;
 
 		// only scan again if we have to or if this the first scan
 		if (scaled_y != last_scaled_y || y == 0) {
@@ -453,7 +452,7 @@ void video_blitNN(unsigned int bpp, unsigned char *pixels, unsigned int pitch, u
 		}
 
 		for (x = 0, fixedx = 0; x < width; x++, fixedx += scalex) {
-			const uint32_t scaled_x = ((fixedx + (1ul << 31)) >> 32);
+			const uint32_t scaled_x = fixedx >> 32;
 
 			switch (bpp) {
 			case 1: *pixels = pixels_u.uc[scaled_x]; break;


### PR DESCRIPTION
The nearest-neighbour interpolator in `video_blitNN` has the following computations:
```
scaled_x = (fixed_x + (1uL << 31)) >> 32;
scaled_y = (fixed_y + (1uL << 31)) >> 32;
```
This is equivalent to the common trick for rounding a number to the nearest integer:
```
int_value = trunc(not_int_value + 0.5);
```
This has been employed here because, on some intuition, it seems that the rounding needs to be to the nearest integer -- this is _nearest neighbour_, after all, right?

But there's a subtle problem with this logic: the "neighbours" in question here are logical pixels, which are, after scaling, regions in the window surface, and the origin of those neighbours isn't the top-left, it's the middle of that rectangular region. In other words, the 0.5 bias _is already a part of the calculation_.

The result of adding 0.5 a second time is that there can be situations where the scanner reads past the end of the `vgamem_read` array. I haven't investigated how easy it is for this to happen. It definitely happens on my, uh, what's-it-called -- "WQXGA" display. The resolution is 2560x1440, and when I fill the screen with the window, it most definitely scans logical row 400 of `vgamem_read`, a structure which only contains rows 0-399.

You can actually visually see this half-pixel bias when switching between hardware and software rendering modes. Everything appears to shift up and to the left _just a tiny bit_ (half a pixel, to be exact). That shift is what results in it going past the bounds. The right edge reads just a bit of the next row, and the bottom edge reads bytes that aren't part of `vgamem_read` at all.

No bias is needed for the final conversion from fixed point back to integer. With this PR, every row and every column of the 640x400 pixels represented by `vgamem_read` map to the same number of actual pixel rows/columns, +/- 1. Without it, the first one is too small and the last one is too long.