### PR TITLE
page_info: update to track `position` rework

### DIFF
--- a/schism/page_info.c
+++ b/schism/page_info.c
@@ -185,7 +185,7 @@ static void info_draw_technical(int base, int height, int active, int first_chan
 		sprintf(buf, "%10" PRIu32, voice->sample_freq);
 		draw_text(buf, 5, pos, 2, 0);
 		// Position
-		sprintf(buf, "%10" PRIu32, voice->position);
+		sprintf(buf, "%10" PRIu32, csf_smp_pos_get_whole(voice->position));
 		draw_text(buf, 16, pos, 2, 0);
 
 		draw_text(str_from_num(3, smp, buf), 27, pos, 2, 0); // Smp


### PR DESCRIPTION
This PR updates page_info.c to extract the whole part of the sample position for display, as `position` alone is no longer that.
