### PR TITLE
disko: export pattern to sample volume

### DIFF
--- a/schism/disko.c
+++ b/schism/disko.c
@@ -662,6 +662,10 @@ int disko_writeout_sample(int smpnum, int pattern, int dobind)
 	dwsong.repeat_count = -1; // FIXME do this right
 	csf_loop_pattern(&dwsong, pattern, 0);
 
+	/* emit samples at a level where if the resulting sample is inserted
+	 * back into the pattern, it will be the same volume */
+	dwsong.mixing_volume = 0x200;
+
 	do {
 		disko_write(&ds, buf, csf_read(&dwsong, buf, sizeof(buf)) * bps);
 		if (ds.length >= (size_t) (MAX_SAMPLE_LENGTH * bps)) {
@@ -738,6 +742,10 @@ int disko_multiwrite_samples(int firstsmp, int pattern)
 		errno = err;
 		return DW_ERROR;
 	}
+
+	/* emit samples at a level where if the resulting sample is inserted
+	 * back into the pattern, it will be the same volume */
+	dwsong.mixing_volume = 0x200;
 
 	for (n = 0; n < MAX_CHANNELS; n++) {
 		dwsong.multi_write[n].data = &ds[n];


### PR DESCRIPTION
I recently thought the Export Pattern function was completely non-functional, because with my settings and ambient sound levels, I literally couldn't hear the sample that it generated. I assumed that playing the sample back would sound the same as playing the song, but the mixer output is considerably quieter than the input even with all the volumes at maximum.

After some debugging, which uncovered another bug and prompted the creation of #837, I figured out that the key factor is the `mixing_volume` for the song, which is by default clamped to the range 0..128 -- but, experimentally, in order for sample values to pass through as-is, a value of 512 is needed!

This PR updates the `disko_writeout_sample` and `disko_multiwrite_samples` functions to force the `mixing_volume` value to 512 in the shadow copy of the `song_t`. Experimentally, this seems to produce the right sound, and logically, it makes sense, because when that sample is subsequently used, the real `mixing_volume` will be applied at that time. Without this change, `mixing_volume` is applied _twice_.

Without this change:

https://github.com/user-attachments/assets/967470da-92e2-410b-bd6b-23531b0accd0

With it:

https://github.com/user-attachments/assets/2d4e74b5-e711-44f5-b920-3474eb54d3b5


