### PR TITLE
`slurp_available` refactor

### DIFF
--- a/fmt/ams.c
+++ b/fmt/ams.c
@@ -38,7 +38,7 @@ int fmt_ams_read_info(dmoz_file_t *file, slurp_t *fp)
 	unsigned char magic[7] = {0};
 	slurp_read(fp, &magic, sizeof(magic));
 
-	if (!(slurp_is_valid_file_pointer(fp, 38, SEEK_CUR) && memcmp(magic, "AMShdr\x1a", 7) == 0))
+	if (!(slurp_could_seek(fp, 38, SEEK_CUR) && memcmp(magic, "AMShdr\x1a", 7) == 0))
 		return 0;
 
 	slurp_seek(fp, 7, SEEK_SET);

--- a/fmt/ams.c
+++ b/fmt/ams.c
@@ -38,7 +38,7 @@ int fmt_ams_read_info(dmoz_file_t *file, slurp_t *fp)
 	unsigned char magic[7] = {0};
 	slurp_read(fp, &magic, sizeof(magic));
 
-	if (!(slurp_available(fp, 38, SEEK_CUR) && memcmp(magic, "AMShdr\x1a", 7) == 0))
+	if (!(slurp_is_valid_file_pointer(fp, 38, SEEK_CUR) && memcmp(magic, "AMShdr\x1a", 7) == 0))
 		return 0;
 
 	slurp_seek(fp, 7, SEEK_SET);

--- a/fmt/au.c
+++ b/fmt/au.c
@@ -67,8 +67,7 @@ static int read_header_au(struct au_header *hdr, slurp_t *fp)
 	hdr->channels = bswapBE32(hdr->channels);
 
 	if (hdr->data_offset < 24
-		|| slurp_available(fp, hdr->data_offset, SEEK_SET)
-		|| slurp_available(fp, hdr->data_size + hdr->data_offset, SEEK_SET))
+	 || !slurp_is_valid_file_pointer(fp, hdr->data_offset + hdr->data_size, SEEK_SET))
 		return 0;
 
 	switch (hdr->channels) {

--- a/fmt/au.c
+++ b/fmt/au.c
@@ -67,7 +67,7 @@ static int read_header_au(struct au_header *hdr, slurp_t *fp)
 	hdr->channels = bswapBE32(hdr->channels);
 
 	if (hdr->data_offset < 24
-	 || !slurp_is_valid_file_pointer(fp, hdr->data_offset + hdr->data_size, SEEK_SET))
+	 || !slurp_could_seek(fp, hdr->data_offset + hdr->data_size, SEEK_SET))
 		return 0;
 
 	switch (hdr->channels) {

--- a/fmt/brr.c
+++ b/fmt/brr.c
@@ -66,7 +66,7 @@ static int brr_load(struct brr_info *brr, slurp_t *fp)
 	 * this should always be the case anyway, though */
 	slurp_rewind(fp);
 
-	if (!slurp_available(fp, 11, SEEK_SET) || slurp_available(fp, UINT16_MAX + 1, SEEK_SET))
+	if (!slurp_is_valid_file_pointer(fp, 11, SEEK_SET) || slurp_is_valid_file_pointer(fp, UINT16_MAX + 1, SEEK_SET))
 		return -1;
 
 	filesize = slurp_length(fp);

--- a/fmt/brr.c
+++ b/fmt/brr.c
@@ -66,7 +66,7 @@ static int brr_load(struct brr_info *brr, slurp_t *fp)
 	 * this should always be the case anyway, though */
 	slurp_rewind(fp);
 
-	if (!slurp_is_valid_file_pointer(fp, 11, SEEK_SET) || slurp_is_valid_file_pointer(fp, UINT16_MAX + 1, SEEK_SET))
+	if (!slurp_could_seek(fp, 11, SEEK_SET) || slurp_could_seek(fp, UINT16_MAX + 1, SEEK_SET))
 		return -1;
 
 	filesize = slurp_length(fp);

--- a/fmt/compression.c
+++ b/fmt/compression.c
@@ -80,7 +80,7 @@ uint32_t it_decompress8(void *dest, uint32_t len, slurp_t *fp, int it215, int ch
 				return 0;
 
 			if (c1 == EOF || c2 == EOF
-				|| !slurp_is_valid_file_pointer(fp, c1 | (c2 << 8), SEEK_CUR))
+				|| !slurp_could_seek(fp, c1 | (c2 << 8), SEEK_CUR))
 				return pos - startpos;
 		}
 		bitbuf = bitnum = 0;
@@ -182,7 +182,7 @@ uint32_t it_decompress16(void *dest, uint32_t len, slurp_t *fp, int it215, int c
 				return 0;
 
 			if (c1 == EOF || c2 == EOF
-				|| !slurp_is_valid_file_pointer(fp, c1 | (c2 << 8), SEEK_CUR))
+				|| !slurp_could_seek(fp, c1 | (c2 << 8), SEEK_CUR))
 				return pos - startpos;
 		}
 

--- a/fmt/compression.c
+++ b/fmt/compression.c
@@ -80,7 +80,7 @@ uint32_t it_decompress8(void *dest, uint32_t len, slurp_t *fp, int it215, int ch
 				return 0;
 
 			if (c1 == EOF || c2 == EOF
-				|| !slurp_available(fp, c1 | (c2 << 8), SEEK_CUR))
+				|| !slurp_is_valid_file_pointer(fp, c1 | (c2 << 8), SEEK_CUR))
 				return pos - startpos;
 		}
 		bitbuf = bitnum = 0;
@@ -182,7 +182,7 @@ uint32_t it_decompress16(void *dest, uint32_t len, slurp_t *fp, int it215, int c
 				return 0;
 
 			if (c1 == EOF || c2 == EOF
-				|| !slurp_available(fp, c1 | (c2 << 8), SEEK_CUR))
+				|| !slurp_is_valid_file_pointer(fp, c1 | (c2 << 8), SEEK_CUR))
 				return pos - startpos;
 		}
 

--- a/fmt/d00.c
+++ b/fmt/d00.c
@@ -60,7 +60,7 @@ static int d00_header_read_v1(struct d00_header *hdr, slurp_t *fp)
 {
 	/* reads old D00 header. this doesn't have a lot of identifying
 	 * info, besides some assumptions we make that I am going to abuse */
-	if (!slurp_available(fp, 15, SEEK_CUR) || slurp_available(fp, UINT16_MAX, SEEK_SET))
+	if (!slurp_is_valid_file_pointer(fp, 15, SEEK_CUR) || slurp_is_valid_file_pointer(fp, UINT16_MAX, SEEK_SET))
 		return 0;
 
 	READ_VALUE(version);
@@ -84,7 +84,7 @@ static int d00_header_read_new(struct d00_header *hdr, slurp_t *fp)
 	// otherwise. 119 is just the size of the header.
 	unsigned char magic[6];
 
-	if (!slurp_available(fp, 119, SEEK_CUR) || slurp_available(fp, UINT16_MAX, SEEK_SET))
+	if (!slurp_is_valid_file_pointer(fp, 119, SEEK_CUR) || slurp_is_valid_file_pointer(fp, UINT16_MAX, SEEK_SET))
 		return 0;
 
 	if ((slurp_read(fp, magic, 6) != 6)
@@ -174,7 +174,7 @@ static int d00_header_read(struct d00_header *hdr, slurp_t *fp)
 
 	/* verify that parapointers are within range for the file */
 #define PARAPTR_VALID(ptr) \
-	(fppos <= ptr || !slurp_available(fp, ptr, SEEK_SET))
+	(fppos <= ptr || !slurp_is_valid_file_pointer(fp, ptr, SEEK_SET))
 
 	/* these can never be invalid */
 	if (!PARAPTR_VALID(hdr->tpoin)
@@ -226,7 +226,7 @@ static int d00_header_read(struct d00_header *hdr, slurp_t *fp)
 
 		for (j = 0; j < 9; j++) {
 			ptrs[j] = bswapLE16(ptrs[j]);
-			if (!slurp_available(fp, ptrs[j], SEEK_SET))
+			if (!slurp_is_valid_file_pointer(fp, ptrs[j], SEEK_SET))
 				return 0;
 		}
 

--- a/fmt/d00.c
+++ b/fmt/d00.c
@@ -60,7 +60,7 @@ static int d00_header_read_v1(struct d00_header *hdr, slurp_t *fp)
 {
 	/* reads old D00 header. this doesn't have a lot of identifying
 	 * info, besides some assumptions we make that I am going to abuse */
-	if (!slurp_is_valid_file_pointer(fp, 15, SEEK_CUR) || slurp_is_valid_file_pointer(fp, UINT16_MAX, SEEK_SET))
+	if (!slurp_could_seek(fp, 15, SEEK_CUR) || slurp_could_seek(fp, UINT16_MAX, SEEK_SET))
 		return 0;
 
 	READ_VALUE(version);
@@ -84,7 +84,7 @@ static int d00_header_read_new(struct d00_header *hdr, slurp_t *fp)
 	// otherwise. 119 is just the size of the header.
 	unsigned char magic[6];
 
-	if (!slurp_is_valid_file_pointer(fp, 119, SEEK_CUR) || slurp_is_valid_file_pointer(fp, UINT16_MAX, SEEK_SET))
+	if (!slurp_could_seek(fp, 119, SEEK_CUR) || slurp_could_seek(fp, UINT16_MAX, SEEK_SET))
 		return 0;
 
 	if ((slurp_read(fp, magic, 6) != 6)
@@ -174,7 +174,7 @@ static int d00_header_read(struct d00_header *hdr, slurp_t *fp)
 
 	/* verify that parapointers are within range for the file */
 #define PARAPTR_VALID(ptr) \
-	(fppos <= ptr || !slurp_is_valid_file_pointer(fp, ptr, SEEK_SET))
+	(fppos <= ptr || !slurp_could_seek(fp, ptr, SEEK_SET))
 
 	/* these can never be invalid */
 	if (!PARAPTR_VALID(hdr->tpoin)
@@ -226,7 +226,7 @@ static int d00_header_read(struct d00_header *hdr, slurp_t *fp)
 
 		for (j = 0; j < 9; j++) {
 			ptrs[j] = bswapLE16(ptrs[j]);
-			if (!slurp_is_valid_file_pointer(fp, ptrs[j], SEEK_SET))
+			if (!slurp_could_seek(fp, ptrs[j], SEEK_SET))
 				return 0;
 		}
 

--- a/fmt/dsm.c
+++ b/fmt/dsm.c
@@ -88,7 +88,7 @@ int fmt_dsm_read_info(dmoz_file_t *file, slurp_t *fp)
 {
 	unsigned char riff[4], dsmf[4];
 
-	if (!slurp_is_valid_file_pointer(fp, 40, SEEK_CUR))
+	if (!slurp_could_seek(fp, 40, SEEK_CUR))
 		return 0;
 
 	if (slurp_read(fp, riff, sizeof(riff)) != sizeof(dsmf)

--- a/fmt/dsm.c
+++ b/fmt/dsm.c
@@ -88,7 +88,7 @@ int fmt_dsm_read_info(dmoz_file_t *file, slurp_t *fp)
 {
 	unsigned char riff[4], dsmf[4];
 
-	if (!slurp_available(fp, 40, SEEK_CUR))
+	if (!slurp_is_valid_file_pointer(fp, 40, SEEK_CUR))
 		return 0;
 
 	if (slurp_read(fp, riff, sizeof(riff)) != sizeof(dsmf)

--- a/fmt/it.c
+++ b/fmt/it.c
@@ -334,7 +334,7 @@ SCHISM_STATIC_ASSERT(MAX_MIDI_MACRO == 32, "MIDI config reading code assumes mac
 int it_read_midi_config(midi_config_t *midi, slurp_t *fp)
 {
 	/* preserving this just for compat with old behavior  --paper */
-	if (!slurp_is_valid_file_pointer(fp, 4896, SEEK_CUR))
+	if (!slurp_could_seek(fp, 4896, SEEK_CUR))
 		return 0;
 
 #define READ_VALUE(x) \
@@ -545,7 +545,7 @@ int fmt_it_load_song(song_t *song, slurp_t *fp, uint32_t lflags)
 			tid = "BeRoTracker";
 	}
 
-	if ((hdr.special & 1) && hdr.msglength && slurp_is_valid_file_pointer(fp, hdr.msgoffset + hdr.msglength, SEEK_SET)) {
+	if ((hdr.special & 1) && hdr.msglength && slurp_could_seek(fp, hdr.msgoffset + hdr.msglength, SEEK_SET)) {
 		int msg_len = MIN(MAX_MESSAGE, hdr.msglength);
 		slurp_seek(fp, hdr.msgoffset, SEEK_SET);
 		slurp_read(fp, song->message, msg_len);

--- a/fmt/it.c
+++ b/fmt/it.c
@@ -334,7 +334,7 @@ SCHISM_STATIC_ASSERT(MAX_MIDI_MACRO == 32, "MIDI config reading code assumes mac
 int it_read_midi_config(midi_config_t *midi, slurp_t *fp)
 {
 	/* preserving this just for compat with old behavior  --paper */
-	if (!slurp_available(fp, 4896, SEEK_CUR))
+	if (!slurp_is_valid_file_pointer(fp, 4896, SEEK_CUR))
 		return 0;
 
 #define READ_VALUE(x) \
@@ -545,7 +545,7 @@ int fmt_it_load_song(song_t *song, slurp_t *fp, uint32_t lflags)
 			tid = "BeRoTracker";
 	}
 
-	if ((hdr.special & 1) && hdr.msglength && slurp_available(fp, hdr.msgoffset + hdr.msglength, SEEK_SET)) {
+	if ((hdr.special & 1) && hdr.msglength && slurp_is_valid_file_pointer(fp, hdr.msgoffset + hdr.msglength, SEEK_SET)) {
 		int msg_len = MIN(MAX_MESSAGE, hdr.msglength);
 		slurp_seek(fp, hdr.msgoffset, SEEK_SET);
 		slurp_read(fp, song->message, msg_len);

--- a/fmt/iti.c
+++ b/fmt/iti.c
@@ -156,7 +156,7 @@ int fmt_iti_read_info(dmoz_file_t *file, slurp_t *fp)
 	unsigned char impi[4];
 	unsigned char name[26];
 
-	if (!slurp_is_valid_file_pointer(fp, 554, SEEK_CUR))
+	if (!slurp_could_seek(fp, 554, SEEK_CUR))
 		return 0;
 
 	if (slurp_read(fp, impi, sizeof(impi)) != sizeof(impi)

--- a/fmt/iti.c
+++ b/fmt/iti.c
@@ -156,7 +156,7 @@ int fmt_iti_read_info(dmoz_file_t *file, slurp_t *fp)
 	unsigned char impi[4];
 	unsigned char name[26];
 
-	if (!slurp_available(fp, 554, SEEK_CUR))
+	if (!slurp_is_valid_file_pointer(fp, 554, SEEK_CUR))
 		return 0;
 
 	if (slurp_read(fp, impi, sizeof(impi)) != sizeof(impi)

--- a/fmt/med.c
+++ b/fmt/med.c
@@ -82,7 +82,7 @@ int fmt_med_read_info(dmoz_file_t *file, slurp_t *fp)
 	struct MMD0 hdr;
 	struct MMD0exp exp;
 
-	if (!slurp_is_valid_file_pointer(fp, 52, SEEK_CUR)) /* sizeof(hdr) */
+	if (!slurp_could_seek(fp, 52, SEEK_CUR)) /* sizeof(hdr) */
 		return 0;
 
 	if ((slurp_read(fp, hdr.id, 4) != 4)
@@ -95,7 +95,7 @@ int fmt_med_read_info(dmoz_file_t *file, slurp_t *fp)
 
 	uint32_t exp_struct_ptr = bswapBE32(hdr.expdata_ptr);
 
-	if (!slurp_is_valid_file_pointer(fp, exp_struct_ptr + 84 /* sizeof(struct MMD0exp) */, SEEK_SET)
+	if (!slurp_could_seek(fp, exp_struct_ptr + 84 /* sizeof(struct MMD0exp) */, SEEK_SET)
 			|| slurp_seek(fp, exp_struct_ptr + 44, SEEK_SET)
 			|| (slurp_read(fp, &exp.songname_ptr, sizeof(exp.songname_ptr)) != sizeof(exp.songname_ptr))
 			|| (slurp_read(fp, &exp.songnamelen, sizeof(exp.songnamelen)) != sizeof(exp.songnamelen)))
@@ -111,7 +111,7 @@ int fmt_med_read_info(dmoz_file_t *file, slurp_t *fp)
 
 	name_buffer[name_len] = 0;
 
-	if (!slurp_is_valid_file_pointer(fp, name_ptr + name_len, SEEK_SET)
+	if (!slurp_could_seek(fp, name_ptr + name_len, SEEK_SET)
 			|| slurp_seek(fp, name_ptr, SEEK_SET)
 			|| (slurp_read(fp, name_buffer, name_len) != name_len)) {
 		free(name_buffer);

--- a/fmt/med.c
+++ b/fmt/med.c
@@ -82,7 +82,7 @@ int fmt_med_read_info(dmoz_file_t *file, slurp_t *fp)
 	struct MMD0 hdr;
 	struct MMD0exp exp;
 
-	if (!slurp_available(fp, 52, SEEK_CUR)) /* sizeof(hdr) */
+	if (!slurp_is_valid_file_pointer(fp, 52, SEEK_CUR)) /* sizeof(hdr) */
 		return 0;
 
 	if ((slurp_read(fp, hdr.id, 4) != 4)
@@ -95,7 +95,7 @@ int fmt_med_read_info(dmoz_file_t *file, slurp_t *fp)
 
 	uint32_t exp_struct_ptr = bswapBE32(hdr.expdata_ptr);
 
-	if (!slurp_available(fp, exp_struct_ptr + 84 /* sizeof(struct MMD0exp) */, SEEK_SET)
+	if (!slurp_is_valid_file_pointer(fp, exp_struct_ptr + 84 /* sizeof(struct MMD0exp) */, SEEK_SET)
 			|| slurp_seek(fp, exp_struct_ptr + 44, SEEK_SET)
 			|| (slurp_read(fp, &exp.songname_ptr, sizeof(exp.songname_ptr)) != sizeof(exp.songname_ptr))
 			|| (slurp_read(fp, &exp.songnamelen, sizeof(exp.songnamelen)) != sizeof(exp.songnamelen)))
@@ -111,7 +111,7 @@ int fmt_med_read_info(dmoz_file_t *file, slurp_t *fp)
 
 	name_buffer[name_len] = 0;
 
-	if (!slurp_available(fp, name_ptr + name_len, SEEK_SET)
+	if (!slurp_is_valid_file_pointer(fp, name_ptr + name_len, SEEK_SET)
 			|| slurp_seek(fp, name_ptr, SEEK_SET)
 			|| (slurp_read(fp, name_buffer, name_len) != name_len)) {
 		free(name_buffer);

--- a/fmt/mmcmp.c
+++ b/fmt/mmcmp.c
@@ -69,8 +69,7 @@ static int read_mmcmp_header(mm_header_t *hdr, slurp_t *fp)
 	    || hdr->blocks == 0
 	    || hdr->filesize < 16
 	    || hdr->filesize > 0x8000000
-	    || !slurp_available(fp, hdr->blktable, SEEK_SET)
-	    || !slurp_available(fp, hdr->blktable + 4 * hdr->blocks, SEEK_SET))
+	    || !slurp_is_valid_file_pointer(fp, hdr->blktable + 4 * hdr->blocks, SEEK_SET))
 		return 0;
 
 	return 1;
@@ -165,7 +164,7 @@ static uint32_t get_bits(mm_bit_buffer_t *bb, uint32_t bits)
 
 int mmcmp_unpack(slurp_t *fp, uint8_t **data, size_t *length)
 {
-	if (!slurp_available(fp, 256, SEEK_CUR))
+	if (!slurp_is_valid_file_pointer(fp, 256, SEEK_CUR))
 		return 0;
 
 	mm_header_t hdr;

--- a/fmt/mmcmp.c
+++ b/fmt/mmcmp.c
@@ -69,7 +69,7 @@ static int read_mmcmp_header(mm_header_t *hdr, slurp_t *fp)
 	    || hdr->blocks == 0
 	    || hdr->filesize < 16
 	    || hdr->filesize > 0x8000000
-	    || !slurp_is_valid_file_pointer(fp, hdr->blktable + 4 * hdr->blocks, SEEK_SET))
+	    || !slurp_could_seek(fp, hdr->blktable + 4 * hdr->blocks, SEEK_SET))
 		return 0;
 
 	return 1;
@@ -164,7 +164,7 @@ static uint32_t get_bits(mm_bit_buffer_t *bb, uint32_t bits)
 
 int mmcmp_unpack(slurp_t *fp, uint8_t **data, size_t *length)
 {
-	if (!slurp_is_valid_file_pointer(fp, 256, SEEK_CUR))
+	if (!slurp_could_seek(fp, 256, SEEK_CUR))
 		return 0;
 
 	mm_header_t hdr;

--- a/fmt/mod.c
+++ b/fmt/mod.c
@@ -147,7 +147,7 @@ int fmt_mod_read_info(dmoz_file_t *file, slurp_t *fp)
 	char tag[4], title[20];
 	int i = 0;
 
-	if (!slurp_is_valid_file_pointer(fp, 1085, SEEK_CUR))
+	if (!slurp_could_seek(fp, 1085, SEEK_CUR))
 		return 0;
 
 	if (slurp_read(fp, title, sizeof(title)) != sizeof(title))

--- a/fmt/mod.c
+++ b/fmt/mod.c
@@ -147,7 +147,7 @@ int fmt_mod_read_info(dmoz_file_t *file, slurp_t *fp)
 	char tag[4], title[20];
 	int i = 0;
 
-	if (!slurp_available(fp, 1085, SEEK_CUR))
+	if (!slurp_is_valid_file_pointer(fp, 1085, SEEK_CUR))
 		return 0;
 
 	if (slurp_read(fp, title, sizeof(title)) != sizeof(title))

--- a/fmt/mt2.c
+++ b/fmt/mt2.c
@@ -33,7 +33,7 @@
 
 int fmt_mt2_read_info(dmoz_file_t *file, slurp_t *fp)
 {
-	if (!slurp_available(fp, 106, SEEK_CUR))
+	if (!slurp_is_valid_file_pointer(fp, 106, SEEK_CUR))
 		return 0;
 
 	unsigned char magic[4];

--- a/fmt/mt2.c
+++ b/fmt/mt2.c
@@ -33,7 +33,7 @@
 
 int fmt_mt2_read_info(dmoz_file_t *file, slurp_t *fp)
 {
-	if (!slurp_is_valid_file_pointer(fp, 106, SEEK_CUR))
+	if (!slurp_could_seek(fp, 106, SEEK_CUR))
 		return 0;
 
 	unsigned char magic[4];

--- a/fmt/mus.c
+++ b/fmt/mus.c
@@ -61,7 +61,7 @@ static int read_mus_header(struct mus_header *hdr, slurp_t *fp)
 	hdr->scorelen   = bswapLE16(hdr->scorelen);
 	hdr->scorestart = bswapLE16(hdr->scorestart);
 
-	if (!slurp_is_valid_file_pointer(fp, hdr->scorestart + hdr->scorelen, SEEK_SET))
+	if (!slurp_could_seek(fp, hdr->scorestart + hdr->scorelen, SEEK_SET))
 		return 0;
 
 	slurp_seek(fp, 8, SEEK_CUR); // skip

--- a/fmt/mus.c
+++ b/fmt/mus.c
@@ -61,7 +61,7 @@ static int read_mus_header(struct mus_header *hdr, slurp_t *fp)
 	hdr->scorelen   = bswapLE16(hdr->scorelen);
 	hdr->scorestart = bswapLE16(hdr->scorestart);
 
-	if (!slurp_available(fp, hdr->scorestart + hdr->scorelen, SEEK_SET))
+	if (!slurp_is_valid_file_pointer(fp, hdr->scorestart + hdr->scorelen, SEEK_SET))
 		return 0;
 
 	slurp_seek(fp, 8, SEEK_CUR); // skip

--- a/fmt/okt.c
+++ b/fmt/okt.c
@@ -36,7 +36,7 @@ int fmt_okt_read_info(dmoz_file_t *file, slurp_t *fp)
 {
 	unsigned char magic[8];
 
-	if (!slurp_is_valid_file_pointer(fp, 16, SEEK_CUR))
+	if (!slurp_could_seek(fp, 16, SEEK_CUR))
 		return 0;
 
 	if (slurp_read(fp, magic, sizeof(magic)) != sizeof(magic)

--- a/fmt/okt.c
+++ b/fmt/okt.c
@@ -36,7 +36,7 @@ int fmt_okt_read_info(dmoz_file_t *file, slurp_t *fp)
 {
 	unsigned char magic[8];
 
-	if (!slurp_available(fp, 16, SEEK_CUR))
+	if (!slurp_is_valid_file_pointer(fp, 16, SEEK_CUR))
 		return 0;
 
 	if (slurp_read(fp, magic, sizeof(magic)) != sizeof(magic)

--- a/fmt/raw.c
+++ b/fmt/raw.c
@@ -38,7 +38,7 @@ int fmt_raw_load_sample(slurp_t *fp, song_sample_t *smp)
 
 	/* this kinda sucks, but it prevents loading the whole thing
 	 * into memory if we're working on an unseekable stream */
-	if (slurp_is_valid_file_pointer(fp, SAMPLE_RAW_MAX, SEEK_SET)) {
+	if (slurp_could_seek(fp, SAMPLE_RAW_MAX, SEEK_SET)) {
 		len = SAMPLE_RAW_MAX;
 	} else {
 		len = slurp_length(fp);

--- a/fmt/raw.c
+++ b/fmt/raw.c
@@ -38,7 +38,7 @@ int fmt_raw_load_sample(slurp_t *fp, song_sample_t *smp)
 
 	/* this kinda sucks, but it prevents loading the whole thing
 	 * into memory if we're working on an unseekable stream */
-	if (slurp_available(fp, SAMPLE_RAW_MAX, SEEK_SET)) {
+	if (slurp_is_valid_file_pointer(fp, SAMPLE_RAW_MAX, SEEK_SET)) {
 		len = SAMPLE_RAW_MAX;
 	} else {
 		len = slurp_length(fp);

--- a/fmt/s3i.c
+++ b/fmt/s3i.c
@@ -104,7 +104,7 @@ static int load_s3i_sample(slurp_t *fp, song_sample_t *smp, int with_data)
 
 		slurp_seek(fp, 80, SEEK_SET);
 
-		if (!slurp_is_valid_file_pointer(fp, smp->length * bytes_per_sample, SEEK_CUR))
+		if (!slurp_could_seek(fp, smp->length * bytes_per_sample, SEEK_CUR))
 			return 0;
 
 		/* convert flags */

--- a/fmt/s3i.c
+++ b/fmt/s3i.c
@@ -104,7 +104,7 @@ static int load_s3i_sample(slurp_t *fp, song_sample_t *smp, int with_data)
 
 		slurp_seek(fp, 80, SEEK_SET);
 
-		if (!slurp_available(fp, smp->length * bytes_per_sample, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, smp->length * bytes_per_sample, SEEK_CUR))
 			return 0;
 
 		/* convert flags */

--- a/fmt/w64.c
+++ b/fmt/w64.c
@@ -62,7 +62,7 @@ static int w64_chunk_peek(struct w64_chunk *chunk, slurp_t *fp)
 		return 0;
 
 	/* w64 sizes are aligned to 64-bit boundaries */
-	return (slurp_seek(fp, (chunk->size + 7) & ~7, SEEK_CUR) != 0);
+	return !slurp_seek(fp, (chunk->size + 7) & ~7, SEEK_CUR);
 }
 
 static int w64_chunk_empty(struct w64_chunk *chunk)

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -165,7 +165,7 @@ int slurp_mmap(slurp_t *useme, const char *filename, uint64_t st);
 #endif
 
 /* stdio-style file processing */
-int slurp_seek(slurp_t *t, int64_t offset, int whence); /* whence => SEEK_SET, SEEK_CUR, SEEK_END */
+int slurp_seek(slurp_t *t, int64_t offset, int whence); /* whence => SEEK_SET, SEEK_CUR, SEEK_END, return => 0 on success, -1 on error */
 int64_t slurp_tell(slurp_t *t);
 #define slurp_rewind(t) slurp_seek((t), 0, SEEK_SET)
 
@@ -221,7 +221,9 @@ int slurp_xz(slurp_t *src);
 int slurp_zstd(slurp_t *src);
 #endif
 
-int slurp_available(slurp_t *fp, size_t x, int whence);
+int slurp_is_valid_file_pointer(slurp_t *fp, ssize_t x, int whence);
+
+void slurp_fill_nonseek_buffer(slurp_t *t, size_t count);
 
 /* ------------------------------------------------------------------------ */
 

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -221,7 +221,7 @@ int slurp_xz(slurp_t *src);
 int slurp_zstd(slurp_t *src);
 #endif
 
-int slurp_is_valid_file_pointer(slurp_t *fp, ssize_t x, int whence);
+int slurp_is_valid_file_pointer(slurp_t *fp, int64_t x, int whence);
 
 void slurp_fill_nonseek_buffer(slurp_t *t, size_t count);
 

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -221,7 +221,7 @@ int slurp_xz(slurp_t *src);
 int slurp_zstd(slurp_t *src);
 #endif
 
-int slurp_is_valid_file_pointer(slurp_t *fp, int64_t x, int whence);
+int slurp_could_seek(slurp_t *fp, int64_t x, int whence);
 
 /* ------------------------------------------------------------------------ */
 

--- a/include/slurp.h
+++ b/include/slurp.h
@@ -223,8 +223,6 @@ int slurp_zstd(slurp_t *src);
 
 int slurp_is_valid_file_pointer(slurp_t *fp, int64_t x, int whence);
 
-void slurp_fill_nonseek_buffer(slurp_t *t, size_t count);
-
 /* ------------------------------------------------------------------------ */
 
 #define SLURP_DEC_OK (0)

--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -821,7 +821,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		sample->flags &= ~(CHN_16BIT | CHN_STEREO);
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		slurp_read(fp, sample->data, len);
@@ -843,7 +843,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(8,M,BE,PCMD): {
 		len = sample->length;
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		slurp_read(fp, sample->data, len);
@@ -877,7 +877,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		len = sample->length * 2;
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		/* Convert split to interleaved */
@@ -911,7 +911,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(8,SI,BE,PCMD): {
 		len = sample->length * 2;
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		slurp_read(fp, sample->data, len);
@@ -944,7 +944,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		len = sample->length;
 
-		if (!slurp_available(fp, len * 2, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len * 2, SEEK_CUR))
 			break;
 
 		// read
@@ -972,7 +972,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(16,SS,BE,PCMU): {
 		len = sample->length * 2;
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		for (int c = 0; c < 2; c++) {
@@ -1001,7 +1001,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(16,SI,BE,PCMD): {
 		len = sample->length * 2;
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		slurp_read(fp, sample->data, len * 2);
@@ -1035,7 +1035,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		if ((flags & SF_CHN_MASK) == SF_SI)
 			len *= 2;
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		if (len > 3*8*(((flags & SF_CHN_MASK) == SF_SI) ? 2 : 1)) {
@@ -1090,7 +1090,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		if ((flags & SF_CHN_MASK) == SF_SI)
 			len *= 2;
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		if (len > 4*8*(((flags & SF_CHN_MASK) == SF_SI) ? 2 : 1)) {
@@ -1139,7 +1139,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		if ((flags & SF_CHN_MASK) == SF_SI)
 			len *= 2;
 
-		if (!slurp_available(fp, len * 4, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len * 4, SEEK_CUR))
 			break;
 
 		for (uint32_t k = 0; k < len; k++) {
@@ -1163,7 +1163,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		len = sample->length * 2;
 
-		if (!slurp_available(fp, len * 4, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len * 4, SEEK_CUR))
 			break;
 
 		for (i = 0; i < 2; i++) {
@@ -1197,7 +1197,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		if ((flags & SF_CHN_MASK) == SF_SI)
 			len *= 2;
 
-		if (!slurp_available(fp, len * 8, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len * 8, SEEK_CUR))
 			break;
 
 		for (uint32_t k = 0; k < len; k++) {
@@ -1221,7 +1221,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		len = sample->length * 2;
 
-		if (!slurp_available(fp, len * 8, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len * 8, SEEK_CUR))
 			break;
 
 		for (i = 0; i < 2; i++) {
@@ -1310,7 +1310,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(PCMD16,8,M,LE): {
 		len = (sample->length + 1) / 2 + 16;
 
-		if (!slurp_available(fp, len, SEEK_CUR))
+		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
 			break;
 
 		int8_t table[16];

--- a/player/csndfile.c
+++ b/player/csndfile.c
@@ -821,7 +821,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		sample->flags &= ~(CHN_16BIT | CHN_STEREO);
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		slurp_read(fp, sample->data, len);
@@ -843,7 +843,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(8,M,BE,PCMD): {
 		len = sample->length;
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		slurp_read(fp, sample->data, len);
@@ -877,7 +877,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		len = sample->length * 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		/* Convert split to interleaved */
@@ -911,7 +911,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(8,SI,BE,PCMD): {
 		len = sample->length * 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		slurp_read(fp, sample->data, len);
@@ -944,7 +944,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		len = sample->length;
 
-		if (!slurp_is_valid_file_pointer(fp, len * 2, SEEK_CUR))
+		if (!slurp_could_seek(fp, len * 2, SEEK_CUR))
 			break;
 
 		// read
@@ -972,7 +972,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(16,SS,BE,PCMU): {
 		len = sample->length * 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		for (int c = 0; c < 2; c++) {
@@ -1001,7 +1001,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(16,SI,BE,PCMD): {
 		len = sample->length * 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		slurp_read(fp, sample->data, len * 2);
@@ -1035,7 +1035,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		if ((flags & SF_CHN_MASK) == SF_SI)
 			len *= 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		if (len > 3*8*(((flags & SF_CHN_MASK) == SF_SI) ? 2 : 1)) {
@@ -1090,7 +1090,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		if ((flags & SF_CHN_MASK) == SF_SI)
 			len *= 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		if (len > 4*8*(((flags & SF_CHN_MASK) == SF_SI) ? 2 : 1)) {
@@ -1139,7 +1139,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		if ((flags & SF_CHN_MASK) == SF_SI)
 			len *= 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len * 4, SEEK_CUR))
+		if (!slurp_could_seek(fp, len * 4, SEEK_CUR))
 			break;
 
 		for (uint32_t k = 0; k < len; k++) {
@@ -1163,7 +1163,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		len = sample->length * 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len * 4, SEEK_CUR))
+		if (!slurp_could_seek(fp, len * 4, SEEK_CUR))
 			break;
 
 		for (i = 0; i < 2; i++) {
@@ -1197,7 +1197,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 		if ((flags & SF_CHN_MASK) == SF_SI)
 			len *= 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len * 8, SEEK_CUR))
+		if (!slurp_could_seek(fp, len * 8, SEEK_CUR))
 			break;
 
 		for (uint32_t k = 0; k < len; k++) {
@@ -1221,7 +1221,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 
 		len = sample->length * 2;
 
-		if (!slurp_is_valid_file_pointer(fp, len * 8, SEEK_CUR))
+		if (!slurp_could_seek(fp, len * 8, SEEK_CUR))
 			break;
 
 		for (i = 0; i < 2; i++) {
@@ -1310,7 +1310,7 @@ uint32_t csf_read_sample(song_sample_t *sample, uint32_t flags, slurp_t *fp)
 	case SF(PCMD16,8,M,LE): {
 		len = (sample->length + 1) / 2 + 16;
 
-		if (!slurp_is_valid_file_pointer(fp, len, SEEK_CUR))
+		if (!slurp_could_seek(fp, len, SEEK_CUR))
 			break;
 
 		int8_t table[16];

--- a/schism/slurp.c
+++ b/schism/slurp.c
@@ -805,7 +805,7 @@ int slurp_receive(slurp_t *t, int (*callback)(const void *, size_t, void *), siz
 	}
 }
 
-int slurp_is_valid_file_pointer(slurp_t *fp, ssize_t x, int whence)
+int slurp_is_valid_file_pointer(slurp_t *fp, int64_t x, int whence)
 {
 	if (!x)
 		return 1; /* ... */

--- a/schism/slurp.c
+++ b/schism/slurp.c
@@ -831,7 +831,7 @@ int slurp_is_valid_file_pointer(slurp_t *fp, int64_t x, int whence)
 	}
 }
 
-void slurp_fill_nonseek_buffer(slurp_t *t, size_t count)
+static void slurp_fill_nonseek_buffer(slurp_t *t, size_t count)
 {
 	/* If we are a nonseek slurp, then a custom available() has been
 	 * installed which reads forward and buffers bytes to ensure that

--- a/schism/slurp.c
+++ b/schism/slurp.c
@@ -654,6 +654,7 @@ int slurp_init_nonseek(slurp_t *fp,
 /* --------------------------------------------------------------------- */
 /* and now, the slurp interface */
 
+/* return: 0 on success, -1 on error */
 int slurp_seek(slurp_t *t, int64_t offset, int whence)
 {
 	int r;
@@ -675,7 +676,7 @@ int slurp_seek(slurp_t *t, int64_t offset, int whence)
 		break;
 	}
 
-	if (offcheck < 0 || !slurp_available(t, offcheck, SEEK_SET))
+	if (offcheck < 0 || !slurp_is_valid_file_pointer(t, offcheck, SEEK_SET))
 		return -1;
 
 	r = t->seek(t, offset, whence);
@@ -804,8 +805,7 @@ int slurp_receive(slurp_t *t, int (*callback)(const void *, size_t, void *), siz
 	}
 }
 
-/* TODO actually test this function within slurp crap */
-int slurp_available(slurp_t *fp, size_t x, int whence)
+int slurp_is_valid_file_pointer(slurp_t *fp, ssize_t x, int whence)
 {
 	if (!x)
 		return 1; /* ... */
@@ -819,7 +819,7 @@ int slurp_available(slurp_t *fp, size_t x, int whence)
 		switch (whence) {
 		case SEEK_SET: break;
 		case SEEK_CUR: pos += slurp_tell(fp); break;
-		case SEEK_END: return 0; /* ??? */
+		case SEEK_END: return (x <= 0); /* file pointers past the end are not valid */
 		}
 
 		if (pos < 0)
@@ -828,6 +828,19 @@ int slurp_available(slurp_t *fp, size_t x, int whence)
 		return (pos + x) <= fp->length(fp);
 	} else {
 		SCHISM_RUNTIME_ASSERT(0, "slurp: available or length is required");
+	}
+}
+
+void slurp_fill_nonseek_buffer(slurp_t *t, size_t count)
+{
+	/* If we are a nonseek slurp, then a custom available() has been
+	 * installed which reads forward and buffers bytes to ensure that
+	 * they are available.
+	 *
+	 * If we are not a nonseek slurp, then there is no buffer to fill.
+	 */
+	if (t->available) {
+		t->available(t, count, SEEK_CUR);
 	}
 }
 
@@ -978,7 +991,7 @@ int slurp_decompress(slurp_t *fp, const struct slurp_decompress_vtable *vtbl)
 	/* read a bit to ensure we've actually got the right thing.
 	 * zlib won't complain if our file Isn't Correct, so we have
 	 * to do it ourselves. */
-	slurp_available(fp, 8096, SEEK_SET);
+	slurp_fill_nonseek_buffer(fp, 8096);
 
 	/* check the error flag. if it's set, we're toast.
 	 * if it was set twice, our whole lives are different than

--- a/schism/slurp.c
+++ b/schism/slurp.c
@@ -676,7 +676,7 @@ int slurp_seek(slurp_t *t, int64_t offset, int whence)
 		break;
 	}
 
-	if (offcheck < 0 || !slurp_is_valid_file_pointer(t, offcheck, SEEK_SET))
+	if (offcheck < 0 || !slurp_could_seek(t, offcheck, SEEK_SET))
 		return -1;
 
 	r = t->seek(t, offset, whence);
@@ -805,7 +805,7 @@ int slurp_receive(slurp_t *t, int (*callback)(const void *, size_t, void *), siz
 	}
 }
 
-int slurp_is_valid_file_pointer(slurp_t *fp, int64_t x, int whence)
+int slurp_could_seek(slurp_t *fp, int64_t x, int whence)
 {
 	if (!x)
 		return 1; /* ... */

--- a/test/cases/slurp.c
+++ b/test/cases/slurp.c
@@ -160,10 +160,10 @@ static testresult_t test_slurp_common(slurp_t *fp)
 	ASSERT(slurp_seek(fp, sizeof(buf) + 1, SEEK_SET) == -1);
 	ASSERT(slurp_tell(fp) == sizeof(buf));
 
-	/* slurp_is_valid_file_pointer */
+	/* slurp_could_seek */
 	ASSERT(slurp_seek(fp, 0, SEEK_SET) == 0);
-	ASSERT(slurp_is_valid_file_pointer(fp, sizeof(buf), SEEK_SET));
-	ASSERT(!slurp_is_valid_file_pointer(fp, sizeof(buf) + 1, SEEK_SET));
+	ASSERT(slurp_could_seek(fp, sizeof(buf), SEEK_SET));
+	ASSERT(!slurp_could_seek(fp, sizeof(buf) + 1, SEEK_SET));
 
 	/* verify state */
 	ASSERT(slurp_tell(fp) == 0);

--- a/test/cases/slurp.c
+++ b/test/cases/slurp.c
@@ -160,10 +160,10 @@ static testresult_t test_slurp_common(slurp_t *fp)
 	ASSERT(slurp_seek(fp, sizeof(buf) + 1, SEEK_SET) == -1);
 	ASSERT(slurp_tell(fp) == sizeof(buf));
 
-	/* slurp_available */
+	/* slurp_is_valid_file_pointer */
 	ASSERT(slurp_seek(fp, 0, SEEK_SET) == 0);
-	ASSERT(slurp_available(fp, sizeof(buf), SEEK_SET));
-	ASSERT(!slurp_available(fp, sizeof(buf) + 1, SEEK_SET));
+	ASSERT(slurp_is_valid_file_pointer(fp, sizeof(buf), SEEK_SET));
+	ASSERT(!slurp_is_valid_file_pointer(fp, sizeof(buf) + 1, SEEK_SET));
 
 	/* verify state */
 	ASSERT(slurp_tell(fp) == 0);


### PR DESCRIPTION
This PR eliminates uncertainty and ambiguity around what exactly `slurp_available` does and how it is intended to be called.

- `slurp_available` is renamed to `slurp_is_valid_file_pointer`
- A use of `slurp_available` that depended on a non-obvious side-effect was updated to call a function that wraps `slurp_available` to provide explicitly the semantics needed.
- Comments have been added explicitly clarifying that `slurp_seek`'s return value is like that of `fseek` (0 on success, -1 on failure).
- A TODO comment was removed because the thing it referred to appears to exist.