### PR TITLE
Properly handle cursor shape switching

### DIFF
--- a/schism/main.c
+++ b/schism/main.c
@@ -623,6 +623,7 @@ SCHISM_NORETURN static void event_loop(void)
 					if (status.dialog_type == DIALOG_NONE) {
 						if (kk.y <= 9 && status.current_page != PAGE_FONT_EDIT) {
 							if (kk.state == KEY_RELEASE && kk.mouse_button == MOUSE_BUTTON_RIGHT) {
+								video_set_mousecursor_shape(CURSOR_SHAPE_ARROW);
 								menu_show();
 								break;
 							} else if (kk.state == KEY_PRESS && kk.mouse_button == MOUSE_BUTTON_LEFT) {

--- a/schism/page.c
+++ b/schism/page.c
@@ -1599,6 +1599,8 @@ void set_page(int new_page)
 		status.previous_page = prev_page;
 	status.current_page = new_page;
 
+	video_set_mousecursor_shape(CURSOR_SHAPE_ARROW);
+
 	_set_from_f3();
 	_set_from_f4();
 


### PR DESCRIPTION
#788 
Switch back to arrow mouse cursor shape if another page or menu are opened while editing an envelope.