### PR TITLE
sys/posix: don't call posix_spawn_file_actions_addchdir on older macOS

### DIFF
--- a/sys/posix/osdefs.c
+++ b/sys/posix/osdefs.c
@@ -42,6 +42,16 @@
 # define posix_spawn_file_actions_addchdir posix_spawn_file_actions_addchdir_np
 #endif
 
+/* On Apple platforms the un-suffixed name is only available from macOS 26
+ * onwards, but it is weak-linked: configure finds the declaration in a newer
+ * SDK, and then running on an older OS leaves the symbol NULL, so the call
+ * jumps to address zero and takes the process with it. The "np" spelling has
+ * been there since 10.15, so always prefer that one here. */
+#if defined(__APPLE__) && defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP)
+# undef posix_spawn_file_actions_addchdir
+# define posix_spawn_file_actions_addchdir posix_spawn_file_actions_addchdir_np
+#endif
+
 /* ugh */
 extern char **environ;
 


### PR DESCRIPTION
Building against a macOS 26 SDK and running the result on anything older segfaults at startup, before the window appears.

`configure` finds `posix_spawn_file_actions_addchdir` because the newer SDK declares it, so `HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR` gets defined. But that symbol is weak-linked and only exists from macOS 26 onwards, so on an older OS it resolves to NULL and the call in `posix_exec()` jumps to address zero.

`run_startup_hook()` reaches this on every launch, before it checks whether a hook file exists, so it is not limited to people who actually use hooks.

Backtrace on macOS 15.6 (Darwin 24.6), arm64:

```
* frame #0: 0x0000000000000000
  frame #1: schismtracker`posix_exec(...) at osdefs.c:90
  frame #2: schismtracker`posix_run_hook(...) at osdefs.c:200
  frame #3: schismtracker`run_startup_hook at main.c:101
  frame #4: schismtracker`schism_main(...) at main.c:1255
```

The compiler does warn about it:

```
sys/posix/osdefs.c:90:8: warning: 'posix_spawn_file_actions_addchdir' is only
available on macOS 26.0 or newer [-Wunguarded-availability-new]
```

The `_np` spelling has been available since macOS 10.15, and there is already a fallback path in this file that maps to it, so this change just prefers that name on Apple platforms. Non-Apple builds are unaffected.

Tested by building on macOS 15.6 with the macOS 26 SDK: crashes on launch before the change, starts normally after, and the availability warning is gone.
