### PR TITLE
Add check to sdl2_video_refresh_rate

### DIFF
--- a/sys/sdl2/video.c
+++ b/sys/sdl2/video.c
@@ -883,6 +883,9 @@ static void sdl2_video_show_cursor(int enabled)
 /* negative if unknown */
 static int sdl2_video_refresh_rate(float *r)
 {
+	if (r == NULL || !video.fullscreen)
+		return -1;
+
 	/* This can get nasty if the user has the window
 	 * in two, three, four monitors */
 	SDL_DisplayMode m;


### PR DESCRIPTION
Add checking for null pointer and fullscreen mode. This solves crashing after turning monitor off on my system. 
According to [SDL Wiki](https://wiki.libsdl.org/SDL2/SDL_GetWindowDisplayMode), SDL_GetWindowDisplayMode is useful only in fullscreen modes.

System specs:
- Debian GNU/Linux 13 (trixie);
- CPU: AMD Ryzen 7 5700X
- RAM: 32 GB;
- GPU: Nvidia GeForce RTX 3060;
- Display: BenQ GW3290QT on DisplayPort;
- WM: Openbox 3.6.1-12+b2 + Picom 13.

- [x] I confirm that I am the author of this code and release it under the GPLv2 license. Any code generated by an LLM is strictly forbidden, including partial contributions.
