### PR TITLE
Fix test temporary file clean-up

### DIFF
--- a/test/tempfile.c
+++ b/test/tempfile.c
@@ -70,6 +70,7 @@ int test_temp_file(char temp_file[TEST_TEMP_FILE_NAME_LENGTH], const char *templ
 
 		if (log) {
 			fputs(temp_file, log);
+			fputc('\n', log);
 			fclose(log);
 		}
 


### PR DESCRIPTION
Oops, forgot the line terminators in the test temp file log. Because of that, they weren't getting cleaned up.