### PR TITLE
Fix W64 sample loading when the files ends right at the end of the data chunk

### DIFF
--- a/fmt/w64.c
+++ b/fmt/w64.c
@@ -42,6 +42,7 @@ struct w64_chunk {
 static int w64_chunk_peek(struct w64_chunk *chunk, slurp_t *fp)
 {
 	int64_t pos;
+	uint64_t chunk_data_size;
 
 	if (slurp_read(fp, chunk->id, sizeof(chunk->id)) != sizeof(chunk->id))
 		return 0;
@@ -62,13 +63,16 @@ static int w64_chunk_peek(struct w64_chunk *chunk, slurp_t *fp)
 		return 0;
 
 	/* w64 sizes are aligned to 64-bit boundaries */
-	slurp_seek(fp, (chunk->size + 7) & ~7, SEEK_CUR);
+	chunk_data_size = (chunk->size + 7) & ~7;
 
-	pos = slurp_tell(fp);
-	if (pos < 0)
+	if (slurp_available(fp, chunk_data_size, SEEK_CUR)) {
+		/* skip chunk data, return successfully peeked chunk */
+		slurp_seek(fp, chunk_data_size, SEEK_CUR);
+		return 1;
+	} else {
+		/* stop reading here, this chunk's data is incomplete */
 		return 0;
-
-	return slurp_available(fp, 1, SEEK_CUR);
+	}
 }
 
 static int w64_chunk_empty(struct w64_chunk *chunk)


### PR DESCRIPTION
In testing and debugging the GStreamer support with 8-bit files, I was trying to find a file format that would supply true 8-bit data (I discovered my previous testing, while an 8-bit file on disk, erroneously reports as 16-bit data from GStreamer), and I created a W64 file and found that it wouldn't load with the built-in W64 support. I debugged it and discovered that the `w64_chunk_peek` function returns false for its `data` chunk even though the chunk is properly-formed and fully there because it contains code that tests for at least 1 byte _after_ the chunk in the file, and the file ends with the chunk.

This PR updates `w64_chunk_peek` to accept chunks that abut the end of the file. With this change, the built-in W64 handling works with my test file:

[M1F1-uint8-AFsp.w64.zip](https://github.com/user-attachments/files/29563541/M1F1-uint8-AFsp.w64.zip)
