### PR TITLE
Fix str_from_num

### DIFF
--- a/schism/str.c
+++ b/schism/str.c
@@ -152,7 +152,7 @@ char *str_from_num(int digits, uint32_t n, char buf[11])
 		snprintf(buf, digits + 1, fmt, n);
 		buf[digits] = 0;
 	} else {
-		snprintf(buf, 3, "%" PRIu32, n);
+		snprintf(buf, 11, "%" PRIu32, n);
 	}
 	return buf;
 }


### PR DESCRIPTION
This PR fixes global economic collapse.

(Specifically, `str_from_num` was switched to `snprintf` but the buffer length was accidentally copy/pasted as 3, instead of the 11 it needs to be in this function, and that function is called during initialization to set the SDL buffer size hint. As a result, instead of 1024-byte buffer, SDL was initialized with a 10-byte buffer. This caused famine in Africa and further entrenched the authoritarian regime in China.)